### PR TITLE
Add hosted-safe protocol passthrough with injectable I/O context

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,10 @@ app.Context("mcp", mcp =>
 In passthrough mode, repl keeps `stdout` available for protocol messages and sends framework diagnostics to `stderr`.
 If the handler requests `IReplIoContext`, write protocol payloads through `io.Output` (stdout in local CLI passthrough).
 Requesting `IReplIoContext` is optional for local CLI handlers that already use `Console.*` directly, but recommended for explicit stream control, better testability, and hosted-session support.
+Framework-rendered handler return payloads (if any) are also written to `stderr` in passthrough mode, so protocol handlers should usually return `Results.Exit(code)` after writing protocol output.
 This is a strong fit for MCP-style stdio servers where the protocol stream must stay pristine.
 Typical shape is `mytool mcp start` in passthrough mode, while `mytool start` stays a normal CLI command.
-It also maps well to DAP/CGI-style stdio flows; socket-first variants (for example FastCGI/FastAGI) usually do not require passthrough.
+It also maps well to DAP/CGI-style stdio flows; socket-first variants (for example FastCGI) usually do not require passthrough.
 Use this mode directly in local CLI/console runs. For hosted terminal sessions (`IReplHost` / remote transports), handlers should request `IReplIoContext`; console-bound toolings that use `Console.*` directly remain CLI-only.
 
 One-shot CLI:

--- a/README.md
+++ b/README.md
@@ -168,6 +168,26 @@ app.Context("client", client =>
 return app.Run(args);
 ```
 
+For stdio protocol handlers (MCP/LSP/JSON-RPC, DAP, CGI-style gateways), mark the route as protocol passthrough:
+
+```csharp
+app.Context("mcp", mcp =>
+{
+    mcp.Map("start", async (IMcpServer server, CancellationToken ct) =>
+    {
+        var exitCode = await server.RunAsync(ct);
+        return Results.Exit(exitCode);
+    })
+    .AsProtocolPassthrough();
+});
+```
+
+In passthrough mode, repl keeps `stdout` clean for protocol messages and sends framework diagnostics to `stderr`.
+This is a strong fit for MCP-style stdio servers where the protocol stream must stay pristine.
+Typical shape is `mytool mcp start` in passthrough mode, while `mytool start` stays a normal CLI command.
+It also maps well to DAP/CGI-style stdio flows; socket-first variants (for example FastCGI/FastAGI) usually do not require passthrough.
+Use this mode directly in local CLI/console runs. For hosted terminal sessions (`IReplHost` / remote transports), handlers should request `IReplIoContext`; console-bound toolings that use `Console.*` directly remain CLI-only.
+
 One-shot CLI:
 
 ```text
@@ -213,6 +233,7 @@ ws-7c650a64   websocket  [::1]:60288  301x31   xterm-256color  1m 34s     1s
 - **Output pipeline** with transformers and aliases  
   (`--output:<format>`, `--json`, `--yaml`, `--markdown`, …)
 - **Typed result model** (`Results.Ok/Error/Validation/NotFound/Cancelled`, etc.)
+- **Protocol passthrough mode** for stdio transports (`AsProtocolPassthrough()`), keeping `stdout` reserved for protocol payloads
 - **Typed interactions**: prompts, progress, status, timeouts, cancellation
 - **Session model + metadata** (transport, terminal identity, window size, ANSI capabilities, etc.)
 - **Hosting primitives** for running sessions over streams, sockets, or custom carriers
@@ -254,6 +275,7 @@ Package details:
 ## Getting started
 
 - Architecture blueprint: [`docs/architecture.md`](docs/architecture.md)
+- Command reference: [`docs/commands.md`](docs/commands.md)
 - Terminal/session metadata: [`docs/terminal-metadata.md`](docs/terminal-metadata.md)
 - Testing toolkit: [`docs/testing-toolkit.md`](docs/testing-toolkit.md)
 - Conditional module presence: [`docs/module-presence.md`](docs/module-presence.md)

--- a/README.md
+++ b/README.md
@@ -182,7 +182,9 @@ app.Context("mcp", mcp =>
 });
 ```
 
-In passthrough mode, repl keeps `stdout` clean for protocol messages and sends framework diagnostics to `stderr`.
+In passthrough mode, repl keeps `stdout` available for protocol messages and sends framework diagnostics to `stderr`.
+If the handler requests `IReplIoContext`, write protocol payloads through `io.Output` (stdout in local CLI passthrough).
+Requesting `IReplIoContext` is optional for local CLI handlers that already use `Console.*` directly, but recommended for explicit stream control, better testability, and hosted-session support.
 This is a strong fit for MCP-style stdio servers where the protocol stream must stay pristine.
 Typical shape is `mytool mcp start` in passthrough mode, while `mytool start` stays a normal CLI command.
 It also maps well to DAP/CGI-style stdio flows; socket-first variants (for example FastCGI/FastAGI) usually do not require passthrough.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -78,11 +78,11 @@ Common protocol families that fit this mode:
 - MCP over stdio
 - LSP / JSON-RPC over stdio
 - DAP over stdio
-- CGI-style process protocols (stdin/stdout contract), including AGI-style integrations
+- CGI-style process protocols (stdin/stdout contract)
 
 Not typical passthrough targets:
 
-- socket-first variants such as FastCGI/FastAGI (their protocol stream is on TCP, not app `stdout`)
+- socket-first variants such as FastCGI (their protocol stream is on TCP, not app `stdout`)
 
 Execution scope note:
 
@@ -99,5 +99,11 @@ In protocol passthrough mode:
 
 - global and command banners are suppressed
 - repl/framework diagnostics are written to `stderr`
+- framework-rendered handler return payloads (if any) are also written to `stderr`
 - `stdout` remains reserved for protocol payloads
 - interactive follow-up is skipped after command execution
+
+Practical guidance:
+
+- for protocol commands, prefer writing protocol bytes/messages directly to `io.Output` (or `Console.Out` when SDK-bound)
+- return `Results.Exit(code)` to keep framework rendering silent

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -89,6 +89,12 @@ Execution scope note:
 - protocol passthrough works out of the box for **local CLI/console execution**
 - hosted terminal sessions (`IReplHost` / remote transports) require handlers to request `IReplIoContext`; console-bound toolings that use `Console.*` directly remain CLI-only
 
+Why `IReplIoContext` is optional:
+
+- many protocol SDKs (for example some MCP/JSON-RPC stacks) read/write `Console.*` directly; these handlers can still work in local CLI passthrough without extra plumbing
+- requesting `IReplIoContext` is the recommended low-level path when you want explicit stream control, easier testing, or hosted-session support
+- in local CLI passthrough, `io.Output` is the protocol stream (`stdout`), while framework diagnostics remain on `stderr`
+
 In protocol passthrough mode:
 
 - global and command banners are suppressed

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,97 @@
+# Command Reference
+
+This page documents **framework-level commands and flags** provided by Repl Toolkit.
+Your application commands are defined by your own route mappings.
+
+## Discover commands
+
+- CLI help at current scope: `myapp --help`
+- Help for a scoped path: `myapp contact --help`
+- Interactive help: `help` or `?`
+
+## Global flags
+
+These flags are parsed before route execution:
+
+- `--help`
+- `--interactive`
+- `--no-interactive`
+- `--no-logo`
+- `--output:<format>`
+- output aliases mapped by `OutputOptions.Aliases` (defaults include `--json`, `--xml`, `--yaml`, `--yml`, `--markdown`)
+- `--answer:<name>[=value]` for non-interactive prompt answers
+
+## Ambient commands
+
+These commands are handled by the runtime (not by your mapped routes):
+
+- `help` or `?`
+- `..` (interactive scope navigation; interactive mode only)
+- `exit` (leave interactive session when enabled)
+- `history [--limit <n>]` (interactive mode only)
+- `complete <command path> --target <name> [--input <text>]`
+- `autocomplete [show]`
+- `autocomplete mode <off|auto|basic|rich>` (interactive mode only)
+
+Notes:
+
+- `history` and `autocomplete` return explicit errors outside interactive mode.
+- `complete` requires a terminal route and a registered `WithCompletion(...)` provider for the selected target.
+
+## Shell completion management commands
+
+When shell completion is enabled, the `completion` context is available in CLI mode:
+
+- `completion install [--shell bash|powershell|zsh|fish|nu] [--force] [--silent]`
+- `completion uninstall [--shell bash|powershell|zsh|fish|nu] [--silent]`
+- `completion status`
+- `completion detect-shell`
+- `completion __complete --shell <...> --line <input> --cursor <position>` (internal protocol bridge, hidden)
+
+See full setup and profile snippets: [shell-completion.md](shell-completion.md)
+
+## Optional documentation export command
+
+If your app calls `UseDocumentationExport()`, it adds:
+
+- `doc export [<path...>]`
+
+By default this command is hidden from help/discovery unless you configure `HiddenByDefault = false`.
+
+## Protocol passthrough commands
+
+For stdio protocols (MCP/LSP/JSON-RPC), mark routes with `AsProtocolPassthrough()`.
+This mode is especially well-suited for **MCP servers over stdio**, where the handler owns `stdin/stdout` end-to-end.
+
+Example command surface:
+
+```text
+mytool mcp start        # protocol mode over stdin/stdout
+mytool start            # normal CLI command
+mytool status --json    # normal structured output
+```
+
+In this model, only `mcp start` should be marked as protocol passthrough.
+
+Common protocol families that fit this mode:
+
+- MCP over stdio
+- LSP / JSON-RPC over stdio
+- DAP over stdio
+- CGI-style process protocols (stdin/stdout contract), including AGI-style integrations
+
+Not typical passthrough targets:
+
+- socket-first variants such as FastCGI/FastAGI (their protocol stream is on TCP, not app `stdout`)
+
+Execution scope note:
+
+- protocol passthrough works out of the box for **local CLI/console execution**
+- hosted terminal sessions (`IReplHost` / remote transports) require handlers to request `IReplIoContext`; console-bound toolings that use `Console.*` directly remain CLI-only
+
+In protocol passthrough mode:
+
+- global and command banners are suppressed
+- repl/framework diagnostics are written to `stderr`
+- `stdout` remains reserved for protocol payloads
+- interactive follow-up is skipped after command execution

--- a/docs/shell-completion.md
+++ b/docs/shell-completion.md
@@ -13,6 +13,12 @@ completion __complete --shell <bash|powershell|zsh|fish|nu> --line <input> --cur
 The shell passes current line + cursor, and Repl returns candidates on `stdout` (one per line).
 `completion __complete` is mapped in the regular command graph through the shell-completion module (CLI channel only).
 The bridge route is marked as protocol passthrough, so repl suppresses banners and routes framework diagnostics to `stderr`.
+The bridge handler writes candidates through `IReplIoContext.Output`, which remains bound to the protocol stream (`stdout`) in local CLI passthrough.
+
+`IReplIoContext` is optional in general protocol commands:
+
+- optional for local CLI commands that already use `Console.*` directly
+- recommended when handlers need explicit stream injection, deterministic tests, or hosted-session compatibility
 
 The module exposes a real `completion` context scope:
 

--- a/docs/shell-completion.md
+++ b/docs/shell-completion.md
@@ -12,6 +12,7 @@ completion __complete --shell <bash|powershell|zsh|fish|nu> --line <input> --cur
 
 The shell passes current line + cursor, and Repl returns candidates on `stdout` (one per line).
 `completion __complete` is mapped in the regular command graph through the shell-completion module (CLI channel only).
+The bridge route is marked as protocol passthrough, so repl suppresses banners and routes framework diagnostics to `stderr`.
 
 The module exposes a real `completion` context scope:
 

--- a/src/Repl.Core/CancelKeyHandler.cs
+++ b/src/Repl.Core/CancelKeyHandler.cs
@@ -59,8 +59,8 @@ internal sealed class CancelKeyHandler : IDisposable
 				e.Cancel = true;
 				_commandCts.Cancel();
 				_lastCancelPress = now;
-				Console.Error.WriteLine();
-				Console.Error.WriteLine("Press Ctrl+C again to exit.");
+				ReplSessionIO.Error.WriteLine();
+				ReplSessionIO.Error.WriteLine("Press Ctrl+C again to exit.");
 				return;
 			}
 

--- a/src/Repl.Core/CommandBuilder.cs
+++ b/src/Repl.Core/CommandBuilder.cs
@@ -154,6 +154,8 @@ public sealed class CommandBuilder
 	/// <summary>
 	/// Marks this command as protocol passthrough.
 	/// In this mode, repl diagnostics are routed to stderr and interactive stdin reads are skipped.
+	/// When handlers request <see cref="IReplIoContext"/>, <see cref="IReplIoContext.Output"/> remains the protocol stream
+	/// (stdout in local CLI passthrough), while framework output stays on stderr.
 	/// For hosted sessions, handlers should request <see cref="IReplIoContext"/> to access transport streams explicitly.
 	/// </summary>
 	/// <returns>The same builder instance.</returns>

--- a/src/Repl.Core/CommandBuilder.cs
+++ b/src/Repl.Core/CommandBuilder.cs
@@ -50,6 +50,11 @@ public sealed class CommandBuilder
 	public IReadOnlyDictionary<string, CompletionDelegate> Completions => _completions;
 
 	/// <summary>
+	/// Gets a value indicating whether this command reserves stdin/stdout for a protocol handler.
+	/// </summary>
+	public bool IsProtocolPassthrough { get; private set; }
+
+	/// <summary>
 	/// Gets the banner delegate rendered before command execution.
 	/// </summary>
 	public Delegate? Banner { get; private set; }
@@ -143,6 +148,18 @@ public sealed class CommandBuilder
 	public CommandBuilder Hidden(bool isHidden = true)
 	{
 		IsHidden = isHidden;
+		return this;
+	}
+
+	/// <summary>
+	/// Marks this command as protocol passthrough.
+	/// In this mode, repl diagnostics are routed to stderr and interactive stdin reads are skipped.
+	/// For hosted sessions, handlers should request <see cref="IReplIoContext"/> to access transport streams explicitly.
+	/// </summary>
+	/// <returns>The same builder instance.</returns>
+	public CommandBuilder AsProtocolPassthrough()
+	{
+		IsProtocolPassthrough = true;
 		return this;
 	}
 }

--- a/src/Repl.Core/CoreReplApp.Documentation.cs
+++ b/src/Repl.Core/CoreReplApp.Documentation.cs
@@ -185,6 +185,7 @@ public sealed partial class CoreReplApp
 		|| parameterType == typeof(CoreReplApp)
 		|| parameterType == typeof(IReplSessionState)
 		|| parameterType == typeof(IReplInteractionChannel)
+		|| parameterType == typeof(IReplIoContext)
 		|| parameterType == typeof(IReplKeyReader);
 
 	private static bool IsRequiredParameter(ParameterInfo parameter)

--- a/src/Repl.Core/CoreReplApp.Routing.cs
+++ b/src/Repl.Core/CoreReplApp.Routing.cs
@@ -294,6 +294,11 @@ public sealed partial class CoreReplApp
 		IServiceProvider serviceProvider,
 		CancellationToken cancellationToken)
 	{
+		if (command.IsProtocolPassthrough)
+		{
+			return;
+		}
+
 		if (command.Banner is { } banner && ShouldRenderBanner(outputFormat))
 		{
 			await InvokeBannerAsync(banner, serviceProvider, cancellationToken).ConfigureAwait(false);

--- a/src/Repl.Core/CoreReplApp.cs
+++ b/src/Repl.Core/CoreReplApp.cs
@@ -458,11 +458,6 @@ public sealed partial class CoreReplApp : ICoreReplApp
 
 	private bool ShouldSuppressGlobalBanner(GlobalInvocationOptions globalOptions)
 	{
-		if (_shellCompletionRuntime.IsBridgeInvocation(globalOptions.RemainingTokens))
-		{
-			return true;
-		}
-
 		if (globalOptions.HelpRequested || globalOptions.RemainingTokens.Count == 0)
 		{
 			return false;
@@ -566,7 +561,9 @@ public sealed partial class CoreReplApp : ICoreReplApp
 		using var protocolScope = ReplSessionIO.SetSession(
 			Console.Error,
 			Console.In,
-			ansiMode: AnsiMode.Never);
+			ansiMode: AnsiMode.Never,
+			commandOutput: Console.Out,
+			error: Console.Error);
 		return await ExecuteMatchedCommandAsync(
 				match,
 				globalOptions,

--- a/src/Repl.Core/CoreReplApp.cs
+++ b/src/Repl.Core/CoreReplApp.cs
@@ -653,7 +653,7 @@ public sealed partial class CoreReplApp : ICoreReplApp
 
 	private ReplRuntimeChannel ResolveCurrentRuntimeChannel()
 	{
-		if (ReplSessionIO.IsSessionActive)
+		if (ReplSessionIO.IsHostedSession)
 		{
 			return ReplRuntimeChannel.Session;
 		}

--- a/src/Repl.Core/CoreReplApp.cs
+++ b/src/Repl.Core/CoreReplApp.cs
@@ -515,7 +515,7 @@ public sealed partial class CoreReplApp : ICoreReplApp
 		CancellationToken cancellationToken)
 	{
 		if (match.Route.Command.IsProtocolPassthrough
-			&& ReplSessionIO.IsSessionActive
+			&& ReplSessionIO.IsHostedSession
 			&& !match.Route.Command.SupportsHostedProtocolPassthrough)
 		{
 			_ = await RenderOutputAsync(
@@ -576,7 +576,8 @@ public sealed partial class CoreReplApp : ICoreReplApp
 			Console.In,
 			ansiMode: AnsiMode.Never,
 			commandOutput: Console.Out,
-			error: Console.Error);
+			error: Console.Error,
+			isHostedSession: false);
 		return await ExecuteMatchedCommandAsync(
 				match,
 				globalOptions,

--- a/src/Repl.Core/IReplIoContext.cs
+++ b/src/Repl.Core/IReplIoContext.cs
@@ -21,7 +21,8 @@ public interface IReplIoContext
 	TextWriter Error { get; }
 
 	/// <summary>
-	/// Gets a value indicating whether execution is currently running in a hosted session.
+	/// Gets a value indicating whether execution is currently running in a real hosted transport session.
+	/// This is false for local CLI execution, including protocol passthrough scopes.
 	/// </summary>
 	bool IsHostedSession { get; }
 

--- a/src/Repl.Core/IReplIoContext.cs
+++ b/src/Repl.Core/IReplIoContext.cs
@@ -1,0 +1,32 @@
+namespace Repl;
+
+/// <summary>
+/// Exposes low-level runtime I/O streams for command handlers.
+/// </summary>
+public interface IReplIoContext
+{
+	/// <summary>
+	/// Gets the active input reader.
+	/// </summary>
+	TextReader Input { get; }
+
+	/// <summary>
+	/// Gets the active output writer.
+	/// </summary>
+	TextWriter Output { get; }
+
+	/// <summary>
+	/// Gets the active error writer.
+	/// </summary>
+	TextWriter Error { get; }
+
+	/// <summary>
+	/// Gets a value indicating whether execution is currently running in a hosted session.
+	/// </summary>
+	bool IsHostedSession { get; }
+
+	/// <summary>
+	/// Gets the current hosted session identifier, when available.
+	/// </summary>
+	string? SessionId { get; }
+}

--- a/src/Repl.Core/LiveReplIoContext.cs
+++ b/src/Repl.Core/LiveReplIoContext.cs
@@ -4,9 +4,9 @@ internal sealed class LiveReplIoContext : IReplIoContext
 {
 	public TextReader Input => ReplSessionIO.Input;
 
-	public TextWriter Output => ReplSessionIO.Output;
+	public TextWriter Output => ReplSessionIO.CommandOutput;
 
-	public TextWriter Error => ReplSessionIO.IsSessionActive ? ReplSessionIO.Output : Console.Error;
+	public TextWriter Error => ReplSessionIO.Error;
 
 	public bool IsHostedSession => ReplSessionIO.IsSessionActive;
 

--- a/src/Repl.Core/LiveReplIoContext.cs
+++ b/src/Repl.Core/LiveReplIoContext.cs
@@ -1,5 +1,8 @@
 namespace Repl;
 
+/// <summary>
+/// Live <see cref="IReplIoContext"/> view backed by the current <see cref="ReplSessionIO"/> async-local state.
+/// </summary>
 internal sealed class LiveReplIoContext : IReplIoContext
 {
 	public TextReader Input => ReplSessionIO.Input;

--- a/src/Repl.Core/LiveReplIoContext.cs
+++ b/src/Repl.Core/LiveReplIoContext.cs
@@ -1,0 +1,14 @@
+namespace Repl;
+
+internal sealed class LiveReplIoContext : IReplIoContext
+{
+	public TextReader Input => ReplSessionIO.Input;
+
+	public TextWriter Output => ReplSessionIO.Output;
+
+	public TextWriter Error => ReplSessionIO.IsSessionActive ? ReplSessionIO.Output : Console.Error;
+
+	public bool IsHostedSession => ReplSessionIO.IsSessionActive;
+
+	public string? SessionId => ReplSessionIO.CurrentSessionId;
+}

--- a/src/Repl.Core/LiveReplIoContext.cs
+++ b/src/Repl.Core/LiveReplIoContext.cs
@@ -11,7 +11,7 @@ internal sealed class LiveReplIoContext : IReplIoContext
 
 	public TextWriter Error => ReplSessionIO.Error;
 
-	public bool IsHostedSession => ReplSessionIO.IsSessionActive;
+	public bool IsHostedSession => ReplSessionIO.IsHostedSession;
 
 	public string? SessionId => ReplSessionIO.CurrentSessionId;
 }

--- a/src/Repl.Core/ReplSessionIO.cs
+++ b/src/Repl.Core/ReplSessionIO.cs
@@ -43,6 +43,9 @@ internal static class ReplSessionIO
 	/// Gets the handler output writer. In protocol passthrough mode this can remain bound to stdout
 	/// while framework output is redirected to stderr.
 	/// </summary>
+	/// <remarks>
+	/// Falls back to <see cref="Output"/>, which itself falls back to <see cref="Console.Out"/>.
+	/// </remarks>
 	public static TextWriter CommandOutput => s_commandOutput.Value ?? Output;
 
 	/// <summary>
@@ -213,6 +216,7 @@ internal static class ReplSessionIO
 
 		EnsureSession(resolvedSessionId);
 		s_output.Value = output;
+		// Default to the active session output for hosted flows unless a separate error writer is supplied.
 		s_error.Value = error ?? output;
 		s_commandOutput.Value = commandOutput ?? output;
 		s_input.Value = input;

--- a/src/Repl.Core/ShellCompletion/IShellCompletionRuntime.cs
+++ b/src/Repl.Core/ShellCompletion/IShellCompletionRuntime.cs
@@ -22,6 +22,4 @@ internal interface IShellCompletionRuntime
 	ValueTask HandleStartupAsync(
 		IServiceProvider serviceProvider,
 		CancellationToken cancellationToken);
-
-	bool IsBridgeInvocation(IReadOnlyList<string> tokens);
 }

--- a/src/Repl.Core/ShellCompletion/ShellCompletionModule.cs
+++ b/src/Repl.Core/ShellCompletion/ShellCompletionModule.cs
@@ -19,6 +19,7 @@ internal sealed class ShellCompletionModule(IShellCompletionRuntime runtime) : I
 					var result = runtime.HandleBridgeRoute(shell, line, cursor);
 					if (result is not string payload)
 					{
+						// Error/validation results are rendered by the framework (stderr in passthrough mode).
 						return result;
 					}
 

--- a/src/Repl.Core/ShellCompletion/ShellCompletionModule.cs
+++ b/src/Repl.Core/ShellCompletion/ShellCompletionModule.cs
@@ -16,6 +16,7 @@ internal sealed class ShellCompletionModule(IShellCompletionRuntime runtime) : I
 				ShellCompletionConstants.ProtocolSubcommandName,
 				(string? shell, string? line, string? cursor) => runtime.HandleBridgeRoute(shell, line, cursor))
 				.WithDescription("Internal completion bridge used by shell integrations.")
+				.AsProtocolPassthrough()
 				.Hidden();
 			completion.Map(
 				"install",

--- a/src/Repl.Core/ShellCompletion/ShellCompletionRuntime.cs
+++ b/src/Repl.Core/ShellCompletion/ShellCompletionRuntime.cs
@@ -285,11 +285,6 @@ internal sealed partial class ShellCompletionRuntime : IShellCompletionRuntime
 		}
 	}
 
-	public bool IsBridgeInvocation(IReadOnlyList<string> tokens) =>
-		tokens.Count >= 2
-		&& string.Equals(tokens[0], ShellCompletionConstants.SetupCommandName, StringComparison.OrdinalIgnoreCase)
-		&& string.Equals(tokens[1], ShellCompletionConstants.ProtocolSubcommandName, StringComparison.OrdinalIgnoreCase);
-
 	private IReplResult? ValidateShellCompletionManagementAvailability()
 	{
 		if (!_options.ShellCompletion.Enabled)

--- a/src/Repl.Defaults/ReplApp.cs
+++ b/src/Repl.Defaults/ReplApp.cs
@@ -589,6 +589,7 @@ public sealed class ReplApp : IReplApp
 			[typeof(IHistoryProvider)] = new InMemoryHistoryProvider(),
 			[typeof(TimeProvider)] = TimeProvider.System,
 			[typeof(IReplKeyReader)] = new ConsoleKeyReader(),
+			[typeof(IReplIoContext)] = new LiveReplIoContext(),
 		};
 
 		var channel = new DefaultsInteractionChannel(
@@ -631,6 +632,7 @@ public sealed class ReplApp : IReplApp
 				sp.GetService<TimeProvider>())));
 		services.TryAddSingleton<IReplKeyReader, ConsoleKeyReader>();
 		services.TryAddSingleton<IReplSessionInfo, LiveSessionInfo>();
+		services.TryAddSingleton<IReplIoContext, LiveReplIoContext>();
 	}
 
 	private sealed class ScopedReplApp(ICoreReplApp map, IServiceCollection services) : IReplApp

--- a/src/Repl.IntegrationTests/ConsoleCaptureHelper.cs
+++ b/src/Repl.IntegrationTests/ConsoleCaptureHelper.cs
@@ -21,6 +21,29 @@ internal static class ConsoleCaptureHelper
 		}
 	}
 
+	public static (int ExitCode, string StdOut, string StdErr) CaptureStdOutAndErr(Func<int> action)
+	{
+		ArgumentNullException.ThrowIfNull(action);
+
+		var previousOut = Console.Out;
+		var previousErr = Console.Error;
+		using var stdout = new StringWriter();
+		using var stderr = new StringWriter();
+		Console.SetOut(stdout);
+		Console.SetError(stderr);
+
+		try
+		{
+			var exitCode = action();
+			return (exitCode, stdout.ToString(), stderr.ToString());
+		}
+		finally
+		{
+			Console.SetOut(previousOut);
+			Console.SetError(previousErr);
+		}
+	}
+
 	public static (int ExitCode, string Text) CaptureWithInput(string input, Func<int> action)
 	{
 		ArgumentNullException.ThrowIfNull(input);
@@ -41,6 +64,36 @@ internal static class ConsoleCaptureHelper
 		finally
 		{
 			Console.SetOut(previousOut);
+			Console.SetIn(previousIn);
+		}
+	}
+
+	public static (int ExitCode, string StdOut, string StdErr) CaptureWithInputStdOutAndErr(
+		string input,
+		Func<int> action)
+	{
+		ArgumentNullException.ThrowIfNull(input);
+		ArgumentNullException.ThrowIfNull(action);
+
+		var previousOut = Console.Out;
+		var previousErr = Console.Error;
+		var previousIn = Console.In;
+		using var stdout = new StringWriter();
+		using var stderr = new StringWriter();
+		using var reader = new StringReader(input);
+		Console.SetOut(stdout);
+		Console.SetError(stderr);
+		Console.SetIn(reader);
+
+		try
+		{
+			var exitCode = action();
+			return (exitCode, stdout.ToString(), stderr.ToString());
+		}
+		finally
+		{
+			Console.SetOut(previousOut);
+			Console.SetError(previousErr);
 			Console.SetIn(previousIn);
 		}
 	}

--- a/src/Repl.IntegrationTests/Given_ProtocolPassthrough.cs
+++ b/src/Repl.IntegrationTests/Given_ProtocolPassthrough.cs
@@ -1,0 +1,151 @@
+namespace Repl.IntegrationTests;
+
+[TestClass]
+[DoNotParallelize]
+public sealed class Given_ProtocolPassthrough
+{
+	[TestMethod]
+	[Description("Regression guard: verifies protocol passthrough suppresses banners so stdout only contains handler protocol output.")]
+	public void When_CommandIsProtocolPassthrough_Then_GlobalAndCommandBannersAreSuppressed()
+	{
+		var sut = ReplApp.Create()
+			.WithDescription("Test banner");
+		sut.Map(
+				"mcp start",
+				() =>
+				{
+					Console.Out.WriteLine("rpc-ready");
+					return Results.Exit(0);
+				})
+			.WithBanner("Command banner")
+			.AsProtocolPassthrough();
+
+		var output = ConsoleCaptureHelper.CaptureStdOutAndErr(() => sut.Run(["mcp", "start"]));
+
+		output.ExitCode.Should().Be(0);
+		output.StdOut.Should().Contain("rpc-ready");
+		output.StdOut.Should().NotContain("Test banner");
+		output.StdOut.Should().NotContain("Command banner");
+		output.StdErr.Should().BeNullOrWhiteSpace();
+	}
+
+	[TestMethod]
+	[Description("Regression guard: verifies protocol passthrough routes repl diagnostics to stderr while keeping stdout clean.")]
+	public void When_ProtocolPassthroughHandlerFails_Then_ReplDiagnosticsAreWrittenToStderr()
+	{
+		var sut = ReplApp.Create()
+			.WithDescription("Test banner");
+		sut.Map(
+				"mcp start",
+				static string () => throw new InvalidOperationException("invalid start"))
+			.AsProtocolPassthrough();
+
+		var output = ConsoleCaptureHelper.CaptureStdOutAndErr(() => sut.Run(["mcp", "start"]));
+
+		output.ExitCode.Should().Be(1);
+		output.StdOut.Should().BeNullOrWhiteSpace();
+		output.StdErr.Should().Contain("Validation: invalid start");
+		output.StdErr.Should().NotContain("Test banner");
+	}
+
+	[TestMethod]
+	[Description("Regression guard: verifies protocol passthrough keeps explicit exit results silent while preserving the exit code.")]
+	public void When_ProtocolPassthroughReturnsExitWithoutPayload_Then_ExitCodeIsPropagatedWithoutFrameworkOutput()
+	{
+		var sut = ReplApp.Create()
+			.WithDescription("Test banner");
+		sut.Map("mcp start", () => Results.Exit(7))
+			.AsProtocolPassthrough();
+
+		var output = ConsoleCaptureHelper.CaptureStdOutAndErr(() => sut.Run(["mcp", "start"]));
+
+		output.ExitCode.Should().Be(7);
+		output.StdOut.Should().BeNullOrWhiteSpace();
+		output.StdErr.Should().BeNullOrWhiteSpace();
+	}
+
+	[TestMethod]
+	[Description("Regression guard: verifies protocol passthrough ignores interactive follow-up so stdin remains available to the handler lifecycle.")]
+	public void When_ProtocolPassthroughIsInvokedWithInteractiveFlag_Then_InteractiveLoopIsNotStarted()
+	{
+		var sut = ReplApp.Create()
+			.WithDescription("Test banner");
+		sut.Map("mcp start", () => Results.Exit(0))
+			.AsProtocolPassthrough();
+
+		var output = ConsoleCaptureHelper.CaptureWithInputStdOutAndErr(
+			"exit\n",
+			() => sut.Run(["mcp", "start", "--interactive"]));
+
+		output.ExitCode.Should().Be(0);
+		output.StdOut.Should().BeNullOrWhiteSpace();
+		output.StdErr.Should().BeNullOrWhiteSpace();
+	}
+
+	[TestMethod]
+	[Description("Regression guard: verifies protocol passthrough fails fast in hosted sessions when handler is console-bound.")]
+	public void When_ProtocolPassthroughRunsInHostedSessionWithoutIoContext_Then_RuntimeReturnsExplicitError()
+	{
+		var sut = ReplApp.Create();
+		sut.Map("mcp start", () => Results.Exit(0))
+			.AsProtocolPassthrough();
+		using var input = new StringReader(string.Empty);
+		using var output = new StringWriter();
+		var host = new InMemoryHost(input, output);
+
+		var exitCode = sut.Run(
+			["mcp", "start"],
+			host,
+			new ReplRunOptions { HostedServiceLifecycle = HostedServiceLifecycleMode.None });
+
+		exitCode.Should().Be(1);
+		output.ToString().Should().Contain("protocol passthrough");
+		output.ToString().Should().Contain("IReplIoContext");
+	}
+
+	[TestMethod]
+	[Description("Regression guard: verifies hosted protocol passthrough works when handler requests IReplIoContext streams explicitly.")]
+	public void When_ProtocolPassthroughRunsInHostedSessionWithIoContext_Then_HandlerCanWriteToSessionStream()
+	{
+		var sut = ReplApp.Create();
+		sut.Map(
+				"transfer send",
+				(IReplIoContext io) =>
+				{
+					io.Output.WriteLine("zmodem-start");
+					return Results.Exit(0);
+				})
+			.AsProtocolPassthrough();
+		using var input = new StringReader(string.Empty);
+		using var output = new StringWriter();
+		var host = new InMemoryHost(input, output);
+
+		var exitCode = sut.Run(
+			["transfer", "send"],
+			host,
+			new ReplRunOptions { HostedServiceLifecycle = HostedServiceLifecycleMode.None });
+
+		exitCode.Should().Be(0);
+		output.ToString().Should().Contain("zmodem-start");
+	}
+
+	[TestMethod]
+	[Description("Regression guard: verifies IReplIoContext is injectable in normal CLI execution.")]
+	public void When_HandlerRequestsIoContextInCli_Then_RuntimeInjectsConsoleContext()
+	{
+		var sut = ReplApp.Create();
+		sut.Map("io check", (IReplIoContext io) => io.IsHostedSession ? "hosted" : "local");
+
+		var output = ConsoleCaptureHelper.Capture(() => sut.Run(["io", "check", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("local");
+	}
+
+	private sealed class InMemoryHost(TextReader input, TextWriter output) : IReplHost
+	{
+		public TextReader Input { get; } = input;
+
+		public TextWriter Output { get; } = output;
+	}
+}

--- a/src/Repl.IntegrationTests/Given_ProtocolPassthrough.cs
+++ b/src/Repl.IntegrationTests/Given_ProtocolPassthrough.cs
@@ -30,6 +30,24 @@ public sealed class Given_ProtocolPassthrough
 	}
 
 	[TestMethod]
+	[Description("Regression guard: verifies ambiguous prefixes still render the banner when ambiguity occurs before route execution, even with dynamic passthrough routes present.")]
+	public void When_AmbiguousPrefixOverlapsDynamicPassthroughRoute_Then_BannerIsNotSuppressed()
+	{
+		var sut = ReplApp.Create()
+			.WithDescription("Test banner");
+		sut.Map("mcp {operation}", static (string operation) => Results.Exit(0))
+			.AsProtocolPassthrough();
+		sut.Map("mcp list", () => "list");
+		sut.Map("mcp load", () => "load");
+
+		var output = ConsoleCaptureHelper.Capture(() => sut.Run(["mcp", "l"]));
+
+		output.ExitCode.Should().Be(1);
+		output.Text.Should().Contain("Test banner");
+		output.Text.Should().Contain("Ambiguous command prefix 'l'.");
+	}
+
+	[TestMethod]
 	[Description("Regression guard: verifies IReplIoContext output stays on stdout in CLI protocol passthrough while framework output remains redirected.")]
 	public void When_ProtocolPassthroughHandlerUsesIoContext_Then_OutputIsWrittenToStdOut()
 	{

--- a/src/Repl.IntegrationTests/Given_ProtocolPassthrough.cs
+++ b/src/Repl.IntegrationTests/Given_ProtocolPassthrough.cs
@@ -74,6 +74,20 @@ public sealed class Given_ProtocolPassthrough
 	}
 
 	[TestMethod]
+	[Description("Regression guard: verifies shell completion bridge protocol errors are rendered by framework on stderr in passthrough mode.")]
+	public void When_CompletionBridgeUsageIsInvalid_Then_ErrorIsWrittenToStderr()
+	{
+		var sut = ReplApp.Create();
+
+		var output = ConsoleCaptureHelper.CaptureStdOutAndErr(
+			() => sut.Run(["completion", "__complete", "--shell", "bash", "--line", "repl ping", "--cursor", "invalid"]));
+
+		output.ExitCode.Should().Be(1);
+		output.StdOut.Should().BeNullOrWhiteSpace();
+		output.StdErr.Should().Contain("usage: completion __complete");
+	}
+
+	[TestMethod]
 	[Description("Regression guard: verifies protocol passthrough keeps explicit exit results silent while preserving the exit code.")]
 	public void When_ProtocolPassthroughReturnsExitWithoutPayload_Then_ExitCodeIsPropagatedWithoutFrameworkOutput()
 	{

--- a/src/Repl.Tests/Given_CommandBuilder.cs
+++ b/src/Repl.Tests/Given_CommandBuilder.cs
@@ -1,0 +1,51 @@
+namespace Repl.Tests;
+
+[TestClass]
+public sealed class Given_CommandBuilder
+{
+	[TestMethod]
+	[Description("Regression guard: verifies mapped commands are not protocol passthrough by default.")]
+	public void When_CommandIsMapped_Then_ProtocolPassthroughIsDisabledByDefault()
+	{
+		var sut = CoreReplApp.Create();
+
+		var command = sut.Map("status", () => "ok");
+
+		command.IsProtocolPassthrough.Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("Regression guard: verifies fluent protocol passthrough API enables the route flag and preserves chaining.")]
+	public void When_AsProtocolPassthroughIsCalled_Then_FlagIsEnabledAndBuilderIsReturned()
+	{
+		var sut = CoreReplApp.Create();
+		var command = sut.Map("mcp start", () => Results.Exit(0));
+
+		var chained = command.AsProtocolPassthrough();
+
+		chained.Should().BeSameAs(command);
+		command.IsProtocolPassthrough.Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("Regression guard: verifies shell completion bridge route is marked as protocol passthrough.")]
+	public void When_ResolvingCompletionBridge_Then_CommandIsProtocolPassthrough()
+	{
+		var sut = CoreReplApp.Create();
+
+		var match = sut.Resolve(
+		[
+			"completion",
+			"__complete",
+			"--shell",
+			"bash",
+			"--line",
+			"repl c",
+			"--cursor",
+			"6",
+		]);
+
+		match.Should().NotBeNull();
+		match!.Route.Command.IsProtocolPassthrough.Should().BeTrue();
+	}
+}


### PR DESCRIPTION
## Why

`AsProtocolPassthrough()` keeps `stdout` clean for stdio protocols (MCP/LSP/DAP/CGI-style), but hosted sessions have a different stream ownership model.

This PR adds an explicit low-level I/O contract for handlers and makes passthrough behavior safe and predictable in hosted transports.

## What changed

- Added new injectable service: `IReplIoContext`
- Added default implementation: `LiveReplIoContext`
- Registered `IReplIoContext` in core/default DI paths (CLI and hosted overlay)
- Extended protocol passthrough runtime behavior:
  - Local CLI: unchanged (`stdout` reserved for protocol stream, repl diagnostics to `stderr`)
  - Hosted session: fail fast unless handler explicitly requests `IReplIoContext`
- Added explicit runtime error code for unsupported hosted passthrough:
  - `protocol_passthrough_hosted_not_supported`
- Marked `IReplIoContext` as framework-injected for documentation export (not exposed as user option)
- Updated docs:
  - new `docs/commands.md`
  - README passthrough guidance
  - shell completion notes preserved

## Developer-facing behavior

A hosted passthrough handler must be stream-capable, e.g.:

```csharp
app.Map("transfer send", (IReplIoContext io) =>
{
    io.Output.WriteLine("zmodem-start");
    return Results.Exit(0);
})
.AsProtocolPassthrough();
```

Console-bound libraries that open `Console.*` directly remain CLI-only.

## Tests

Added/updated coverage for:

- `CommandBuilder` passthrough API and shell completion bridge marking
- passthrough banner suppression and stdout/stderr cleanliness
- hosted fail-fast when passthrough handler is not stream-capable
- hosted success when handler requests `IReplIoContext`
- `IReplIoContext` injection in CLI mode

Validated with:

- `Repl.Tests` ✅
- `Repl.IntegrationTests` ✅
- `Repl.ProtocolTests` ✅

## Compatibility

- No breaking change to `AsProtocolPassthrough()` API surface
- Behavioral change is scoped to hosted sessions:
  - previously ambiguous
  - now explicit fail-fast unless stream-capable handler is declared

## Notes

This lays groundwork for niche remote stream workflows (for example ZMODEM-like transfers) without weakening safety for console-bound protocol SDKs.
