### PR TITLE
Add tuple return support for multiple successive renders

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -172,6 +172,58 @@ Handler parameters support native conversion for:
 
 Path existence is not validated at parse time; handlers decide validation policy.
 
+## Handler return types
+
+Handlers can return any type. The framework renders the return value through the active output transformer (`--human`, `--json`, etc.).
+
+### Supported return patterns
+
+| Return type | Behavior |
+|---|---|
+| `string` | Rendered as plain text |
+| Object / anonymous type | Rendered as key-value pairs (human) or serialized (JSON/XML/YAML) |
+| `IEnumerable<T>` | Rendered as a table (human) or collection (structured formats) |
+| `IReplResult` | Structured result with kind prefix (`Results.Ok`, `Error`, `NotFound`...) |
+| `ReplNavigationResult` | Renders payload and navigates scope (`Results.NavigateUp`, `NavigateTo`) |
+| `IExitResult` | Renders optional payload and sets process exit code (`Results.Exit`) |
+| `void` / `null` | No output |
+
+### Result factory helpers
+
+```csharp
+Results.Ok("done")                          // plain text
+Results.Text("content")                     // plain text (alias)
+Results.Success("created", details)         // success with optional details object
+Results.Error("not_allowed", "message")     // error with code
+Results.Validation("invalid input")         // validation error
+Results.NotFound("no such item")            // not-found
+Results.Cancelled("user declined")          // cancellation
+Results.NavigateUp(payload)                 // navigate up one scope level
+Results.NavigateTo("client/42", payload)    // navigate to explicit scope
+Results.Exit(0, payload)                    // explicit exit code
+```
+
+### Multiple return values (tuples)
+
+Handlers can return C# tuples to produce multiple results rendered separately in sequence:
+
+```csharp
+app.Map("status", () => (
+    "Current user: alice",
+    Results.Success("All systems operational")
+));
+```
+
+Each tuple element goes through the full rendering pipeline independently. This works with all handler signatures — sync, `Task<(T1, T2)>`, and `ValueTask<(T1, T2)>` — and supports up to 8 elements.
+
+Tuple semantics:
+
+- each element is rendered as a separate output block
+- navigation results (`NavigateUp`, `NavigateTo`) are only applied on the **last** element
+- exit code is determined by the last element
+- null elements are silently skipped
+- nested tuples are not flattened — use a flat tuple instead
+
 ## Ambient commands
 
 These commands are handled by the runtime (not by your mapped routes):

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -47,6 +47,7 @@ Repl Toolkit is a command-surface framework — not just a CLI parser. It builds
 | XML / YAML / Markdown output | ❌ | ❌ | ✅ Built-in |
 | Custom output transformers | ❌ | ❌ | ✅ `AddTransformer` |
 | Typed result objects | ❌ | ❌ | ✅ Ok, Error, NotFound... |
+| Multiple return values (tuple) | ❌ | ❌ | ✅ `(T1, T2, ...)` rendered separately |
 | Rich terminal UI (charts, trees...) | ❌ Removed | ✅ Full Spectre.Console | ⚠️ Via add-on |
 | ANSI color auto-detection | ❌ | ✅ | ✅ |
 | `NO_COLOR` / `CLICOLOR_FORCE` | ❌ | ✅ | ✅ |

--- a/src/Repl.Core/CoreReplApp.cs
+++ b/src/Repl.Core/CoreReplApp.cs
@@ -1045,17 +1045,11 @@ public sealed partial class CoreReplApp : ICoreReplApp
 			var isLast = i == tuple.Length - 1;
 
 			// Navigation results: only apply navigation on the last element.
-			object? normalized;
-			if (element is ReplNavigationResult nav && !isLast)
-			{
-				normalized = nav.Payload;
-			}
-			else
-			{
-				normalized = isLast
+			var normalized = element is ReplNavigationResult nav && !isLast
+				? nav.Payload
+				: isLast
 					? ApplyNavigationResult(element, scopeTokens)
 					: element;
-			}
 
 			ExecutionObserver?.OnResult(normalized);
 

--- a/src/Repl.Core/CoreReplApp.cs
+++ b/src/Repl.Core/CoreReplApp.cs
@@ -993,6 +993,13 @@ public sealed partial class CoreReplApp : ICoreReplApp
 						serviceProvider,
 						cancellationToken)
 					.ConfigureAwait(false);
+
+				if (TupleDecomposer.IsTupleResult(result, out var tuple))
+				{
+					return await RenderTupleResultAsync(tuple, scopeTokens, globalOptions, cancellationToken)
+						.ConfigureAwait(false);
+				}
+
 				var normalizedResult = ApplyNavigationResult(result, scopeTokens);
 				ExecutionObserver?.OnResult(normalizedResult);
 				var rendered = await RenderOutputAsync(normalizedResult, globalOptions.OutputFormat, cancellationToken, scopeTokens is not null)
@@ -1021,6 +1028,52 @@ public sealed partial class CoreReplApp : ICoreReplApp
 				.ConfigureAwait(false);
 			return 1;
 		}
+	}
+
+	private async ValueTask<int> RenderTupleResultAsync(
+		ITuple tuple,
+		List<string>? scopeTokens,
+		GlobalInvocationOptions globalOptions,
+		CancellationToken cancellationToken)
+	{
+		var isInteractive = scopeTokens is not null;
+		var exitCode = 0;
+
+		for (var i = 0; i < tuple.Length; i++)
+		{
+			var element = tuple[i];
+			var isLast = i == tuple.Length - 1;
+
+			// Navigation results: only apply navigation on the last element.
+			object? normalized;
+			if (element is ReplNavigationResult nav && !isLast)
+			{
+				normalized = nav.Payload;
+			}
+			else
+			{
+				normalized = isLast
+					? ApplyNavigationResult(element, scopeTokens)
+					: element;
+			}
+
+			ExecutionObserver?.OnResult(normalized);
+
+			var rendered = await RenderOutputAsync(normalized, globalOptions.OutputFormat, cancellationToken, isInteractive)
+				.ConfigureAwait(false);
+
+			if (!rendered)
+			{
+				return 1;
+			}
+
+			if (isLast)
+			{
+				exitCode = ComputeExitCode(normalized);
+			}
+		}
+
+		return exitCode;
 	}
 
 	private static int ComputeExitCode(object? result)

--- a/src/Repl.Core/Internal/TupleDecomposer.cs
+++ b/src/Repl.Core/Internal/TupleDecomposer.cs
@@ -1,0 +1,38 @@
+using System.Runtime.CompilerServices;
+
+namespace Repl;
+
+internal static class TupleDecomposer
+{
+	/// <summary>
+	/// Returns true if <paramref name="value"/> is a ValueTuple with 2 or more elements.
+	/// </summary>
+	internal static bool IsTupleResult(object? value, out ITuple tuple)
+	{
+		if (value is ITuple t && t.Length >= 2 && IsValueTupleType(value!.GetType()))
+		{
+			tuple = t;
+			return true;
+		}
+
+		tuple = default!;
+		return false;
+	}
+
+	private static bool IsValueTupleType(Type type)
+	{
+		if (!type.IsValueType || !type.IsGenericType)
+		{
+			return false;
+		}
+
+		var def = type.GetGenericTypeDefinition();
+		return def == typeof(ValueTuple<,>)
+			|| def == typeof(ValueTuple<,,>)
+			|| def == typeof(ValueTuple<,,,>)
+			|| def == typeof(ValueTuple<,,,,>)
+			|| def == typeof(ValueTuple<,,,,,>)
+			|| def == typeof(ValueTuple<,,,,,,>)
+			|| def == typeof(ValueTuple<,,,,,,,>);
+	}
+}

--- a/src/Repl.Tests/Given_CommandInvoker.cs
+++ b/src/Repl.Tests/Given_CommandInvoker.cs
@@ -103,6 +103,54 @@ public sealed class Given_CommandInvoker
 		result.Should().Be(15);
 	}
 
+	[TestMethod]
+	[Description("Verifies synchronous tuple-returning handler produces a boxed ValueTuple that implements ITuple.")]
+	public async Task When_HandlerReturnsTuple_Then_ResultIsBoxedValueTuple()
+	{
+		var result = await CommandInvoker.InvokeAsync(
+			(Func<(string, int)>)(() => ("hello", 42)),
+			[]);
+
+		TupleDecomposer.IsTupleResult(result, out var tuple).Should().BeTrue();
+		tuple.Length.Should().Be(2);
+		tuple[0].Should().Be("hello");
+		tuple[1].Should().Be(42);
+	}
+
+	[TestMethod]
+	[Description("Verifies async Task<tuple>-returning handler unwraps to a boxed ValueTuple.")]
+	public async Task When_HandlerReturnsTaskOfTuple_Then_ResultIsBoxedValueTuple()
+	{
+		var result = await CommandInvoker.InvokeAsync(
+			(Func<Task<(string, int)>>)(async () =>
+			{
+				await Task.Yield();
+				return ("async", 7);
+			}),
+			[]);
+
+		TupleDecomposer.IsTupleResult(result, out var tuple).Should().BeTrue();
+		tuple[0].Should().Be("async");
+		tuple[1].Should().Be(7);
+	}
+
+	[TestMethod]
+	[Description("Verifies async ValueTask<tuple>-returning handler unwraps to a boxed ValueTuple.")]
+	public async Task When_HandlerReturnsValueTaskOfTuple_Then_ResultIsBoxedValueTuple()
+	{
+		var result = await CommandInvoker.InvokeAsync(
+			(Func<ValueTask<(string, int)>>)(async () =>
+			{
+				await Task.Yield();
+				return ("vtask", 9);
+			}),
+			[]);
+
+		TupleDecomposer.IsTupleResult(result, out var tuple).Should().BeTrue();
+		tuple[0].Should().Be("vtask");
+		tuple[1].Should().Be(9);
+	}
+
 	private sealed class InstanceHandler(int offset)
 	{
 		public int AddOffset(int value) => value + offset;

--- a/src/Repl.Tests/Given_TupleDecomposer.cs
+++ b/src/Repl.Tests/Given_TupleDecomposer.cs
@@ -1,0 +1,73 @@
+using System.Runtime.CompilerServices;
+
+namespace Repl.Tests;
+
+[TestClass]
+public sealed class Given_TupleDecomposer
+{
+	[TestMethod]
+	[Description("Detects a two-element ValueTuple as a tuple result.")]
+	public void When_ValueIsTwoElementTuple_Then_DetectedAsTuple()
+	{
+		object value = (1, "hello");
+
+		var result = TupleDecomposer.IsTupleResult(value, out var tuple);
+
+		result.Should().BeTrue();
+		tuple.Length.Should().Be(2);
+		tuple[0].Should().Be(1);
+		tuple[1].Should().Be("hello");
+	}
+
+	[TestMethod]
+	[Description("Detects a three-element ValueTuple as a tuple result.")]
+	public void When_ValueIsThreeElementTuple_Then_DetectedAsTuple()
+	{
+		object value = ("a", "b", "c");
+
+		var result = TupleDecomposer.IsTupleResult(value, out var tuple);
+
+		result.Should().BeTrue();
+		tuple.Length.Should().Be(3);
+	}
+
+	[TestMethod]
+	[Description("Rejects null as not a tuple.")]
+	public void When_ValueIsNull_Then_NotDetectedAsTuple()
+	{
+		var result = TupleDecomposer.IsTupleResult(value: null, tuple: out _);
+
+		result.Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("Rejects a plain string as not a tuple.")]
+	public void When_ValueIsString_Then_NotDetectedAsTuple()
+	{
+		var result = TupleDecomposer.IsTupleResult("hello", out _);
+
+		result.Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("Rejects a reference Tuple<> as not a tuple result.")]
+	public void When_ValueIsReferenceTuple_Then_NotDetectedAsTuple()
+	{
+		var result = TupleDecomposer.IsTupleResult(Tuple.Create(1, 2), out _);
+
+		result.Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("Handles an eight-element ValueTuple (which uses nested TRest internally).")]
+	public void When_ValueIsEightElementTuple_Then_DetectedAsTuple()
+	{
+		object value = (1, 2, 3, 4, 5, 6, 7, 8);
+
+		var result = TupleDecomposer.IsTupleResult(value, out var tuple);
+
+		result.Should().BeTrue();
+		tuple.Length.Should().Be(8);
+		tuple[7].Should().Be(8);
+	}
+}

--- a/src/Repl.Tests/Given_TupleRendering.cs
+++ b/src/Repl.Tests/Given_TupleRendering.cs
@@ -1,0 +1,97 @@
+namespace Repl.Tests;
+
+[TestClass]
+public sealed class Given_TupleRendering
+{
+	[TestMethod]
+	[Description("Verifies tuple elements are rendered as separate output lines.")]
+	public void When_HandlerReturnsTuple_Then_EachElementIsRenderedSeparately()
+	{
+		var sut = ReplApp.Create();
+		sut.Map("test", () => ("first line", "second line"));
+
+		using var output = new StringWriter();
+		using var scope = ReplSessionIO.SetSession(output, TextReader.Null);
+
+		var exitCode = sut.Run(["test"]);
+
+		exitCode.Should().Be(0);
+		var text = output.ToString();
+		text.Should().Contain("first line");
+		text.Should().Contain("second line");
+	}
+
+	[TestMethod]
+	[Description("Verifies three-element tuple renders all elements.")]
+	public void When_HandlerReturnsThreeElementTuple_Then_AllElementsAreRendered()
+	{
+		var sut = ReplApp.Create();
+		sut.Map("test", () => ("one", 2, "three"));
+
+		using var output = new StringWriter();
+		using var scope = ReplSessionIO.SetSession(output, TextReader.Null);
+
+		var exitCode = sut.Run(["test"]);
+
+		exitCode.Should().Be(0);
+		var text = output.ToString();
+		text.Should().Contain("one");
+		text.Should().Contain("2");
+		text.Should().Contain("three");
+	}
+
+	[TestMethod]
+	[Description("Verifies tuple with IReplResult element renders the result message.")]
+	public void When_TupleContainsReplResult_Then_ResultMessageIsRendered()
+	{
+		var sut = ReplApp.Create();
+		sut.Map("test", () => ("status", Results.Success("done")));
+
+		using var output = new StringWriter();
+		using var scope = ReplSessionIO.SetSession(output, TextReader.Null);
+
+		var exitCode = sut.Run(["test"]);
+
+		exitCode.Should().Be(0);
+		var text = output.ToString();
+		text.Should().Contain("status");
+		text.Should().Contain("done");
+	}
+
+	[TestMethod]
+	[Description("Verifies exit code is determined by the last tuple element.")]
+	public void When_LastTupleElementIsError_Then_ExitCodeIsNonZero()
+	{
+		var sut = ReplApp.Create();
+		sut.Map("test", () => ("info", Results.Error("fail", "something broke")));
+
+		using var output = new StringWriter();
+		using var scope = ReplSessionIO.SetSession(output, TextReader.Null);
+
+		var exitCode = sut.Run(["test"]);
+
+		exitCode.Should().Be(1);
+	}
+
+	[TestMethod]
+	[Description("Verifies async tuple handler renders all elements.")]
+	public void When_HandlerReturnsAsyncTuple_Then_AllElementsAreRendered()
+	{
+		var sut = ReplApp.Create();
+		sut.Map("test", async () =>
+		{
+			await Task.Yield();
+			return ("async-one", "async-two");
+		});
+
+		using var output = new StringWriter();
+		using var scope = ReplSessionIO.SetSession(output, TextReader.Null);
+
+		var exitCode = sut.Run(["test"]);
+
+		exitCode.Should().Be(0);
+		var text = output.ToString();
+		text.Should().Contain("async-one");
+		text.Should().Contain("async-two");
+	}
+}


### PR DESCRIPTION
## Summary
- Handlers can now return C# ValueTuples to produce multiple results rendered separately in sequence
- Each tuple element goes through the full rendering pipeline independently (transformer, colorization, output)
- Works with all return styles: sync, `Task<(T1,T2)>`, `ValueTask<(T1,T2)>`, up to 8 elements
- Navigation instructions in tuples are only applied on the last element
- Exit code is determined by the last element

## Example

```csharp
app.Map("status", () => ("Current user: alice", Results.Success("All systems operational")));
```

This renders two separate outputs: the plain string first, then the success result.