### PR TITLE
Add Spectre.Console integration for rich terminal output

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Globex
 | [`Repl.Protocol`](https://www.nuget.org/packages/Repl.Protocol) | Machine-readable contracts (help, errors, tool schemas) |
 | [`Repl.WebSocket`](https://www.nuget.org/packages/Repl.WebSocket) | Session hosting over WebSocket |
 | [`Repl.Telnet`](https://www.nuget.org/packages/Repl.Telnet) | Telnet framing, negotiation, session adapters |
+| [`Repl.Spectre`](https://www.nuget.org/packages/Repl.Spectre) | Spectre.Console integration: rich prompts, `IAnsiConsole`, table rendering |
 | [`Repl.Testing`](https://www.nuget.org/packages/Repl.Testing) | In-memory multi-session test harness |
 
 ## Samples
@@ -106,6 +107,7 @@ Progressive learning path — start with 01:
 4. **[Interactive Ops](samples/04-interactive-ops/)** — prompts, progress, timeouts, cancellation
 5. **[Hosting Remote](samples/05-hosting-remote/)** — WebSocket / Telnet session hosting
 6. **[Testing](samples/06-testing/)** — multi-session typed assertions
+7. **[Spectre](samples/07-spectre/)** — Spectre.Console renderables, visualizations, rich prompts
 
 ## Documentation
 
@@ -118,6 +120,7 @@ Progressive learning path — start with 01:
 | Testing toolkit | [`docs/testing-toolkit.md`](docs/testing-toolkit.md) |
 | Shell completion | [`docs/shell-completion.md`](docs/shell-completion.md) |
 | Comparison & migration | [`docs/comparison.md`](docs/comparison.md) |
+| Interaction channel | [`docs/interaction.md`](docs/interaction.md) |
 | Conditional module presence | [`docs/module-presence.md`](docs/module-presence.md) |
 | Publishing & deployment | [`docs/publishing.md`](docs/publishing.md) |
 | Interactive docs & AI Q\&A | [deepwiki.com/yllibed/repl](https://deepwiki.com/yllibed/repl) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,8 @@
 	- WebSocket session host integration (`ReplWebSocketSession`) over `StreamedReplHost`.
 - `Repl.Telnet`
 	- Telnet framing/session integration (`ReplTelnetSession`) with NAWS window-size negotiation.
+- `Repl.Spectre`
+	- Spectre.Console integration: `SpectreInteractionHandler` for rich prompts, `IAnsiConsole` DI injection, `"spectre"` output transformer for auto-rendered tables, `SpectreConsoleOptions` for capability configuration.
 - `Repl.Testing`
 	- In-memory multi-session testing toolkit (`ReplTestHost`, `ReplSessionHandle`, typed execution results/events).
 - `Repl.Tests`

--- a/docs/interaction.md
+++ b/docs/interaction.md
@@ -429,3 +429,31 @@ var app = ReplApp.Create(services =>
 ```
 
 The framework injects `ITerminalInfo` automatically — no manual registration required.
+
+---
+
+## Spectre.Console integration
+
+The `Repl.Spectre` package provides a production-ready `IReplInteractionHandler` that renders
+all prompts as rich Spectre.Console widgets, plus injectable `IAnsiConsole` for custom renderables.
+
+```csharp
+var app = ReplApp.Create(services =>
+{
+    services.AddSpectreConsole();
+})
+.UseSpectreConsole();
+```
+
+With this setup:
+
+- `AskChoiceAsync` renders as a Spectre `SelectionPrompt` (arrow-key navigation)
+- `AskMultiChoiceAsync` renders as a `MultiSelectionPrompt` (checkbox-style)
+- `AskConfirmationAsync` renders as a `ConfirmationPrompt`
+- `AskTextAsync` renders as a `TextPrompt<string>`
+- `AskSecretAsync` renders as a `TextPrompt<string>.Secret()`
+- Collections returned from handlers render as bordered Spectre tables
+
+Command handlers remain unchanged — the upgrade from built-in prompts to Spectre prompts is transparent.
+
+See also: [`Repl.Spectre` README](../src/Repl.Spectre/README.md) | [sample 07-spectre](../samples/07-spectre/)

--- a/samples/07-spectre/ContactStore.cs
+++ b/samples/07-spectre/ContactStore.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel.DataAnnotations;
+
+internal sealed record Contact(
+	[property: Display(Order = 0)] string Name,
+	[property: Display(Order = 1)] string Email,
+	[property: Display(Order = 2)] string Phone,
+	[property: Display(Order = 3)] string Department);
+
+internal interface IContactStore
+{
+	IReadOnlyList<Contact> All();
+	Contact? Get(string name);
+	void Add(Contact contact);
+	IReadOnlyDictionary<string, List<Contact>> GroupByDomain();
+}
+
+internal sealed class InMemoryContactStore : IContactStore
+{
+	private readonly List<Contact> _contacts =
+	[
+		new("Carl de Billy", "carl@gmail.com", "555-0101", "Engineering"),
+		new("Bob Smith", "bob@company.com", "555-0102", "Sales"),
+		new("Alice Martin", "alice@example.com", "555-0103", "Engineering"),
+		new("Charlie Brown", "charlie@gmail.com", "555-0104", "Marketing"),
+		new("Diana Prince", "diana@company.com", "555-0105", "Engineering"),
+		new("Eve Torres", "eve@example.com", "555-0106", "Sales"),
+		new("Frank Castle", "frank@gmail.com", "555-0107", "Marketing"),
+		new("Grace Hopper", "grace@company.com", "555-0108", "Engineering"),
+	];
+
+	public IReadOnlyList<Contact> All() => _contacts;
+
+	public Contact? Get(string name) =>
+		_contacts.FirstOrDefault(c => c.Name.Contains(name, StringComparison.OrdinalIgnoreCase));
+
+	public void Add(Contact contact)
+	{
+		ArgumentNullException.ThrowIfNull(contact);
+		_contacts.Add(contact);
+	}
+
+	public IReadOnlyDictionary<string, List<Contact>> GroupByDomain() =>
+		_contacts
+			.GroupBy(c => c.Email.Split('@')[^1])
+			.ToDictionary(g => g.Key, g => g.ToList());
+}

--- a/samples/07-spectre/GlobalUsings.cs
+++ b/samples/07-spectre/GlobalUsings.cs
@@ -1,0 +1,5 @@
+global using Repl.Interaction;
+global using Repl.Spectre;
+global using Spectre.Console;
+global using Spectre.Console.Json;
+global using Spectre.Console.Rendering;

--- a/samples/07-spectre/Program.cs
+++ b/samples/07-spectre/Program.cs
@@ -1,0 +1,423 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Repl;
+
+var app = ReplApp.Create(services =>
+	{
+		services.AddSingleton<IContactStore, InMemoryContactStore>();
+		services.AddSpectreConsole();
+	})
+	.WithDescription("Spectre.Console integration: rich renderables, interactive prompts, data visualization.")
+	.WithBanner((IAnsiConsole console) =>
+	{
+		console.Write(new FigletText("Spectre").Color(Color.Blue));
+		console.MarkupLine("  [grey]Commands:[/] tour, list, detail, chart, tree, json, path, calendar,");
+		console.MarkupLine("           figlet, status, progress, add, configure, login");
+	})
+	.UseDefaultInteractive()
+	.UseCliProfile()
+	.UseSpectreConsole();
+
+// ──────────────────────────────────────────────────────────────
+// tour — Guided walkthrough (the star command)
+// ──────────────────────────────────────────────────────────────
+app.Map("tour",
+	[Description("Guided walkthrough of Spectre features")]
+	async (IAnsiConsole console, IReplInteractionChannel channel, IContactStore store, CancellationToken ct) =>
+	{
+		// 1. FigletText welcome banner
+		console.Write(new FigletText("Welcome!").Color(Color.Blue));
+
+		// 2. TextPrompt — ask user's name
+		var name = await channel.AskTextAsync("name", "What is your name?");
+		if (string.IsNullOrWhiteSpace(name))
+		{
+			name = "Guest";
+		}
+
+		// 3. Panel — greeting
+		console.Write(new Panel(new Markup($"Hello, [bold yellow]{Markup.Escape(name)}[/]!"))
+			.Header("Greeting")
+			.Border(BoxBorder.Rounded)
+			.BorderColor(Color.Green));
+		console.WriteLine();
+
+		// 4. SelectionPrompt — choose a data category
+		string[] categories = ["All contacts", "By domain", "By department"];
+		var categoryIndex = await channel.AskChoiceAsync("category", "Choose a data category:", categories);
+		var category = categories[categoryIndex];
+
+		// 5. Table — display data for chosen category
+		var contacts = store.All();
+		var table = new Table().Border(TableBorder.Rounded).BorderColor(Color.Blue)
+			.AddColumn("Name").AddColumn("Email").AddColumn("Department");
+
+		IEnumerable<Contact> displayContacts = categoryIndex switch
+		{
+			1 => store.GroupByDomain().First().Value,
+			2 => contacts.GroupBy(c => c.Department).First(),
+			_ => contacts,
+		};
+
+		foreach (var c in displayContacts)
+		{
+			table.AddRow(Markup.Escape(c.Name), Markup.Escape(c.Email), Markup.Escape(c.Department));
+		}
+
+		console.Write(table);
+		console.WriteLine();
+
+		// 6. BarChart — stats
+		var domainGroups = store.GroupByDomain();
+		var barChart = new BarChart().Label("[bold]Contacts by Domain[/]").CenterLabel();
+		var colors = new[] { Color.Blue, Color.Green, Color.Red, Color.Yellow, Color.Purple };
+		var i = 0;
+		foreach (var (domain, domainContacts) in domainGroups)
+		{
+			barChart.AddItem(domain, domainContacts.Count, colors[i++ % colors.Length]);
+		}
+
+		console.Write(barChart);
+		console.WriteLine();
+
+		// 7. Tree — hierarchical breakdown
+		var tree = new Tree("Contacts");
+		foreach (var (domain, domainContacts) in domainGroups)
+		{
+			var node = tree.AddNode($"[yellow]{Markup.Escape(domain)}[/]");
+			foreach (var c in domainContacts)
+			{
+				node.AddNode(Markup.Escape(c.Name));
+			}
+		}
+
+		console.Write(tree);
+		console.WriteLine();
+
+		// 8. ConfirmationPrompt — continue to summary?
+		var continueToSummary = await channel.AskConfirmationAsync(
+			"continue", "Continue to summary?", defaultValue: true);
+		if (!continueToSummary)
+		{
+			return Results.Cancelled("Tour stopped by user.");
+		}
+
+		// 9. Calendar — current month
+		var today = DateTime.Today;
+		var calendar = new Calendar(today.Year, today.Month)
+			.AddCalendarEvent(today)
+			.HighlightStyle(new Style(Color.Blue, decoration: Decoration.Bold));
+		console.Write(new Panel(calendar).Header("This Month").Border(BoxBorder.Rounded));
+		console.WriteLine();
+
+		// 10. Rule + summary Panel
+		console.Write(new Rule("[blue]Summary[/]").RuleStyle(new Style(Color.Grey)));
+		console.Write(new Panel(new Markup(
+				$"[bold]Tour complete![/]\n" +
+				$"  Name: [yellow]{Markup.Escape(name)}[/]\n" +
+				$"  Category: [green]{Markup.Escape(category)}[/]\n" +
+				$"  Contacts: [blue]{contacts.Count}[/]\n" +
+				$"  Domains: [blue]{domainGroups.Count}[/]"))
+			.Header("Results")
+			.Border(BoxBorder.Double)
+			.BorderColor(Color.Gold1));
+
+		return Results.Success("Tour complete!");
+	});
+
+// ──────────────────────────────────────────────────────────────
+// list — Returns collection, auto-rendered as Spectre table
+// ──────────────────────────────────────────────────────────────
+app.Map("list",
+	[Description("List all contacts (auto-rendered table)")]
+	(IContactStore store) => store.All());
+
+// ──────────────────────────────────────────────────────────────
+// detail — Panel + Grid
+// ──────────────────────────────────────────────────────────────
+app.Map("detail {name}",
+	[Description("Show contact details in a panel")]
+	(string name, IContactStore store, IAnsiConsole console) =>
+	{
+		var contact = store.Get(name);
+		if (contact is null)
+		{
+			return Results.NotFound($"Contact '{name}' not found.");
+		}
+
+		var grid = new Grid();
+		grid.AddColumn(new GridColumn().NoWrap().PadRight(2));
+		grid.AddColumn(new GridColumn());
+		grid.AddRow(new Markup("[bold]Name[/]"), new Markup(Markup.Escape(contact.Name)));
+		grid.AddRow(new Markup("[bold]Email[/]"), new Markup(Markup.Escape(contact.Email)));
+		grid.AddRow(new Markup("[bold]Phone[/]"), new Markup(Markup.Escape(contact.Phone)));
+		grid.AddRow(new Markup("[bold]Dept[/]"), new Markup(Markup.Escape(contact.Department)));
+
+		console.Write(new Panel(grid)
+			.Header(Markup.Escape(contact.Name))
+			.Border(BoxBorder.Rounded)
+			.BorderColor(Color.Blue));
+
+		return Results.Success($"Details for {contact.Name}.");
+	});
+
+// ──────────────────────────────────────────────────────────────
+// chart — BarChart + BreakdownChart
+// ──────────────────────────────────────────────────────────────
+app.Map("chart",
+	[Description("Visualize contacts by domain")]
+	(IContactStore store, IAnsiConsole console) =>
+	{
+		var groups = store.GroupByDomain();
+		var colors = new[] { Color.Blue, Color.Green, Color.Red, Color.Yellow, Color.Purple, Color.Aqua };
+
+		var barChart = new BarChart()
+			.Label("[bold]Contacts per Domain[/]")
+			.CenterLabel();
+		var i = 0;
+		foreach (var (domain, contacts) in groups)
+		{
+			barChart.AddItem(domain, contacts.Count, colors[i++ % colors.Length]);
+		}
+
+		console.Write(barChart);
+		console.WriteLine();
+
+		var breakdown = new BreakdownChart();
+		i = 0;
+		foreach (var (domain, contacts) in groups)
+		{
+			breakdown.AddItem(domain, contacts.Count, colors[i++ % colors.Length]);
+		}
+
+		console.Write(new Panel(breakdown)
+			.Header("Email Provider Breakdown")
+			.Border(BoxBorder.Rounded));
+
+		return Results.Success($"{groups.Count} domains visualized.");
+	});
+
+// ──────────────────────────────────────────────────────────────
+// tree — Tree view
+// ──────────────────────────────────────────────────────────────
+app.Map("tree",
+	[Description("Show contacts as a tree by domain")]
+	(IContactStore store, IAnsiConsole console) =>
+	{
+		var groups = store.GroupByDomain();
+		var tree = new Tree("[bold]Contacts[/]");
+
+		foreach (var (domain, contacts) in groups)
+		{
+			var node = tree.AddNode($"[yellow]@{Markup.Escape(domain)}[/] [grey]({contacts.Count})[/]");
+			foreach (var c in contacts)
+			{
+				node.AddNode($"{Markup.Escape(c.Name)} [grey]- {Markup.Escape(c.Department)}[/]");
+			}
+		}
+
+		console.Write(tree);
+		return Results.Success($"{store.All().Count} contacts in {groups.Count} domains.");
+	});
+
+// ──────────────────────────────────────────────────────────────
+// json — JsonText
+// ──────────────────────────────────────────────────────────────
+app.Map("json {name}",
+	[Description("Show contact as syntax-highlighted JSON")]
+	(string name, IContactStore store, IAnsiConsole console) =>
+	{
+		var contact = store.Get(name);
+		if (contact is null)
+		{
+			return Results.NotFound($"Contact '{name}' not found.");
+		}
+
+		var json = JsonSerializer.Serialize(contact, JsonOptions.Indented);
+		console.Write(new Panel(new JsonText(json))
+			.Header("JSON")
+			.Border(BoxBorder.Rounded)
+			.BorderColor(Color.Yellow));
+
+		return Results.Success($"JSON for {contact.Name}.");
+	});
+
+// ──────────────────────────────────────────────────────────────
+// path — TextPath + Columns
+// ──────────────────────────────────────────────────────────────
+app.Map("path",
+	[Description("Show file paths with TextPath in Columns layout")]
+	(IAnsiConsole console) =>
+	{
+		string[] paths =
+		[
+			"C:/Projects/ContactManager/src/Models/Contact.cs",
+			"C:/Projects/ContactManager/src/Services/ContactStore.cs",
+			"C:/Projects/ContactManager/src/Controllers/ContactController.cs",
+			"C:/Projects/ContactManager/tests/ContactStoreTests.cs",
+			"C:/Projects/ContactManager/docs/README.md",
+			"C:/Projects/ContactManager/config/appsettings.json",
+		];
+
+		var textPaths = paths.Select(p => (IRenderable)new TextPath(p)
+			.StemColor(Color.Yellow)
+			.LeafColor(Color.Green)
+			.SeparatorColor(Color.Grey)
+			.RootColor(Color.Blue)).ToArray();
+
+		console.Write(new Columns(textPaths));
+		return Results.Success($"{paths.Length} paths displayed.");
+	});
+
+// ──────────────────────────────────────────────────────────────
+// calendar — Calendar
+// ──────────────────────────────────────────────────────────────
+app.Map("calendar",
+	[Description("Show a calendar with highlighted dates")]
+	(IAnsiConsole console) =>
+	{
+		var today = DateTime.Today;
+		var calendar = new Calendar(today.Year, today.Month)
+			.AddCalendarEvent(today)
+			.AddCalendarEvent(today.Year, today.Month, 1)
+			.AddCalendarEvent(today.Year, today.Month, 15)
+			.HighlightStyle(new Style(Color.Blue, decoration: Decoration.Bold))
+			.HeaderStyle(new Style(Color.Yellow));
+
+		console.Write(new Panel(calendar)
+			.Header($"{today:MMMM yyyy}")
+			.Border(BoxBorder.Rounded)
+			.BorderColor(Color.Blue));
+
+		return Results.Success("Calendar displayed.");
+	});
+
+// ──────────────────────────────────────────────────────────────
+// figlet — FigletText
+// ──────────────────────────────────────────────────────────────
+app.Map("figlet {text}",
+	[Description("Render large ASCII art text")]
+	(string text, IAnsiConsole console) =>
+	{
+		console.Write(new FigletText(text).Color(Color.Green));
+		return Results.Success($"Rendered '{text}' as FigletText.");
+	});
+
+// ──────────────────────────────────────────────────────────────
+// status — Status spinner
+// ──────────────────────────────────────────────────────────────
+app.Map("status",
+	[Description("Show a spinner progressing through stages")]
+	async (IAnsiConsole console, CancellationToken ct) =>
+	{
+		await console.Status().StartAsync("Initializing...", async ctx =>
+		{
+			ctx.Spinner = Spinner.Known.Dots;
+			ctx.SpinnerStyle = new Style(Color.Blue);
+			await Task.Delay(1000, ct);
+
+			ctx.Status = "Loading contacts...";
+			ctx.SpinnerStyle = new Style(Color.Green);
+			await Task.Delay(1000, ct);
+
+			ctx.Status = "Building index...";
+			ctx.SpinnerStyle = new Style(Color.Yellow);
+			await Task.Delay(1000, ct);
+
+			ctx.Status = "Finalizing...";
+			ctx.SpinnerStyle = new Style(Color.Purple);
+			await Task.Delay(1000, ct);
+		});
+
+		return Results.Success("All stages complete.");
+	});
+
+// ──────────────────────────────────────────────────────────────
+// progress — Progress bars
+// ──────────────────────────────────────────────────────────────
+app.Map("progress",
+	[Description("Show multi-task progress bars")]
+	async (IAnsiConsole console, CancellationToken ct) =>
+	{
+		await console.Progress()
+			.Columns(
+				new TaskDescriptionColumn(),
+				new ProgressBarColumn(),
+				new PercentageColumn(),
+				new SpinnerColumn())
+			.StartAsync(async ctx =>
+			{
+				var task1 = ctx.AddTask("Downloading contacts");
+				var task2 = ctx.AddTask("Processing records");
+				var task3 = ctx.AddTask("Generating reports");
+
+				while (!ctx.IsFinished)
+				{
+					await Task.Delay(50, ct);
+					task1.Increment(1.5);
+					task2.Increment(0.9);
+					task3.Increment(0.5);
+				}
+			});
+
+		return Results.Success("All tasks complete.");
+	});
+
+// ──────────────────────────────────────────────────────────────
+// add — Interactive prompts (transparent Spectre upgrade)
+// ──────────────────────────────────────────────────────────────
+app.Map("add",
+	[Description("Add a contact (interactive prompts via Spectre)")]
+	async (IReplInteractionChannel channel, IContactStore store, CancellationToken ct) =>
+	{
+		var name = await channel.AskTextAsync("name", "Contact name?");
+		while (string.IsNullOrWhiteSpace(name))
+		{
+			name = await channel.AskTextAsync("name", "Contact name?");
+		}
+
+		var email = await channel.AskTextAsync("email", "Email address?");
+		var phone = await channel.AskTextAsync("phone", "Phone number?");
+
+		string[] departments = ["Engineering", "Sales", "Marketing", "Support", "Management"];
+		var deptIndex = await channel.AskChoiceAsync("department", "Department?", departments);
+
+		store.Add(new Contact(name, email, phone, departments[deptIndex]));
+		return Results.Success($"Contact '{name}' added.");
+	});
+
+// ──────────────────────────────────────────────────────────────
+// configure — MultiSelectionPrompt
+// ──────────────────────────────────────────────────────────────
+app.Map("configure",
+	[Description("Configure features (multi-selection)")]
+	async (IReplInteractionChannel channel, CancellationToken ct) =>
+	{
+		var selected = await channel.AskMultiChoiceAsync(
+			"features",
+			"Enable features:",
+			["Authentication", "Logging", "Caching", "Metrics", "Rate Limiting", "Compression"],
+			defaultIndices: [0, 1]);
+
+		return Results.Success($"Enabled {selected.Count} feature(s).");
+	});
+
+// ──────────────────────────────────────────────────────────────
+// login — Secret input
+// ──────────────────────────────────────────────────────────────
+app.Map("login",
+	[Description("Simulate login (secret input via Spectre)")]
+	async (IReplInteractionChannel channel, CancellationToken ct) =>
+	{
+		var username = await channel.AskTextAsync("username", "Username?");
+		var password = await channel.AskSecretAsync("password", "Password?");
+		return Results.Success($"Logged in as '{username}' (password length: {password.Length}).");
+	});
+
+return app.Run(args);
+
+file static class JsonOptions
+{
+	internal static readonly JsonSerializerOptions Indented = new() { WriteIndented = true };
+}

--- a/samples/07-spectre/README.md
+++ b/samples/07-spectre/README.md
@@ -1,0 +1,204 @@
+# 07 — Spectre
+**Rich Spectre.Console integration: renderables, visualizations, and interactive prompts**
+
+This sample showcases the `Repl.Spectre` package with **21 Spectre.Console features**
+across **14 commands**. It demonstrates both direct `IAnsiConsole` usage for custom
+renderables and the transparent prompt upgrade where `IReplInteractionChannel` calls
+are automatically rendered as Spectre prompts.
+
+---
+
+## Quick start
+
+```bash
+dotnet run --project samples/07-spectre/SpectreOpsSample.csproj
+```
+
+---
+
+## Commands
+
+### `tour` — Guided walkthrough (the star command)
+
+A multi-step flow chaining 10 Spectre features sequentially:
+
+1. **FigletText** — ASCII art welcome banner
+2. **TextPrompt** — ask user's name (via `AskTextAsync`)
+3. **Panel** — greeting panel with the name
+4. **SelectionPrompt** — choose a data category (via `AskChoiceAsync`)
+5. **Table** — display contacts for the chosen category
+6. **BarChart** — domain distribution visualization
+7. **Tree** — hierarchical contact breakdown
+8. **ConfirmationPrompt** — "Continue to summary?" (via `AskConfirmationAsync`)
+9. **Calendar** — current month with today highlighted
+10. **Rule** + **Panel** — divider and summary
+
+### `list` — Auto-rendered Spectre table
+
+Returns a collection; the `"spectre"` output transformer renders it as a bordered
+table automatically. Zero rendering code in the handler.
+
+### `detail {name}` — Panel + Grid
+
+Uses `IAnsiConsole` to render a `Panel` containing a `Grid` of contact details.
+
+### `chart` — BarChart + BreakdownChart
+
+Renders a `BarChart` of contact counts per domain and a `BreakdownChart`
+of email provider distribution.
+
+### `tree` — Tree view
+
+Renders a `Tree` of contacts grouped by email domain.
+
+### `json {name}` — JsonText
+
+Renders syntax-highlighted JSON for a contact using `Spectre.Console.Json.JsonText`.
+
+### `path` — TextPath + Columns
+
+Renders file paths with `TextPath` (syntax-highlighted path components) in a `Columns` layout.
+
+### `calendar` — Calendar
+
+Renders a `Calendar` with today and event dates highlighted.
+
+### `figlet {text}` — FigletText
+
+Renders large ASCII art from user input.
+
+### `status` — Status spinner
+
+Uses `IAnsiConsole` with `Status().StartAsync()` to show a spinner progressing
+through named stages with changing colors.
+
+### `progress` — Progress bars
+
+Uses `IAnsiConsole` with `Progress().StartAsync()` to show multi-task progress
+bars with description, percentage, and spinner columns.
+
+### `add` — Interactive prompts
+
+Uses `IReplInteractionChannel` for `AskTextAsync` + `AskChoiceAsync`. With
+Spectre registered, these are automatically rendered as rich Spectre prompts —
+no Spectre-specific code in the handler.
+
+### `configure` — MultiSelectionPrompt
+
+Uses `AskMultiChoiceAsync` which renders as a Spectre `MultiSelectionPrompt`
+with checkbox-style selection.
+
+### `login` — Secret input
+
+Uses `AskSecretAsync` which renders as a Spectre `TextPrompt` with masked input.
+
+---
+
+## Spectre features coverage
+
+| Feature | Class | Used in |
+|---------|-------|---------|
+| FigletText | `FigletText` | `tour`, `figlet`, banner |
+| Table | `Table` | `tour` |
+| Table (auto) | via output transformer | `list` |
+| Tree | `Tree` | `tour`, `tree` |
+| Panel | `Panel` | `tour`, `detail`, `json`, `calendar`, `chart` |
+| Rule | `Rule` | `tour` |
+| BarChart | `BarChart` | `tour`, `chart` |
+| BreakdownChart | `BreakdownChart` | `chart` |
+| Calendar | `Calendar` | `tour`, `calendar` |
+| JsonText | `JsonText` | `json` |
+| TextPath | `TextPath` | `path` |
+| Columns | `Columns` | `path` |
+| Grid | `Grid` | `detail` |
+| Markup | `Markup` | throughout |
+| Status | `Status` | `status` |
+| Progress | `Progress` | `progress` |
+| SelectionPrompt | via `AskChoiceAsync` | `tour`, `add` |
+| MultiSelectionPrompt | via `AskMultiChoiceAsync` | `configure` |
+| ConfirmationPrompt | via `AskConfirmationAsync` | `tour` |
+| TextPrompt | via `AskTextAsync` | `tour`, `add` |
+| TextPrompt.Secret | via `AskSecretAsync` | `login` |
+
+---
+
+## Two integration paths
+
+### 1. Direct `IAnsiConsole` injection
+
+Inject `IAnsiConsole` into any command handler to use any Spectre renderable:
+
+```csharp
+app.Map("chart", (IAnsiConsole console, IContactStore store) =>
+{
+    var chart = new BarChart().Label("Contacts per Domain");
+    // ... add items ...
+    console.Write(chart);
+});
+```
+
+### 2. Transparent prompt upgrade
+
+Call `IReplInteractionChannel` methods as usual — with Spectre registered,
+they render as rich Spectre prompts automatically:
+
+```csharp
+app.Map("add", async (IReplInteractionChannel channel) =>
+{
+    var name = await channel.AskTextAsync("name", "Contact name?");
+    var dept = await channel.AskChoiceAsync("dept", "Department?",
+        ["Engineering", "Sales", "Marketing"]);
+});
+```
+
+No Spectre-specific code in the handler — the same handler works with or without Spectre.
+
+---
+
+## Banner with `IAnsiConsole`
+
+The sample uses `IAnsiConsole` directly in the banner callback to render
+a FigletText header at startup:
+
+```csharp
+.WithBanner((IAnsiConsole console) =>
+{
+    console.Write(new FigletText("Spectre").Color(Color.Blue));
+    console.MarkupLine("  [grey]Commands:[/] tour, list, detail, ...");
+})
+```
+
+---
+
+## Configuration
+
+`UseSpectreConsole()` accepts an optional configuration callback:
+
+```csharp
+// Default: Unicode enabled, UTF-8 output encoding
+.UseSpectreConsole()
+
+// Disable Unicode for terminals that don't support it
+.UseSpectreConsole(o => o.Unicode = false)
+```
+
+When `Unicode` is `true` (the default), `UseSpectreConsole` sets
+`Console.OutputEncoding` to UTF-8 so that box-drawing characters,
+progress bars, and spinners render correctly on Windows.
+
+---
+
+## What's next?
+
+You now have the full progressive path:
+
+- Routing and parsing (01)
+- Scopes and DI (02)
+- Composable modules (03)
+- Interaction channel (04)
+- Remote hosting (05)
+- Testing toolkit (06)
+- **Spectre.Console integration (07)**
+
+See also: [`Repl.Spectre` package README](../../src/Repl.Spectre/README.md)
+for the integration API reference.

--- a/samples/07-spectre/SpectreOpsSample.csproj
+++ b/samples/07-spectre/SpectreOpsSample.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Repl\Repl.csproj" />
+    <ProjectReference Include="..\..\src\Repl.Spectre\Repl.Spectre.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Spectre.Console.Json" Version="0.54.0" />
+  </ItemGroup>
+</Project>

--- a/samples/README.md
+++ b/samples/README.md
@@ -16,8 +16,10 @@ If you’re new, start with **01**, then follow the sequence.
    Prompts, progress, timeouts, cancellation, and deterministic automation via `--answer:*`.
 5. [05 — Hosting Remote](05-hosting-remote/)  
    Session hosting over transports (raw WebSocket, Telnet-over-WebSocket, SignalR), shared state, session visibility, terminal metadata.
-6. [06 — Testing](06-testing/)  
+6. [06 — Testing](06-testing/)
    `Repl.Testing` harness: multi-step + multi-session, typed results, interaction/timeline events, metadata snapshots.
+7. [07 — Spectre](07-spectre/)
+   `Repl.Spectre` integration: FigletText, Table, Panel, Tree, BarChart, BreakdownChart, Calendar, JsonText, TextPath, Grid, Columns, Rule, Status, Progress, and all Spectre-powered prompts.
 
 ## Run
 
@@ -34,6 +36,7 @@ Replace the project path with the one you want:
 - `samples/04-interactive-ops/InteractiveOpsSample.csproj`
 - `samples/05-hosting-remote/HostingRemoteSample.csproj`
 - `samples/06-testing/TestingSample.csproj`
+- `samples/07-spectre/SpectreOpsSample.csproj`
 
 ## Suggested reading (existing docs)
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,6 +13,7 @@
 	<ItemGroup Label="Runtime dependencies">
 		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3"/>
 		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.3"/>
+		<PackageVersion Include="Spectre.Console" Version="0.54.0"/>
 	</ItemGroup>
 
 	<ItemGroup Label="Test dependencies">

--- a/src/Repl.Core/CoreReplApp.Routing.cs
+++ b/src/Repl.Core/CoreReplApp.Routing.cs
@@ -318,7 +318,7 @@ public sealed partial class CoreReplApp
 		var format = string.IsNullOrWhiteSpace(requestedOutputFormat)
 			? _options.Output.DefaultFormat
 			: requestedOutputFormat;
-		return string.Equals(format, "human", StringComparison.OrdinalIgnoreCase);
+		return _options.Output.BannerFormats.Contains(format);
 	}
 
 	private async ValueTask InvokeBannerAsync(

--- a/src/Repl.Core/CoreReplApp.cs
+++ b/src/Repl.Core/CoreReplApp.cs
@@ -853,7 +853,7 @@ public sealed partial class CoreReplApp : ICoreReplApp
 		var requestedFormat = string.IsNullOrWhiteSpace(globalOptions.OutputFormat)
 			? _options.Output.DefaultFormat
 			: globalOptions.OutputFormat;
-		if (!string.Equals(requestedFormat, "human", StringComparison.OrdinalIgnoreCase))
+		if (!_options.Output.BannerFormats.Contains(requestedFormat))
 		{
 			return;
 		}

--- a/src/Repl.Core/InternalsVisibleTo.cs
+++ b/src/Repl.Core/InternalsVisibleTo.cs
@@ -4,3 +4,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Repl.IntegrationTests")]
 [assembly: InternalsVisibleTo("Repl.Defaults")]
 [assembly: InternalsVisibleTo("Repl.Testing")]
+[assembly: InternalsVisibleTo("Repl.Spectre")]

--- a/src/Repl.Core/OutputOptions.cs
+++ b/src/Repl.Core/OutputOptions.cs
@@ -62,6 +62,13 @@ public sealed class OutputOptions
 	public bool BannerEnabled { get; set; } = true;
 
 	/// <summary>
+	/// Gets the set of output format names eligible for banner rendering.
+	/// Only formats in this set will display banners in interactive mode.
+	/// Add custom format names (e.g. "spectre") to enable banners for those formats.
+	/// </summary>
+	public ISet<string> BannerFormats { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "human" };
+
+	/// <summary>
 	/// Gets or sets a value indicating whether structured output (for example JSON)
 	/// should be ANSI colorized during interactive sessions.
 	/// </summary>

--- a/src/Repl.Spectre/GlobalUsings.cs
+++ b/src/Repl.Spectre/GlobalUsings.cs
@@ -1,0 +1,4 @@
+global using Repl;
+global using Repl.Interaction;
+global using Spectre.Console;
+global using Spectre.Console.Rendering;

--- a/src/Repl.Spectre/InternalsVisibleTo.cs
+++ b/src/Repl.Spectre/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Repl.SpectreTests")]

--- a/src/Repl.Spectre/README.md
+++ b/src/Repl.Spectre/README.md
@@ -6,29 +6,102 @@ Spectre.Console integration for Repl Toolkit. Provides rich interactive prompts,
 
 - **Rich prompts** — `SelectionPrompt`, `MultiSelectionPrompt`, `ConfirmationPrompt`, `TextPrompt`, and secret input via Spectre.Console
 - **IAnsiConsole injection** — use `IAnsiConsole` as a command parameter to render tables, trees, panels, and other Spectre renderables
-- **Table output** — the "spectre" output format renders collections as bordered Spectre tables
+- **Table output** — the `"spectre"` output format renders collections as bordered Spectre tables with `[Display]` attribute support
+- **Banner support** — inject `IAnsiConsole` into `WithBanner()` callbacks for rich startup banners (FigletText, Markup, etc.)
+- **Configurable capabilities** — `SpectreConsoleOptions` to control Unicode rendering for different terminal environments
 
-## Usage
+## Setup
 
 ```csharp
 var app = ReplApp.Create(services =>
 {
-    services.AddSpectreConsole();
-});
-app.UseSpectreConsole();
+    services.AddSpectreConsole(); // DI: IAnsiConsole + SpectreInteractionHandler
+})
+.UseSpectreConsole(); // Output transformer + banner format + UTF-8 encoding
+```
 
-app.Map("list", () => new[]
-{
-    new { Name = "Alpha", Status = "Active" },
-    new { Name = "Beta",  Status = "Paused" },
-});
+Two calls, two concerns:
 
+| Method | Scope | What it does |
+|--------|-------|-------------|
+| `AddSpectreConsole()` | `IServiceCollection` | Registers `IAnsiConsole` (transient) and `SpectreInteractionHandler` in DI |
+| `UseSpectreConsole()` | `ReplApp` | Registers `"spectre"` output transformer, sets it as default, enables banners, configures UTF-8 |
+
+## Usage
+
+### Auto-rendered tables
+
+Return a collection from a command — the output transformer renders it as a bordered Spectre table:
+
+```csharp
+app.Map("list", (IContactStore store) => store.All());
+```
+
+Column headers are derived from `[Display]` attributes. No rendering code needed.
+
+### Direct `IAnsiConsole` injection
+
+Inject `IAnsiConsole` to use any Spectre renderable:
+
+```csharp
 app.Map("report", (IAnsiConsole console) =>
 {
-    var table = new Table();
-    table.AddColumn("Name");
-    table.AddColumn("Value");
+    var table = new Table().AddColumn("Name").AddColumn("Value");
     table.AddRow("Item", "42");
     console.Write(table);
 });
 ```
+
+Works with all Spectre renderables: `Table`, `Tree`, `Panel`, `BarChart`, `Calendar`, `FigletText`, `Progress`, `Status`, and more.
+
+### Transparent prompt upgrade
+
+`IReplInteractionChannel` calls are automatically rendered as Spectre prompts:
+
+| Channel method | Spectre prompt |
+|----------------|---------------|
+| `AskTextAsync` | `TextPrompt<string>` |
+| `AskChoiceAsync` | `SelectionPrompt<string>` |
+| `AskMultiChoiceAsync` | `MultiSelectionPrompt<string>` |
+| `AskConfirmationAsync` | `ConfirmationPrompt` |
+| `AskSecretAsync` | `TextPrompt<string>.Secret()` |
+
+No Spectre-specific code in handlers — the same handler works with or without the Spectre package.
+
+### Banner with `IAnsiConsole`
+
+Use `IAnsiConsole` in banner callbacks for rich startup output:
+
+```csharp
+app.WithBanner((IAnsiConsole console) =>
+{
+    console.Write(new FigletText("My App").Color(Color.Blue));
+    console.MarkupLine("[grey]Type 'help' to get started[/]");
+});
+```
+
+## Configuration
+
+`UseSpectreConsole()` accepts an optional callback to configure capabilities:
+
+```csharp
+// Default: Unicode enabled
+.UseSpectreConsole()
+
+// Disable Unicode for limited terminals
+.UseSpectreConsole(o => o.Unicode = false)
+```
+
+### `SpectreConsoleOptions`
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Unicode` | `bool` | `true` | Enable Unicode box-drawing characters and symbols. When `false`, Spectre falls back to ASCII. |
+
+When `Unicode` is enabled, `UseSpectreConsole()` sets `Console.OutputEncoding` to UTF-8 to ensure
+Unicode characters (progress bars, spinners, box-drawing) render correctly on Windows.
+
+## Sample
+
+See [**sample 07-spectre**](../../samples/07-spectre/) for a comprehensive demo covering
+21 Spectre features across 14 commands.

--- a/src/Repl.Spectre/README.md
+++ b/src/Repl.Spectre/README.md
@@ -1,0 +1,34 @@
+# Repl.Spectre
+
+Spectre.Console integration for Repl Toolkit. Provides rich interactive prompts, injectable `IAnsiConsole`, and beautiful table rendering.
+
+## Features
+
+- **Rich prompts** — `SelectionPrompt`, `MultiSelectionPrompt`, `ConfirmationPrompt`, `TextPrompt`, and secret input via Spectre.Console
+- **IAnsiConsole injection** — use `IAnsiConsole` as a command parameter to render tables, trees, panels, and other Spectre renderables
+- **Table output** — the "spectre" output format renders collections as bordered Spectre tables
+
+## Usage
+
+```csharp
+var app = ReplApp.Create(services =>
+{
+    services.AddSpectreConsole();
+});
+app.UseSpectreConsole();
+
+app.Map("list", () => new[]
+{
+    new { Name = "Alpha", Status = "Active" },
+    new { Name = "Beta",  Status = "Paused" },
+});
+
+app.Map("report", (IAnsiConsole console) =>
+{
+    var table = new Table();
+    table.AddColumn("Name");
+    table.AddColumn("Value");
+    table.AddRow("Item", "42");
+    console.Write(table);
+});
+```

--- a/src/Repl.Spectre/Repl.Spectre.csproj
+++ b/src/Repl.Spectre/Repl.Spectre.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<Description>Spectre.Console integration for Repl Toolkit: rich prompts, IAnsiConsole injection, and table rendering.</Description>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Repl.Defaults\Repl.Defaults.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Spectre.Console" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="README.md" Pack="true" PackagePath="" />
+	</ItemGroup>
+
+</Project>

--- a/src/Repl.Spectre/SessionAnsiConsole.cs
+++ b/src/Repl.Spectre/SessionAnsiConsole.cs
@@ -1,0 +1,138 @@
+using System.Text;
+
+namespace Repl.Spectre;
+
+/// <summary>
+/// Creates <see cref="IAnsiConsole"/> instances that route output through
+/// <see cref="ReplSessionIO.Output"/> for per-session isolation.
+/// </summary>
+internal static class SessionAnsiConsole
+{
+	/// <summary>
+	/// Creates a new <see cref="IAnsiConsole"/> bound to the current session I/O.
+	/// </summary>
+	public static IAnsiConsole Create()
+	{
+		var settings = new AnsiConsoleSettings
+		{
+			Ansi = AnsiSupport.Yes,
+			ColorSystem = ColorSystemSupport.TrueColor,
+			Out = new SessionAnsiConsoleOutput(),
+		};
+
+		return AnsiConsole.Create(settings);
+	}
+
+	/// <summary>
+	/// Creates an <see cref="IAnsiConsole"/> that renders to the provided <see cref="TextWriter"/>.
+	/// Used by the output transformer to capture rendered output as a string.
+	/// </summary>
+	public static IAnsiConsole CreateForWriter(TextWriter writer, int width)
+	{
+		var settings = new AnsiConsoleSettings
+		{
+			Ansi = AnsiSupport.Yes,
+			ColorSystem = ColorSystemSupport.TrueColor,
+			Out = new WriterAnsiConsoleOutput(writer, width),
+		};
+
+		return AnsiConsole.Create(settings);
+	}
+
+	private sealed class SessionAnsiConsoleOutput : IAnsiConsoleOutput
+	{
+		public TextWriter Writer { get; } = new SessionDelegatingTextWriter();
+
+		public bool IsTerminal => !ReplSessionIO.IsHostedSession && !Console.IsOutputRedirected;
+
+		public int Width => ResolveWidth();
+
+		public int Height => ResolveHeight();
+
+		public void SetEncoding(Encoding encoding)
+		{
+			// Encoding is managed by the session writer.
+		}
+
+		private static int ResolveWidth()
+		{
+			if (ReplSessionIO.WindowSize is { } size)
+			{
+				return size.Width;
+			}
+
+			try
+			{
+				return Console.WindowWidth;
+			}
+			catch
+			{
+				return 120;
+			}
+		}
+
+		private static int ResolveHeight()
+		{
+			if (ReplSessionIO.WindowSize is { } size)
+			{
+				return size.Height;
+			}
+
+			try
+			{
+				return Console.WindowHeight;
+			}
+			catch
+			{
+				return 24;
+			}
+		}
+	}
+
+	private sealed class WriterAnsiConsoleOutput(TextWriter writer, int width) : IAnsiConsoleOutput
+	{
+		public TextWriter Writer => writer;
+
+		public bool IsTerminal => false;
+
+		public int Width => width;
+
+		public int Height => 24;
+
+		public void SetEncoding(Encoding encoding)
+		{
+		}
+	}
+
+	/// <summary>
+	/// TextWriter that delegates all writes to <see cref="ReplSessionIO.Output"/>
+	/// at call time, ensuring session-correct routing even if captured early.
+	/// </summary>
+	private sealed class SessionDelegatingTextWriter : TextWriter
+	{
+		public override Encoding Encoding => ReplSessionIO.Output.Encoding;
+
+		public override void Write(char value) => ReplSessionIO.Output.Write(value);
+
+		public override void Write(string? value) => ReplSessionIO.Output.Write(value);
+
+		public override void Write(char[] buffer, int index, int count) =>
+			ReplSessionIO.Output.Write(buffer, index, count);
+
+		public override void WriteLine() => ReplSessionIO.Output.WriteLine();
+
+		public override void WriteLine(string? value) => ReplSessionIO.Output.WriteLine(value);
+
+		public override void Flush() => ReplSessionIO.Output.Flush();
+
+		public override Task WriteAsync(char value) => ReplSessionIO.Output.WriteAsync(value);
+
+		public override Task WriteAsync(string? value) => ReplSessionIO.Output.WriteAsync(value);
+
+		public override Task WriteLineAsync() => ReplSessionIO.Output.WriteLineAsync();
+
+		public override Task WriteLineAsync(string? value) => ReplSessionIO.Output.WriteLineAsync(value);
+
+		public override Task FlushAsync() => ReplSessionIO.Output.FlushAsync();
+	}
+}

--- a/src/Repl.Spectre/SessionAnsiConsole.cs
+++ b/src/Repl.Spectre/SessionAnsiConsole.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text;
 
 namespace Repl.Spectre;
@@ -77,7 +78,7 @@ internal static class SessionAnsiConsole
 			{
 				return Console.WindowWidth;
 			}
-			catch
+			catch (Exception ex) when (ex is IOException or PlatformNotSupportedException or InvalidOperationException)
 			{
 				return 120;
 			}
@@ -94,7 +95,7 @@ internal static class SessionAnsiConsole
 			{
 				return Console.WindowHeight;
 			}
-			catch
+			catch (Exception ex) when (ex is IOException or PlatformNotSupportedException or InvalidOperationException)
 			{
 				return 24;
 			}

--- a/src/Repl.Spectre/SessionAnsiConsole.cs
+++ b/src/Repl.Spectre/SessionAnsiConsole.cs
@@ -13,6 +13,13 @@ internal static class SessionAnsiConsole
 	/// Gets or sets the console options shared by all factory methods.
 	/// Set by <see cref="SpectreReplExtensions.UseSpectreConsole"/> during app configuration.
 	/// </summary>
+	/// <remarks>
+	/// This is process-wide shared state. When multiple <see cref="ReplApp"/> instances
+	/// coexist in the same process with different Spectre configurations, the last
+	/// <see cref="SpectreReplExtensions.UseSpectreConsole"/> call wins. If per-app
+	/// isolation is needed, this should be refactored to flow through the service
+	/// container or <see cref="ReplSessionIO"/> instead.
+	/// </remarks>
 	internal static SpectreConsoleOptions Options { get; set; } = new();
 
 	/// <summary>

--- a/src/Repl.Spectre/SessionAnsiConsole.cs
+++ b/src/Repl.Spectre/SessionAnsiConsole.cs
@@ -9,6 +9,12 @@ namespace Repl.Spectre;
 internal static class SessionAnsiConsole
 {
 	/// <summary>
+	/// Gets or sets the console options shared by all factory methods.
+	/// Set by <see cref="SpectreReplExtensions.UseSpectreConsole"/> during app configuration.
+	/// </summary>
+	internal static SpectreConsoleOptions Options { get; set; } = new();
+
+	/// <summary>
 	/// Creates a new <see cref="IAnsiConsole"/> bound to the current session I/O.
 	/// </summary>
 	public static IAnsiConsole Create()
@@ -20,7 +26,7 @@ internal static class SessionAnsiConsole
 			Out = new SessionAnsiConsoleOutput(),
 		};
 
-		return AnsiConsole.Create(settings);
+		return ApplyOptions(AnsiConsole.Create(settings));
 	}
 
 	/// <summary>
@@ -36,7 +42,13 @@ internal static class SessionAnsiConsole
 			Out = new WriterAnsiConsoleOutput(writer, width),
 		};
 
-		return AnsiConsole.Create(settings);
+		return ApplyOptions(AnsiConsole.Create(settings));
+	}
+
+	private static IAnsiConsole ApplyOptions(IAnsiConsole console)
+	{
+		console.Profile.Capabilities.Unicode = Options.Unicode;
+		return console;
 	}
 
 	private sealed class SessionAnsiConsoleOutput : IAnsiConsoleOutput

--- a/src/Repl.Spectre/SpectreConsoleOptions.cs
+++ b/src/Repl.Spectre/SpectreConsoleOptions.cs
@@ -1,0 +1,14 @@
+namespace Repl.Spectre;
+
+/// <summary>
+/// Configuration options for the Spectre.Console integration.
+/// </summary>
+public sealed class SpectreConsoleOptions
+{
+	/// <summary>
+	/// Gets or sets a value indicating whether Unicode box-drawing characters
+	/// and symbols are used. When <c>false</c>, Spectre falls back to ASCII.
+	/// Default is <c>true</c>.
+	/// </summary>
+	public bool Unicode { get; set; } = true;
+}

--- a/src/Repl.Spectre/SpectreHumanOutputTransformer.cs
+++ b/src/Repl.Spectre/SpectreHumanOutputTransformer.cs
@@ -228,7 +228,7 @@ internal sealed class SpectreHumanOutputTransformer : IOutputTransformer
 
 	private static string RenderToString(IRenderable renderable)
 	{
-		var writer = new StringWriter();
+		using var writer = new StringWriter();
 
 		var width = 120;
 		if (ReplSessionIO.WindowSize is { } size && size.Width > 0)
@@ -245,7 +245,7 @@ internal sealed class SpectreHumanOutputTransformer : IOutputTransformer
 					width = consoleWidth;
 				}
 			}
-			catch
+			catch (Exception ex) when (ex is IOException or PlatformNotSupportedException or InvalidOperationException)
 			{
 				// Width may be unavailable in redirected output.
 			}

--- a/src/Repl.Spectre/SpectreHumanOutputTransformer.cs
+++ b/src/Repl.Spectre/SpectreHumanOutputTransformer.cs
@@ -1,0 +1,304 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+
+namespace Repl.Spectre;
+
+/// <summary>
+/// Output transformer that renders values using Spectre.Console renderables
+/// (bordered tables, panels, grids) for rich terminal output.
+/// </summary>
+internal sealed class SpectreHumanOutputTransformer : IOutputTransformer
+{
+	/// <inheritdoc />
+	public string Name => "spectre";
+
+	/// <inheritdoc />
+	public ValueTask<string> TransformAsync(object? value, CancellationToken cancellationToken = default)
+	{
+		cancellationToken.ThrowIfCancellationRequested();
+
+		if (value is null)
+		{
+			return ValueTask.FromResult(string.Empty);
+		}
+
+		if (value is IReplResult replResult)
+		{
+			return ValueTask.FromResult(RenderReplResult(replResult));
+		}
+
+		if (value is string text)
+		{
+			return ValueTask.FromResult(text);
+		}
+
+		if (value is System.Collections.IEnumerable enumerable)
+		{
+			return ValueTask.FromResult(RenderEnumerable(enumerable));
+		}
+
+		if (TryRenderObject(value, out var objectText))
+		{
+			return ValueTask.FromResult(objectText);
+		}
+
+		return ValueTask.FromResult(
+			Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty);
+	}
+
+	private static string RenderReplResult(IReplResult result)
+	{
+		var prefix = result.Kind.ToLowerInvariant() switch
+		{
+			"text" => string.Empty,
+			"success" => "[green]Success[/]",
+			"error" => "[red]Error[/]",
+			"validation" => "[yellow]Validation[/]",
+			"not_found" => "[yellow]Not found[/]",
+			"cancelled" => "[grey]Cancelled[/]",
+			_ => "[blue]Result[/]",
+		};
+
+		var message = string.IsNullOrWhiteSpace(prefix)
+			? Markup.Escape(result.Message)
+			: $"{prefix}: {Markup.Escape(result.Message)}";
+
+		if (result.Details is null)
+		{
+			return RenderToString(new Markup(message));
+		}
+
+		var detailText = RenderValue(result.Details);
+		if (string.IsNullOrWhiteSpace(detailText))
+		{
+			return RenderToString(new Markup(message));
+		}
+
+		return RenderToString(new Markup(message)) + Environment.NewLine + detailText;
+	}
+
+	private static string RenderEnumerable(System.Collections.IEnumerable enumerable)
+	{
+		var items = enumerable.Cast<object?>().ToArray();
+		if (items.Length == 0)
+		{
+			return "No results.";
+		}
+
+		var firstNonNull = items.FirstOrDefault(item => item is not null);
+		if (firstNonNull is null)
+		{
+			return "No results.";
+		}
+
+		if (IsSimpleValue(firstNonNull.GetType()))
+		{
+			return string.Join(
+				Environment.NewLine,
+				items.Select(item =>
+					Convert.ToString(item, CultureInfo.InvariantCulture) ?? string.Empty));
+		}
+
+		var members = GetDisplayMembers(firstNonNull.GetType());
+		if (members.Length == 0)
+		{
+			return string.Join(
+				Environment.NewLine,
+				items.Select(item =>
+					Convert.ToString(item, CultureInfo.InvariantCulture) ?? string.Empty));
+		}
+
+		return RenderTable(items, members);
+	}
+
+	private static string RenderTable(object?[] items, DisplayMember[] members)
+	{
+		var table = new Table()
+			.Border(TableBorder.Rounded)
+			.BorderColor(Color.Grey);
+
+		foreach (var member in members)
+		{
+			table.AddColumn(new TableColumn(Markup.Escape(member.Label))
+				.NoWrap());
+		}
+
+		foreach (var item in items)
+		{
+			if (item is null)
+			{
+				table.AddRow(members.Select(_ => new Markup(string.Empty)).ToArray());
+				continue;
+			}
+
+			var cells = new IRenderable[members.Length];
+			for (var i = 0; i < members.Length; i++)
+			{
+				var memberValue = members[i].Property.GetValue(item);
+				var text = RenderScalar(memberValue, members[i]);
+				cells[i] = new Markup(Markup.Escape(text));
+			}
+
+			table.AddRow(cells);
+		}
+
+		return RenderToString(table);
+	}
+
+	private static bool TryRenderObject(object value, out string text)
+	{
+		var members = GetDisplayMembers(value.GetType());
+		if (members.Length == 0)
+		{
+			text = string.Empty;
+			return false;
+		}
+
+		var grid = new Grid();
+		grid.AddColumn(new GridColumn().NoWrap().PadRight(2));
+		grid.AddColumn(new GridColumn());
+
+		foreach (var member in members)
+		{
+			var memberValue = member.Property.GetValue(value);
+			if (memberValue is System.Collections.IEnumerable collectionValue
+				&& memberValue is not string)
+			{
+				var rendered = RenderEnumerable(collectionValue);
+				grid.AddRow(
+					new Markup($"[bold]{Markup.Escape(member.Label)}[/]:"),
+					new Markup(Markup.Escape(rendered)));
+			}
+			else
+			{
+				var rendered = RenderScalar(memberValue, member);
+				grid.AddRow(
+					new Markup($"[bold]{Markup.Escape(member.Label)}[/]:"),
+					new Markup(Markup.Escape(rendered)));
+			}
+		}
+
+		text = RenderToString(grid);
+		return true;
+	}
+
+	private static string RenderScalar(object? value, DisplayMember? member)
+	{
+		if (value is null)
+		{
+			return member?.NullDisplayText ?? string.Empty;
+		}
+
+		if (value is string text)
+		{
+			return text;
+		}
+
+		return Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+	}
+
+	private static string RenderValue(object? value)
+	{
+		if (value is null)
+		{
+			return string.Empty;
+		}
+
+		if (value is string text)
+		{
+			return text;
+		}
+
+		if (value is System.Collections.IEnumerable enumerable)
+		{
+			return RenderEnumerable(enumerable);
+		}
+
+		if (TryRenderObject(value, out var objectText))
+		{
+			return objectText;
+		}
+
+		return Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+	}
+
+	private static string RenderToString(IRenderable renderable)
+	{
+		var writer = new StringWriter();
+
+		var width = 120;
+		if (ReplSessionIO.WindowSize is { } size && size.Width > 0)
+		{
+			width = size.Width;
+		}
+		else
+		{
+			try
+			{
+				var consoleWidth = Console.WindowWidth;
+				if (consoleWidth > 0)
+				{
+					width = consoleWidth;
+				}
+			}
+			catch
+			{
+				// Width may be unavailable in redirected output.
+			}
+		}
+
+		var console = SessionAnsiConsole.CreateForWriter(writer, width);
+		console.Write(renderable);
+		return writer.ToString().TrimEnd();
+	}
+
+	private static bool IsSimpleValue(Type type) =>
+		type.IsPrimitive
+		|| type.IsEnum
+		|| type == typeof(string)
+		|| type == typeof(decimal)
+		|| type == typeof(Guid)
+		|| type == typeof(DateTime)
+		|| type == typeof(DateTimeOffset)
+		|| type == typeof(TimeSpan);
+
+	[UnconditionalSuppressMessage(
+		"Trimming",
+		"IL2070",
+		Justification = "Output rendering relies on runtime reflection over return models.")]
+	private static DisplayMember[] GetDisplayMembers(Type type) =>
+		type
+			.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+			.Where(property => property.GetMethod is not null && property.GetIndexParameters().Length == 0)
+			.Select(property =>
+			{
+				var browsable = property.GetCustomAttribute<BrowsableAttribute>();
+				if (browsable is not null && !browsable.Browsable)
+				{
+					return null;
+				}
+
+				var display = property.GetCustomAttribute<DisplayAttribute>();
+				var displayFormat = property.GetCustomAttribute<DisplayFormatAttribute>();
+				return new DisplayMember(
+					property,
+					string.IsNullOrWhiteSpace(display?.GetName()) ? property.Name : display!.GetName()!,
+					display?.GetOrder(),
+					displayFormat?.NullDisplayText);
+			})
+			.Where(member => member is not null)
+			.Select(member => member!)
+			.OrderBy(member => member.Order ?? int.MaxValue)
+			.ThenBy(member => member.Property.MetadataToken)
+			.ToArray();
+
+	private sealed record DisplayMember(
+		PropertyInfo Property,
+		string Label,
+		int? Order,
+		string? NullDisplayText);
+}

--- a/src/Repl.Spectre/SpectreInteractionHandler.cs
+++ b/src/Repl.Spectre/SpectreInteractionHandler.cs
@@ -143,7 +143,7 @@ public sealed class SpectreInteractionHandler : IReplInteractionHandler
 		var console = SessionAnsiConsole.Create();
 		var prompt = new TextPrompt<string>(r.Prompt);
 
-		var effectiveMask = r.Options?.Mask ?? '*';
+		var effectiveMask = r.Options is { } options ? options.Mask : '*';
 		prompt.Secret(effectiveMask);
 
 		if (r.Options?.AllowEmpty == true)

--- a/src/Repl.Spectre/SpectreInteractionHandler.cs
+++ b/src/Repl.Spectre/SpectreInteractionHandler.cs
@@ -84,12 +84,9 @@ public sealed class SpectreInteractionHandler : IReplInteractionHandler
 
 		if (r.DefaultIndices is { } defaults)
 		{
-			foreach (var defaultIdx in defaults)
+			foreach (var defaultIdx in defaults.Where(i => i >= 0 && i < choices.Count))
 			{
-				if (defaultIdx >= 0 && defaultIdx < choices.Count)
-				{
-					prompt.Select(choices[defaultIdx]);
-				}
+				prompt.Select(choices[defaultIdx]);
 			}
 		}
 
@@ -172,7 +169,7 @@ public sealed class SpectreInteractionHandler : IReplInteractionHandler
 	/// <summary>
 	/// Strips mnemonic markers from choice labels for Spectre display.
 	/// </summary>
-	private static List<string> StripMnemonics(IReadOnlyList<string> choices)
+	internal static List<string> StripMnemonics(IReadOnlyList<string> choices)
 	{
 		var result = new List<string>(choices.Count);
 		for (var i = 0; i < choices.Count; i++)
@@ -187,8 +184,9 @@ public sealed class SpectreInteractionHandler : IReplInteractionHandler
 	/// <summary>
 	/// Maps a selected display string back to the original choice index
 	/// by stripping mnemonics from original choices and matching.
+	/// Returns <c>-1</c> when the selected value does not match any choice.
 	/// </summary>
-	private static int MapBackToOriginalIndex(string selected, IReadOnlyList<string> originalChoices)
+	internal static int MapBackToOriginalIndex(string selected, IReadOnlyList<string> originalChoices)
 	{
 		for (var i = 0; i < originalChoices.Count; i++)
 		{
@@ -199,6 +197,6 @@ public sealed class SpectreInteractionHandler : IReplInteractionHandler
 			}
 		}
 
-		return 0;
+		return -1;
 	}
 }

--- a/src/Repl.Spectre/SpectreInteractionHandler.cs
+++ b/src/Repl.Spectre/SpectreInteractionHandler.cs
@@ -52,18 +52,20 @@ public sealed class SpectreInteractionHandler : IReplInteractionHandler
 	{
 		var console = SessionAnsiConsole.Create();
 		var choices = StripMnemonics(r.Choices);
+
+		// Reorder so the default item appears first (Spectre highlights first item).
+		if (r.DefaultIndex is { } idx && idx > 0 && idx < choices.Count)
+		{
+			(choices[0], choices[idx]) = (choices[idx], choices[0]);
+		}
+
 		var prompt = new SelectionPrompt<string>()
 			.Title(r.Prompt)
 			.AddChoices(choices);
 
-		if (r.DefaultIndex is { } idx && idx >= 0 && idx < choices.Count)
+		if (r.DefaultIndex is >= 0)
 		{
 			prompt.HighlightStyle(new Style(Color.Blue));
-			// Reorder so the default item appears first (Spectre highlights first item).
-			if (idx > 0)
-			{
-				(choices[0], choices[idx]) = (choices[idx], choices[0]);
-			}
 		}
 
 		var selected = await Task.Run(() => console.Prompt(prompt), ct).ConfigureAwait(false);

--- a/src/Repl.Spectre/SpectreInteractionHandler.cs
+++ b/src/Repl.Spectre/SpectreInteractionHandler.cs
@@ -1,0 +1,204 @@
+namespace Repl.Spectre;
+
+/// <summary>
+/// Handles interaction requests using Spectre.Console rich prompts.
+/// Returns <see cref="InteractionResult.Unhandled"/> when the terminal
+/// does not support interactive Spectre prompts (hosted sessions, redirected input).
+/// </summary>
+public sealed class SpectreInteractionHandler : IReplInteractionHandler
+{
+	/// <inheritdoc />
+	public ValueTask<InteractionResult> TryHandleAsync(
+		InteractionRequest request, CancellationToken cancellationToken)
+	{
+		if (!CanHandle())
+		{
+			return new ValueTask<InteractionResult>(InteractionResult.Unhandled);
+		}
+
+		return request switch
+		{
+			AskChoiceRequest r => HandleChoiceAsync(r, cancellationToken),
+			AskMultiChoiceRequest r => HandleMultiChoiceAsync(r, cancellationToken),
+			AskConfirmationRequest r => HandleConfirmationAsync(r, cancellationToken),
+			AskTextRequest r => HandleTextAsync(r, cancellationToken),
+			AskSecretRequest r => HandleSecretAsync(r, cancellationToken),
+			ClearScreenRequest => HandleClearScreenAsync(),
+			_ => new ValueTask<InteractionResult>(InteractionResult.Unhandled),
+		};
+	}
+
+	/// <summary>
+	/// Returns <c>true</c> when Spectre prompts can operate:
+	/// non-hosted session and non-redirected input.
+	/// </summary>
+	private static bool CanHandle()
+	{
+		if (ReplSessionIO.IsHostedSession)
+		{
+			return false;
+		}
+
+		if (Console.IsInputRedirected)
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	private static async ValueTask<InteractionResult> HandleChoiceAsync(
+		AskChoiceRequest r, CancellationToken ct)
+	{
+		var console = SessionAnsiConsole.Create();
+		var choices = StripMnemonics(r.Choices);
+		var prompt = new SelectionPrompt<string>()
+			.Title(r.Prompt)
+			.AddChoices(choices);
+
+		if (r.DefaultIndex is { } idx && idx >= 0 && idx < choices.Count)
+		{
+			prompt.HighlightStyle(new Style(Color.Blue));
+			// Reorder so the default item appears first (Spectre highlights first item).
+			if (idx > 0)
+			{
+				(choices[0], choices[idx]) = (choices[idx], choices[0]);
+			}
+		}
+
+		var selected = await Task.Run(() => console.Prompt(prompt), ct).ConfigureAwait(false);
+
+		// Map back to original index (account for potential reorder).
+		var selectedIndex = MapBackToOriginalIndex(selected, r.Choices);
+		return InteractionResult.Success(selectedIndex);
+	}
+
+	private static async ValueTask<InteractionResult> HandleMultiChoiceAsync(
+		AskMultiChoiceRequest r, CancellationToken ct)
+	{
+		var console = SessionAnsiConsole.Create();
+		var choices = StripMnemonics(r.Choices);
+		var prompt = new MultiSelectionPrompt<string>()
+			.Title(r.Prompt)
+			.AddChoices(choices);
+
+		if (r.DefaultIndices is { } defaults)
+		{
+			foreach (var defaultIdx in defaults)
+			{
+				if (defaultIdx >= 0 && defaultIdx < choices.Count)
+				{
+					prompt.Select(choices[defaultIdx]);
+				}
+			}
+		}
+
+		if (r.Options?.MinSelections is > 0)
+		{
+			prompt.Required();
+		}
+
+		var selected = await Task.Run(() => console.Prompt(prompt), ct).ConfigureAwait(false);
+
+		var indices = selected
+			.Select(s => MapBackToOriginalIndex(s, r.Choices))
+			.Where(i => i >= 0)
+			.Order()
+			.ToArray();
+
+		return InteractionResult.Success((IReadOnlyList<int>)indices);
+	}
+
+	private static async ValueTask<InteractionResult> HandleConfirmationAsync(
+		AskConfirmationRequest r, CancellationToken ct)
+	{
+		var console = SessionAnsiConsole.Create();
+		var prompt = new ConfirmationPrompt(r.Prompt)
+		{
+			DefaultValue = r.DefaultValue,
+		};
+
+		var result = await Task.Run(() => console.Prompt(prompt), ct).ConfigureAwait(false);
+		return InteractionResult.Success(result);
+	}
+
+	private static async ValueTask<InteractionResult> HandleTextAsync(
+		AskTextRequest r, CancellationToken ct)
+	{
+		var console = SessionAnsiConsole.Create();
+		var prompt = new TextPrompt<string>(r.Prompt)
+			.AllowEmpty();
+
+		if (!string.IsNullOrEmpty(r.DefaultValue))
+		{
+			prompt.DefaultValue(r.DefaultValue);
+		}
+
+		var result = await Task.Run(() => console.Prompt(prompt), ct).ConfigureAwait(false);
+		return InteractionResult.Success(result);
+	}
+
+	private static async ValueTask<InteractionResult> HandleSecretAsync(
+		AskSecretRequest r, CancellationToken ct)
+	{
+		var console = SessionAnsiConsole.Create();
+		var prompt = new TextPrompt<string>(r.Prompt);
+
+		if (r.Options?.Mask is { } mask)
+		{
+			prompt.Secret(mask);
+		}
+		else
+		{
+			prompt.Secret(mask: null);
+		}
+
+		if (r.Options?.AllowEmpty == true)
+		{
+			prompt.AllowEmpty();
+		}
+
+		var result = await Task.Run(() => console.Prompt(prompt), ct).ConfigureAwait(false);
+		return InteractionResult.Success(result);
+	}
+
+	private static ValueTask<InteractionResult> HandleClearScreenAsync()
+	{
+		var console = SessionAnsiConsole.Create();
+		console.Clear();
+		return new ValueTask<InteractionResult>(InteractionResult.Success(value: true));
+	}
+
+	/// <summary>
+	/// Strips mnemonic markers from choice labels for Spectre display.
+	/// </summary>
+	private static List<string> StripMnemonics(IReadOnlyList<string> choices)
+	{
+		var result = new List<string>(choices.Count);
+		for (var i = 0; i < choices.Count; i++)
+		{
+			var (display, _) = MnemonicParser.Parse(choices[i]);
+			result.Add(display);
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// Maps a selected display string back to the original choice index
+	/// by stripping mnemonics from original choices and matching.
+	/// </summary>
+	private static int MapBackToOriginalIndex(string selected, IReadOnlyList<string> originalChoices)
+	{
+		for (var i = 0; i < originalChoices.Count; i++)
+		{
+			var (display, _) = MnemonicParser.Parse(originalChoices[i]);
+			if (string.Equals(display, selected, StringComparison.Ordinal))
+			{
+				return i;
+			}
+		}
+
+		return 0;
+	}
+}

--- a/src/Repl.Spectre/SpectreInteractionHandler.cs
+++ b/src/Repl.Spectre/SpectreInteractionHandler.cs
@@ -143,14 +143,8 @@ public sealed class SpectreInteractionHandler : IReplInteractionHandler
 		var console = SessionAnsiConsole.Create();
 		var prompt = new TextPrompt<string>(r.Prompt);
 
-		if (r.Options?.Mask is { } mask)
-		{
-			prompt.Secret(mask);
-		}
-		else
-		{
-			prompt.Secret(mask: null);
-		}
+		var effectiveMask = r.Options?.Mask ?? '*';
+		prompt.Secret(effectiveMask);
 
 		if (r.Options?.AllowEmpty == true)
 		{

--- a/src/Repl.Spectre/SpectreReplExtensions.cs
+++ b/src/Repl.Spectre/SpectreReplExtensions.cs
@@ -37,6 +37,7 @@ public static class SpectreReplExtensions
 		{
 			options.Output.AddTransformer("spectre", new SpectreHumanOutputTransformer());
 			options.Output.DefaultFormat = "spectre";
+			options.Output.BannerFormats.Add("spectre");
 		});
 
 		return app;

--- a/src/Repl.Spectre/SpectreReplExtensions.cs
+++ b/src/Repl.Spectre/SpectreReplExtensions.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Repl.Spectre;
+
+/// <summary>
+/// Extension methods to enable Spectre.Console integration in a Repl application.
+/// </summary>
+public static class SpectreReplExtensions
+{
+	/// <summary>
+	/// Registers Spectre.Console services: <see cref="SpectreInteractionHandler"/>
+	/// for rich prompts and <see cref="IAnsiConsole"/> for direct injection into commands.
+	/// </summary>
+	/// <param name="services">Target service collection.</param>
+	/// <returns>The same service collection for chaining.</returns>
+	public static IServiceCollection AddSpectreConsole(this IServiceCollection services)
+	{
+		ArgumentNullException.ThrowIfNull(services);
+		services.AddSingleton<IReplInteractionHandler, SpectreInteractionHandler>();
+		services.TryAddTransient<IAnsiConsole>(_ => SessionAnsiConsole.Create());
+		return services;
+	}
+
+	/// <summary>
+	/// Enables Spectre.Console output rendering by registering the "spectre" output
+	/// transformer and setting it as the default format. Also registers the
+	/// <see cref="SpectreInteractionHandler"/> and <see cref="IAnsiConsole"/> DI service.
+	/// </summary>
+	/// <param name="app">Target REPL application.</param>
+	/// <returns>The same app instance for chaining.</returns>
+	public static ReplApp UseSpectreConsole(this ReplApp app)
+	{
+		ArgumentNullException.ThrowIfNull(app);
+
+		app.Options(options =>
+		{
+			options.Output.AddTransformer("spectre", new SpectreHumanOutputTransformer());
+			options.Output.DefaultFormat = "spectre";
+		});
+
+		return app;
+	}
+}

--- a/src/Repl.Spectre/SpectreReplExtensions.cs
+++ b/src/Repl.Spectre/SpectreReplExtensions.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -28,16 +29,26 @@ public static class SpectreReplExtensions
 	/// <see cref="SpectreInteractionHandler"/> and <see cref="IAnsiConsole"/> DI service.
 	/// </summary>
 	/// <param name="app">Target REPL application.</param>
+	/// <param name="configure">Optional callback to configure Spectre console options.</param>
 	/// <returns>The same app instance for chaining.</returns>
-	public static ReplApp UseSpectreConsole(this ReplApp app)
+	public static ReplApp UseSpectreConsole(this ReplApp app, Action<SpectreConsoleOptions>? configure = null)
 	{
 		ArgumentNullException.ThrowIfNull(app);
 
-		app.Options(options =>
+		var spectreOptions = new SpectreConsoleOptions();
+		configure?.Invoke(spectreOptions);
+		SessionAnsiConsole.Options = spectreOptions;
+
+		if (spectreOptions.Unicode && !Console.IsOutputRedirected)
 		{
-			options.Output.AddTransformer("spectre", new SpectreHumanOutputTransformer());
-			options.Output.DefaultFormat = "spectre";
-			options.Output.BannerFormats.Add("spectre");
+			Console.OutputEncoding = Encoding.UTF8;
+		}
+
+		app.Options(o =>
+		{
+			o.Output.AddTransformer("spectre", new SpectreHumanOutputTransformer());
+			o.Output.DefaultFormat = "spectre";
+			o.Output.BannerFormats.Add("spectre");
 		});
 
 		return app;

--- a/src/Repl.SpectreTests/Given_SpectreInteractionHandler.cs
+++ b/src/Repl.SpectreTests/Given_SpectreInteractionHandler.cs
@@ -1,0 +1,75 @@
+namespace Repl.SpectreTests;
+
+[TestClass]
+public sealed class Given_SpectreInteractionHandler
+{
+	[TestMethod]
+	[Description("MapBackToOriginalIndex should return the correct index when a match is found.")]
+	public void When_MapBackToOriginalIndex_WithMatch_Then_ReturnsCorrectIndex()
+	{
+		var choices = new[] { "_Abort", "_Retry", "_Fail" };
+
+		var index = SpectreInteractionHandler.MapBackToOriginalIndex("Retry", choices);
+
+		index.Should().Be(1);
+	}
+
+	[TestMethod]
+	[Description("MapBackToOriginalIndex should return the first match index for the first choice.")]
+	public void When_MapBackToOriginalIndex_WithFirstChoice_Then_ReturnsZero()
+	{
+		var choices = new[] { "_Abort", "_Retry", "_Fail" };
+
+		var index = SpectreInteractionHandler.MapBackToOriginalIndex("Abort", choices);
+
+		index.Should().Be(0);
+	}
+
+	[TestMethod]
+	[Description("BUG: MapBackToOriginalIndex must return -1 (not 0) when no match is found, so the caller's Where(i => i >= 0) filter can exclude it.")]
+	public void When_MapBackToOriginalIndex_WithNoMatch_Then_ReturnsNegativeOne()
+	{
+		var choices = new[] { "_Abort", "_Retry", "_Fail" };
+
+		var index = SpectreInteractionHandler.MapBackToOriginalIndex("Unknown", choices);
+
+		index.Should().Be(-1);
+	}
+
+	[TestMethod]
+	[Description("MapBackToOriginalIndex should return -1 when the choices list is empty.")]
+	public void When_MapBackToOriginalIndex_WithEmptyChoices_Then_ReturnsNegativeOne()
+	{
+		var choices = Array.Empty<string>();
+
+		var index = SpectreInteractionHandler.MapBackToOriginalIndex("Anything", choices);
+
+		index.Should().Be(-1);
+	}
+
+	[TestMethod]
+	[Description("StripMnemonics should remove mnemonic underscores from choice labels.")]
+	public void When_StripMnemonics_Then_MnemonicMarkersAreRemoved()
+	{
+		var choices = new[] { "_Abort", "_Retry", "_Fail" };
+
+		var stripped = SpectreInteractionHandler.StripMnemonics(choices);
+
+		stripped[0].Should().Be("Abort");
+		stripped[1].Should().Be("Retry");
+		stripped[2].Should().Be("Fail");
+	}
+
+	[TestMethod]
+	[Description("StripMnemonics should return labels as-is when no mnemonic markers are present.")]
+	public void When_StripMnemonics_WithNoMnemonics_Then_LabelsUnchanged()
+	{
+		var choices = new[] { "Save", "Cancel", "Quit" };
+
+		var stripped = SpectreInteractionHandler.StripMnemonics(choices);
+
+		stripped[0].Should().Be("Save");
+		stripped[1].Should().Be("Cancel");
+		stripped[2].Should().Be("Quit");
+	}
+}

--- a/src/Repl.SpectreTests/GlobalUsings.cs
+++ b/src/Repl.SpectreTests/GlobalUsings.cs
@@ -1,0 +1,3 @@
+global using AwesomeAssertions;
+global using Microsoft.VisualStudio.TestTools.UnitTesting;
+global using Repl.Spectre;

--- a/src/Repl.SpectreTests/Repl.SpectreTests.csproj
+++ b/src/Repl.SpectreTests/Repl.SpectreTests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="MSTest.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="AwesomeAssertions" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Repl.Spectre\Repl.Spectre.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Repl.Tests/Given_BannerFormats.cs
+++ b/src/Repl.Tests/Given_BannerFormats.cs
@@ -1,0 +1,47 @@
+namespace Repl.Tests;
+
+[TestClass]
+public sealed class Given_BannerFormats
+{
+	[TestMethod]
+	[Description("BannerFormats should contain 'human' by default.")]
+	public void When_Default_Then_ContainsHuman()
+	{
+		var options = new OutputOptions();
+
+		options.BannerFormats.Should().Contain("human");
+	}
+
+	[TestMethod]
+	[Description("BannerFormats should support adding custom format names.")]
+	public void When_CustomFormatAdded_Then_ContainsCustomFormat()
+	{
+		var options = new OutputOptions();
+
+		options.BannerFormats.Add("spectre");
+
+		options.BannerFormats.Should().Contain("spectre");
+		options.BannerFormats.Should().Contain("human");
+	}
+
+	[TestMethod]
+	[Description("BannerFormats should be case-insensitive.")]
+	public void When_CheckingCaseInsensitive_Then_Matches()
+	{
+		var options = new OutputOptions();
+
+		options.BannerFormats.Should().Contain("HUMAN");
+		options.BannerFormats.Should().Contain("Human");
+	}
+
+	[TestMethod]
+	[Description("Removing 'human' from BannerFormats should exclude it.")]
+	public void When_HumanRemoved_Then_NoLongerContainsHuman()
+	{
+		var options = new OutputOptions();
+
+		options.BannerFormats.Remove("human");
+
+		options.BannerFormats.Should().NotContain("human");
+	}
+}

--- a/src/Repl.slnx
+++ b/src/Repl.slnx
@@ -11,6 +11,7 @@
 	<Project Path="Repl.Tests/Repl.Tests.csproj" />
 	<Project Path="Repl.IntegrationTests/Repl.IntegrationTests.csproj" />
 	<Project Path="Repl.ProtocolTests/Repl.ProtocolTests.csproj" />
+	<Project Path="Repl.SpectreTests/Repl.SpectreTests.csproj" />
 	<Folder Name="/Samples/">
 		<Project Path="../samples/01-core-basics/CoreBasicsSample.csproj" />
 		<Project Path="../samples/02-scoped-contacts/ScopedContactsSample.csproj" />

--- a/src/Repl.slnx
+++ b/src/Repl.slnx
@@ -18,5 +18,6 @@
 		<Project Path="../samples/04-interactive-ops/InteractiveOpsSample.csproj" />
 		<Project Path="../samples/05-hosting-remote/HostingRemoteSample.csproj" />
 		<Project Path="../samples/06-testing/TestingSample.csproj" />
+		<Project Path="../samples/07-spectre/SpectreOpsSample.csproj" />
 	</Folder>
 </Solution>

--- a/src/Repl.slnx
+++ b/src/Repl.slnx
@@ -6,6 +6,7 @@
 	<Project Path="Repl.WebSocket/Repl.WebSocket.csproj" />
 	<Project Path="Repl.Telnet/Repl.Telnet.csproj" />
 	<Project Path="Repl.Testing/Repl.Testing.csproj" />
+	<Project Path="Repl.Spectre/Repl.Spectre.csproj" />
 	<Project Path="Repl.ShellCompletionTestHost/Repl.ShellCompletionTestHost.csproj" />
 	<Project Path="Repl.Tests/Repl.Tests.csproj" />
 	<Project Path="Repl.IntegrationTests/Repl.IntegrationTests.csproj" />


### PR DESCRIPTION
## Summary
- Add `Repl.Spectre` package providing Spectre.Console integration for REPL applications that want rich terminal rendering
- `SpectreHumanOutputTransformer`: renders objects as bordered tables, grids with label-value pairs, and color-coded `IReplResult` messages (green for success, red for error, yellow for validation/not found, etc.)
- `SpectreInteractionHandler`: handles interactive prompts (single/multi selection, confirmation, text input, secret input, clear screen) using Spectre.Console widgets, with automatic fallback to `Unhandled` for hosted sessions or redirected input
- `SessionAnsiConsole`: per-session `IAnsiConsole` isolation routing output through `ReplSessionIO`, supporting both live terminal and string-capture rendering modes
- `SpectreConsoleOptions`: configurable Unicode support for Spectre rendering
- `SpectreReplExtensions.UseSpectreConsole()`: single extension method to register the transformer, interaction handler, and banner format in one call
- `BannerFormats` on `OutputOptions`: extensible set of output format names eligible for banner rendering, replacing the previous hardcoded `"human"` check — allows custom formats like `"spectre"` to display banners
- Mnemonic-aware choice rendering: strips mnemonic markers (`_Abort` → `Abort`) for Spectre display and maps selections back to original indices
- Add sample `07-spectre` demonstrating 21 Spectre.Console features including tables, panels, trees, bar charts, calendars, Figlet text, and interactive prompts
- Fix `MapBackToOriginalIndex` returning 0 instead of -1 on no-match, which silently included the wrong choice in multi-selection results
- Replace generic catch clauses with specific exception types, add `using` on disposable `StringWriter`