### PR TITLE
Add MCP server support — expose Repl apps as AI agent tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,5 +454,29 @@ jobs:
         if: success()
         shell: pwsh
         run: |
-          dotnet nuget push packages/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-          dotnet nuget push packages/*.snupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          $source = 'https://api.nuget.org/v3/index.json'
+          $apiKey = '${{ secrets.NUGET_API_KEY }}'
+          $failed = @()
+
+          foreach ($pkg in Get-ChildItem packages/*.nupkg) {
+            Write-Host "Pushing $($pkg.Name)..."
+            dotnet nuget push $pkg.FullName --api-key $apiKey --source $source --skip-duplicate 2>&1
+            if ($LASTEXITCODE -ne 0) {
+              Write-Warning "Failed to push $($pkg.Name) (exit code $LASTEXITCODE) — continuing with remaining packages."
+              $failed += $pkg.Name
+            }
+          }
+
+          foreach ($pkg in Get-ChildItem packages/*.snupkg -ErrorAction SilentlyContinue) {
+            Write-Host "Pushing $($pkg.Name)..."
+            dotnet nuget push $pkg.FullName --api-key $apiKey --source $source --skip-duplicate 2>&1
+            if ($LASTEXITCODE -ne 0) {
+              Write-Warning "Failed to push $($pkg.Name) (exit code $LASTEXITCODE) — continuing with remaining packages."
+              $failed += $pkg.Name
+            }
+          }
+
+          if ($failed.Count -gt 0) {
+            Write-Warning "The following packages failed to publish: $($failed -join ', ')"
+            Write-Warning "This may be expected for new packages awaiting NuGet validation."
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,9 +453,11 @@ jobs:
       - name: Publish to NuGet
         if: success()
         shell: pwsh
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
           $source = 'https://api.nuget.org/v3/index.json'
-          $apiKey = '${{ secrets.NUGET_API_KEY }}'
+          $apiKey = $env:NUGET_API_KEY
           $failed = @()
 
           foreach ($pkg in Get-ChildItem packages/*.nupkg) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,7 +476,12 @@ jobs:
             }
           }
 
+          $nupkgCount = @(Get-ChildItem packages/*.nupkg).Count
+          $succeeded = $nupkgCount - $failed.Count
           if ($failed.Count -gt 0) {
             Write-Warning "The following packages failed to publish: $($failed -join ', ')"
             Write-Warning "This may be expected for new packages awaiting NuGet validation."
+          }
+          if ($succeeded -eq 0 -and $nupkgCount -gt 0) {
+            throw "All $nupkgCount packages failed to publish. Check API key and NuGet source."
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,7 +477,8 @@ jobs:
           }
 
           $nupkgCount = @(Get-ChildItem packages/*.nupkg).Count
-          $succeeded = $nupkgCount - $failed.Count
+          $failedNupkgCount = @($failed | Where-Object { $_ -like '*.nupkg' }).Count
+          $succeeded = $nupkgCount - $failedNupkgCount
           if ($failed.Count -gt 0) {
             Write-Warning "The following packages failed to publish: $($failed -join ', ')"
             Write-Warning "This may be expected for new packages awaiting NuGet validation."

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 **A .NET framework for building composable command surfaces.**
 Define your commands once — run them as a CLI, explore them in an interactive REPL,
-host them in session-based terminals, or drive them from automation and AI agents.
+host them in session-based terminals, expose them as MCP servers for AI agents,
+or drive them from automation scripts.
 
 > **New here?** The [DeepWiki](https://deepwiki.com/yllibed/repl) has full architecture docs, diagrams, and an AI assistant you can ask questions about the toolkit.
 
@@ -32,6 +33,7 @@ return app.Run(args);
 - **POSIX-like semantics** — familiar flag syntax, `--` separator, predictable parsing
 - **Hierarchical scopes** — stateful navigation with `..`, contexts, route constraints (`{id:int}`, `{when:date}`)
 - **Multiple output formats** — `--json`, `--xml`, `--yaml`, `--markdown`, or `--human`
+- **MCP server** — expose your commands as tools for AI agents with `app.UseMcpServer()` — zero boilerplate
 - **AI/agent-friendly** — machine-readable contracts, deterministic outputs, pre-answered prompts (`--answer:*`)
 - **Typed results** — `Ok`, `Error`, `NotFound`, `Cancelled` with payloads — not raw strings
 - **Typed interactions** — prompts, progress, status, timeouts, cancellation
@@ -84,6 +86,18 @@ ACME
 Globex
 ```
 
+**MCP mode** (same command graph, exposed to AI agents):
+
+```csharp
+app.UseMcpServer();  // add one line
+```
+
+```json
+{ "command": "myapp", "args": ["mcp", "serve"] }
+```
+
+One command graph. CLI, REPL, remote sessions, and AI agents — all from the same code.
+
 ## Packages
 
 | Package | Description |
@@ -94,6 +108,7 @@ Globex
 | [`Repl.Protocol`](https://www.nuget.org/packages/Repl.Protocol) | Machine-readable contracts (help, errors, tool schemas) |
 | [`Repl.WebSocket`](https://www.nuget.org/packages/Repl.WebSocket) | Session hosting over WebSocket |
 | [`Repl.Telnet`](https://www.nuget.org/packages/Repl.Telnet) | Telnet framing, negotiation, session adapters |
+| [`Repl.Mcp`](https://www.nuget.org/packages/Repl.Mcp) | MCP server: expose commands as AI agent tools, resources, and prompts |
 | [`Repl.Spectre`](https://www.nuget.org/packages/Repl.Spectre) | Spectre.Console integration: rich prompts, `IAnsiConsole`, table rendering |
 | [`Repl.Testing`](https://www.nuget.org/packages/Repl.Testing) | In-memory multi-session test harness |
 
@@ -108,6 +123,7 @@ Progressive learning path — start with 01:
 5. **[Hosting Remote](samples/05-hosting-remote/)** — WebSocket / Telnet session hosting
 6. **[Testing](samples/06-testing/)** — multi-session typed assertions
 7. **[Spectre](samples/07-spectre/)** — Spectre.Console renderables, visualizations, rich prompts
+8. **[MCP Server](samples/08-mcp-server/)** — expose commands as MCP tools for AI agents
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Progressive learning path — start with 01:
 | Shell completion | [`docs/shell-completion.md`](docs/shell-completion.md) |
 | Comparison & migration | [`docs/comparison.md`](docs/comparison.md) |
 | Interaction channel | [`docs/interaction.md`](docs/interaction.md) |
+| MCP server (AI agents) | [`docs/mcp-server.md`](docs/mcp-server.md) |
 | Conditional module presence | [`docs/module-presence.md`](docs/module-presence.md) |
 | Publishing & deployment | [`docs/publishing.md`](docs/publishing.md) |
 | Interactive docs & AI Q\&A | [deepwiki.com/yllibed/repl](https://deepwiki.com/yllibed/repl) |

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/yllibed/repl)
 
 **A .NET framework for building composable command surfaces.**
-Define your commands once — run them as a CLI, explore them in an interactive REPL,
-host them in session-based terminals, expose them as MCP servers for AI agents,
-or drive them from automation scripts.
+- Define your commands once — run them as a CLI, explore them in an interactive REPL,
+- host them in session-based terminals, expose them as MCP servers for AI agents,
+- or drive them from automation scripts.
 
 > **New here?** The [DeepWiki](https://deepwiki.com/yllibed/repl) has full architecture docs, diagrams, and an AI assistant you can ask questions about the toolkit.
 

--- a/docs/mcp-advanced.md
+++ b/docs/mcp-advanced.md
@@ -1,0 +1,86 @@
+# MCP Advanced: Custom Transports & HTTP Integration
+
+This guide covers two advanced integration scenarios beyond the default stdio transport.
+
+> **Prerequisite**: read [mcp-server.md](mcp-server.md) first for the basics of exposing a Repl app as an MCP server.
+
+## Scenario A: Stdio-over-anything
+
+The MCP protocol is JSON-RPC over stdin/stdout. The `TransportFactory` option lets you replace the physical transport while keeping the same protocol — useful for WebSocket bridges, named pipes, SSH tunnels, etc.
+
+### How it works
+
+`TransportFactory` receives the server name and an I/O context, and returns an `ITransport`. The MCP server uses this transport instead of `StdioServerTransport`.
+
+```csharp
+app.UseMcpServer(o =>
+{
+    o.TransportFactory = (serverName, io) =>
+    {
+        // Bridge a WebSocket connection to MCP via streams.
+        var (inputStream, outputStream) = CreateWebSocketBridge();
+        return new StreamServerTransport(inputStream, outputStream, serverName);
+    };
+});
+```
+
+The app still launches via `myapp mcp serve` — the framework handles the full MCP lifecycle (tool registration, routing invalidation, shutdown).
+
+### When to use
+
+- You have a non-stdio transport (WebSocket, named pipe, TCP) that carries the standard MCP JSON-RPC protocol
+- You want the framework to manage the server lifecycle
+- Single-session per process is acceptable
+
+## Scenario B: MCP-over-HTTP (Streamable HTTP)
+
+The MCP spec defines a native HTTP transport: POST for client→server messages, GET/SSE for server→client streaming, with session management. This requires an HTTP host (typically ASP.NET Core) rather than a CLI command.
+
+### How it works
+
+`BuildMcpServerOptions()` constructs the full `McpServerOptions` (tools, resources, prompts, capabilities) from your Repl app's command graph — without starting a server. You pass these options to the MCP C# SDK's HTTP integration.
+
+```csharp
+var app = ReplApp.Create();
+app.Map("greet {name}", (string name) => $"Hello, {name}!");
+app.Map("status", () => "all systems go").ReadOnly();
+
+// Build MCP options from the command graph.
+var mcpOptions = app.Core.BuildMcpServerOptions(configure: o =>
+{
+    o.ServerName = "MyApi";
+    o.ResourceUriScheme = "myapi";
+});
+
+// Use with McpServer.Create for a custom HTTP handler...
+var server = McpServer.Create(httpTransport, mcpOptions);
+
+// ...or pass the collections to ASP.NET Core's MapMcp.
+```
+
+### Multi-session
+
+Each HTTP request creates an isolated MCP session. This uses the same mechanism as Repl's hosted sessions:
+
+- `ReplSessionIO.SetSession()` creates an `AsyncLocal` scope per request
+- Each session has its own output writer, input reader, and session ID
+- Tool invocations are fully isolated — concurrent requests don't interfere
+
+This is identical to how the framework handles concurrent tool calls in stdio mode (via `McpToolAdapter.ExecuteThroughPipelineAsync`).
+
+### When to use
+
+- You're building a web API that also exposes MCP endpoints
+- You need multiple concurrent MCP sessions (agents connecting via HTTP)
+- You want to integrate with the ASP.NET Core pipeline (auth, middleware, etc.)
+
+## Configuration reference
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `TransportFactory` | `null` (stdio) | Custom transport factory for Scenario A |
+| `ResourceUriScheme` | `"repl"` | URI scheme for MCP resources (`{scheme}://path`) |
+| `ServerName` | Assembly product name | Server name in MCP `initialize` response |
+| `ServerVersion` | `"1.0.0"` | Server version in MCP `initialize` response |
+
+See [mcp-server.md](mcp-server.md) for the full configuration reference.

--- a/docs/mcp-advanced.md
+++ b/docs/mcp-advanced.md
@@ -24,13 +24,32 @@ app.UseMcpServer(o =>
 });
 ```
 
-The app still launches via `myapp mcp serve` — the framework handles the full MCP lifecycle (tool registration, routing invalidation, shutdown).
+The app still launches via `myapp mcp serve` — the framework handles the full MCP lifecycle (tool registration, routing invalidation, shutdown). This approach gives you **one session per process**.
+
+### Multi-session (accept N connections)
+
+For multiple concurrent sessions over a custom transport (e.g. a WebSocket listener accepting many clients), use `BuildMcpServerOptions` to build the options once, then create a server per connection:
+
+```csharp
+var mcpOptions = app.Core.BuildMcpServerOptions();
+
+// For each incoming WebSocket connection:
+async Task HandleConnectionAsync(Stream input, Stream output, CancellationToken ct)
+{
+    var transport = new StreamServerTransport(input, output, "my-server");
+    var server = McpServer.Create(transport, mcpOptions);
+    await server.RunAsync(ct);
+    await server.DisposeAsync();
+}
+```
+
+Each session is fully isolated — tool invocations run in separate `AsyncLocal` scopes with their own I/O streams, just like hosted sessions.
 
 ### When to use
 
 - You have a non-stdio transport (WebSocket, named pipe, TCP) that carries the standard MCP JSON-RPC protocol
-- You want the framework to manage the server lifecycle
-- Single-session per process is acceptable
+- Single-session: use `TransportFactory` via `mcp serve` (simplest)
+- Multi-session: use `BuildMcpServerOptions` + one `McpServer.Create` per connection
 
 ## Scenario B: MCP-over-HTTP (Streamable HTTP)
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -304,6 +304,10 @@ app.UseMcpServer(o =>
 - **Collection parameters** (`List<T>`, `int[]`): MCP passes JSON arrays as a single element. The CLI binding layer expects repeated values (`--tag vip --tag priority`), so collection parameters are not correctly bound from MCP tool calls yet. Use string parameters with custom parsing as a workaround.
 - **Parameterized resources**: Commands with route parameters (e.g. `config {env}`) marked `.AsResource()` are exposed as MCP resource templates with URI variables (e.g. `repl://config/{env}`). Agents read them via `resources/read` with the concrete URI (e.g. `repl://config/production`) and the parameters are passed to the command handler.
 
+## Advanced: custom transports & HTTP
+
+For custom transports (WebSocket, named pipes, SSH) or HTTP integration (ASP.NET Core Streamable HTTP), see [mcp-advanced.md](mcp-advanced.md).
+
 ## Configuration options
 
 ```csharp

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -313,6 +313,7 @@ app.UseMcpServer(o =>
     o.ServerVersion = "1.0.0";                                  // MCP initialize response
     o.ContextName = "mcp";                                      // myapp {ContextName} serve
     o.ToolNamingSeparator = ToolNamingSeparator.Underscore;     // contact_add
+    o.ResourceUriScheme = "repl";                               // resource URIs: repl://path
     o.InteractivityMode = InteractivityMode.PrefillThenFail;    // interaction degradation
     o.ResourceFallbackToTools = false;                          // opt-in: also expose resources as tools
     o.PromptFallbackToTools = false;                             // opt-in: also expose prompts as tools

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,466 @@
+# MCP Server Integration
+
+Expose your Repl command graph as an [MCP](https://modelcontextprotocol.io) (Model Context Protocol) server so AI agents can discover and invoke your commands as typed tools.
+
+See also: [sample 08-mcp-server](../samples/08-mcp-server/) for a working demo.
+
+## Quick start
+
+```bash
+dotnet add package Repl.Mcp
+```
+
+```csharp
+var app = ReplApp.Create().UseDefaultInteractive();
+app.UseMcpServer();
+
+app.Map("greet {name}", (string name) => $"Hello, {name}!");
+
+return app.Run(args);
+```
+
+```bash
+myapp mcp serve    # starts MCP stdio server
+myapp              # still works as CLI / interactive REPL
+```
+
+One command graph. CLI, REPL, remote sessions, and AI agents — all from the same code.
+
+> **Note:** `UseMcpServer()` registers a hidden `mcp serve` context. The tool list is built lazily when an agent connects, so it sees all commands regardless of registration order.
+
+## How it works
+
+`UseMcpServer()` registers a hidden `mcp serve` command that starts an MCP stdio server. When an agent connects, the server reads the command graph via `CreateDocumentationModel()`, generates typed JSON Schema for each command, and dispatches tool calls through the standard Repl pipeline (routing, binding, middleware, rendering).
+
+Commands map to MCP primitives:
+
+| Repl concept | MCP primitive | How |
+|---|---|---|
+| `Map()` | Tool | Automatic — every non-hidden command becomes a tool |
+| `Map().AsResource()` | Resource | Explicit — marks data-to-consult |
+| `.ReadOnly()` | Resource (auto-promoted) | ReadOnly tools are also exposed as resources |
+| `Map().AsPrompt()` | Prompt | Explicit — handler return becomes prompt template |
+| `options.Prompt()` | Prompt | Explicit — registered in `ReplMcpServerOptions` |
+
+## Annotations
+
+Annotations tell agents how to use your tools safely. They map directly to [MCP tool annotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#annotations):
+
+```csharp
+app.Map("contacts", handler).ReadOnly();                          // safe to call autonomously
+app.Map("contact add", handler).OpenWorld().Idempotent();         // calls external systems, retriable
+app.Map("contact delete {id}", handler).Destructive();            // agent asks for confirmation
+app.Map("deploy", handler).Destructive().LongRunning().OpenWorld();
+app.Map("wizard", handler).AutomationHidden();                    // excluded from MCP entirely
+```
+
+| Annotation | MCP hint | Agent behavior |
+|---|---|---|
+| `.ReadOnly()` | `readOnlyHint: true` | Call autonomously, no confirmation needed |
+| `.Destructive()` | `destructiveHint: true` | Ask user for confirmation before calling |
+| `.Idempotent()` | `idempotentHint: true` | Safe to retry on transient failure |
+| `.OpenWorld()` | `openWorldHint: true` | Expects latency, may fail (external systems) |
+| `.LongRunning()` | _(task support — future)_ | Use task-based execution |
+| `.AutomationHidden()` | _(excluded from list)_ | Not visible to agents at all |
+
+Without annotations, agents must assume worst-case (destructive, non-idempotent), leading to excessive confirmation prompts. **Annotate every command exposed to agents.**
+
+## Rich descriptions
+
+`WithDetails()` provides extended markdown content for agent tool descriptions and documentation export:
+
+```csharp
+app.Map("deploy {env}", handler)
+    .WithDescription("Deploy the application")          // short summary (shown everywhere)
+    .WithDetails("""
+        Deploys to the specified environment.
+
+        Prerequisites:
+        - Valid credentials in ~/.config/deploy
+        - Target environment must be provisioned
+
+        Examples:
+        - deploy staging
+        - deploy production (requires approval)
+        """);
+```
+
+`Description` is the short summary visible in help and tool listings. `Details` is extended content consumed by agents and documentation tools — it is not displayed in terminal `--help`.
+
+## Tool vs Resource vs Prompt
+
+| Aspect | Tool | Resource | Prompt |
+|---|---|---|---|
+| Intent | Perform an action | Consult data | Guide a conversation |
+| MCP primitive | `tools/call` | `resources/read` | `prompts/get` |
+| Invoked by | Model (automatic) | Model or user | User only |
+| Side effects | Yes (unless ReadOnly) | No | No |
+| Repl API | `Map()` | `Map().AsResource()` | `Map().AsPrompt()` or `options.Prompt()` |
+| Auto-promotion | — | ReadOnly → resource | — |
+| Parameters | Any types | Any types | All optional (MCP constraint) |
+
+**When to use each:**
+- **Tool**: operations that change state (`add`, `delete`, `deploy`, `import`)
+- **Resource**: data sources an agent should consult before acting (`contacts`, `config`, `status`)
+- **Prompt**: reusable instruction templates that shape agent behavior (`summarize-data`, `review-changes`, `troubleshoot`)
+
+## JSON Schema generation
+
+Route constraints and handler parameter types produce typed JSON Schema:
+
+| Repl type | JSON Schema | Format |
+|---|---|---|
+| `string` | `string` | — |
+| `int` | `integer` | — |
+| `long` | `integer` | — |
+| `bool` | `boolean` | — |
+| `double`, `decimal` | `number` | — |
+| `enum` | `string` + `enum: [...]` | — |
+| `List<T>` | `array` + `items` | — |
+| `{x:email}` | `string` | `email` |
+| `{x:guid}` | `string` | `uuid` |
+| `{x:date}` | `string` | `date` |
+| `{x:datetime}` | `string` | `date-time` |
+| `{x:uri}` | `string` | `uri` |
+| `{x:time}` | `string` | `time` |
+| `{x:timespan}` | `string` | `duration` |
+
+Route arguments become **required** properties. Options with defaults become **optional** properties. `[Description]` attributes on handler parameters populate the schema `description` field.
+
+## Tool naming
+
+MCP tools are flat (no hierarchy). Context segments are flattened into tool names:
+
+| Route | Tool name |
+|---|---|
+| `greet` | `greet` |
+| `contact add` | `contact_add` |
+| `contact {id} notes` | `contact_notes` (`id` → required property) |
+| `project {pid} task {tid}` | `project_task` (both → required properties) |
+
+Dynamic segments are removed from the name and become input properties. The separator is configurable:
+
+```csharp
+app.UseMcpServer(o => o.ToolNamingSeparator = ToolNamingSeparator.Slash);
+// contact add → contact/add
+```
+
+If two routes produce the same flattened name, startup throws with an actionable error suggesting a different separator.
+
+## Interaction in MCP mode
+
+Commands that use runtime prompts (`AskChoiceAsync`, `AskConfirmationAsync`, etc.) degrade gracefully:
+
+| Tier | Mechanism | When |
+|---|---|---|
+| 1. Prefill | Values from tool arguments (`answer:confirm=yes`) | Always tried first |
+| 2. Elicitation | Structured form request to user through agent client | `PrefillThenElicitation` mode + client supports it |
+| 3. Sampling | LLM answers on behalf of user | `PrefillThenElicitation` or `PrefillThenSampling` + client supports it |
+| 4. Default/Fail | Use default value or fail with descriptive error | Fallback |
+
+`AskSecretAsync` is **always prefill-only** — secrets never go through elicitation or sampling.
+
+```csharp
+app.UseMcpServer(o => o.InteractivityMode = InteractivityMode.PrefillThenElicitation);
+```
+
+| Mode | Behavior |
+|---|---|
+| `PrefillThenFail` (default) | Prefill or fail with descriptive error |
+| `PrefillThenDefaults` | Prefill, then use prompt defaults |
+| `PrefillThenElicitation` | Prefill → elicitation → sampling → fail |
+| `PrefillThenSampling` | Prefill → sampling → fail |
+
+## Progress and status
+
+`WriteProgressAsync` maps to MCP progress notifications — agents see real-time progress. `WriteStatusAsync` maps to MCP log messages (`level: info`). No changes needed in command handlers:
+
+```csharp
+app.Map("import", async (IReplInteractionChannel interaction, CancellationToken ct) =>
+{
+    await interaction.WriteProgressAsync("Importing...", 0, ct);
+    // ... work ...
+    await interaction.WriteProgressAsync("Done", 100, ct);
+    return Results.Success("Imported.");
+});
+```
+
+## Dynamic tool discovery
+
+When `InvalidateRouting()` is called (module presence changes, session state changes), the MCP server automatically refreshes its tool list and emits `list_changed` notifications. Agents that support discovery refresh their available tools.
+
+```csharp
+app.MapModule(new AdminModule(),
+    ctx => ctx.Channel != ReplRuntimeChannel.Programmatic);
+```
+
+## Controlling which commands are exposed
+
+Multiple strategies at different granularities:
+
+| Strategy | Granularity | Example |
+|---|---|---|
+| `.AutomationHidden()` | Per-command | Interactive-only commands |
+| `.Hidden()` | Per-command | Hidden from all surfaces |
+| `CommandFilter` | App-level | `o.CommandFilter = c => !c.Path.StartsWith("admin")` |
+| Module presence + `Programmatic` | Per-module | Entire feature areas |
+
+```csharp
+app.UseMcpServer(o =>
+{
+    o.CommandFilter = cmd => !cmd.Path.StartsWith("debug", StringComparison.OrdinalIgnoreCase);
+});
+```
+
+## Configuration options
+
+```csharp
+app.UseMcpServer(o =>
+{
+    o.ServerName = "MyApp";                                     // MCP initialize response
+    o.ServerVersion = "1.0.0";                                  // MCP initialize response
+    o.ContextName = "mcp";                                      // myapp {ContextName} serve
+    o.ToolNamingSeparator = ToolNamingSeparator.Underscore;     // contact_add
+    o.InteractivityMode = InteractivityMode.PrefillThenFail;    // interaction degradation
+    o.ResourceFallbackToTools = true;                           // expose resources as tools when client doesn't support resources
+    o.CommandFilter = cmd => true;                              // filter which commands become tools
+    o.Prompt("summarize", (string topic) => ...);               // explicit prompt registration
+});
+```
+
+## MCP client compatibility
+
+Feature support varies across agent clients. The table below reflects the state as of **March 2025** — check [mcp-availability.com](https://mcp-availability.com/) for current data.
+
+| Feature | Claude Desktop | Claude Code | VS Code Copilot | Cursor | Continue |
+|---|---|---|---|---|---|
+| Tools | Yes | Yes | Yes | Yes | Yes |
+| Resources | Yes | — | Yes | Yes | — |
+| Prompts | Yes | — | Yes | — | Yes |
+| Discovery (`list_changed`) | — | Yes | — | — | — |
+| Sampling | — | — | Yes | — | — |
+| Elicitation | — | — | Yes | — | — |
+
+**Implications:**
+- `PrefillThenFail` is the safest default (works with all clients)
+- `PrefillThenElicitation` provides the best UX but requires elicitation support, degrading gracefully through sampling then failure
+- Resources should be annotated `.ReadOnly()` as well, so they're always accessible as tools even when the client doesn't support resources
+
+## Agent configuration
+
+### Claude Desktop
+
+**File:** `~/.config/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows)
+
+```json
+{
+  "mcpServers": {
+    "myapp": {
+      "command": "myapp",
+      "args": ["mcp", "serve"],
+      "env": {
+        "MYAPP_API_KEY": "..."
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+**File:** `~/.claude.json` or project `.claude/settings.json`
+
+```json
+{
+  "mcpServers": {
+    "myapp": {
+      "command": "myapp",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+### VS Code (GitHub Copilot)
+
+**File:** `.vscode/mcp.json` (workspace) or `~/.mcp.json` (global)
+
+```json
+{
+  "servers": {
+    "myapp": {
+      "type": "stdio",
+      "command": "myapp",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+### Cursor
+
+**File:** `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global)
+
+```json
+{
+  "mcpServers": {
+    "myapp": {
+      "command": "myapp",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+### Debugging with MCP Inspector
+
+```bash
+npx @modelcontextprotocol/inspector myapp mcp serve
+```
+
+## Publishing as a dotnet tool MCP server
+
+Repl apps can be published as NuGet tools for zero-config agent discovery.
+
+### Project configuration
+
+```xml
+<PropertyGroup>
+  <PackAsTool>true</PackAsTool>
+  <ToolCommandName>myapp</ToolCommandName>
+  <PackageType>McpServer</PackageType>
+</PropertyGroup>
+```
+
+### `.mcp/server.json`
+
+Include this file in the package to enable registry-based discovery:
+
+```json
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "name": "io.github.myorg/myapp",
+  "description": "My application MCP server",
+  "version": "1.0.0",
+  "packages": [
+    {
+      "registryType": "nuget",
+      "registryBaseUrl": "https://api.nuget.org",
+      "identifier": "MyApp",
+      "version": "1.0.0",
+      "transport": { "type": "stdio" },
+      "packageArguments": ["mcp", "serve"],
+      "environmentVariables": []
+    }
+  ]
+}
+```
+
+### Publishing and installation
+
+```bash
+# Publish
+dotnet pack -c Release
+dotnet nuget push bin/Release/MyApp.1.0.0.nupkg --source https://api.nuget.org/v3/index.json
+
+# Install and run
+dotnet tool install -g MyApp
+myapp mcp serve
+```
+
+NuGet.org discovery: `nuget.org/packages?packagetype=mcpserver`
+
+## Full example
+
+```csharp
+var app = ReplApp.Create(services =>
+{
+    services.AddReplMcpServer(mcp =>
+    {
+        mcp.ServerName = "ContactManager";
+        mcp.InteractivityMode = InteractivityMode.PrefillThenElicitation;
+    });
+});
+
+app.UseMcpServer();
+
+// ── Resources ──────────────────────────────────────────────────────
+
+app.Map("contacts", (IContactDb db) => db.GetAll())
+    .WithDescription("List all contacts")
+    .ReadOnly()
+    .AsResource();
+
+// ── Contact operations (grouped context) ───────────────────────────
+
+app.Context("contact", contact =>
+{
+    contact.Map("{id:guid}", (Guid id, IContactDb db) => db.Get(id))
+        .WithDescription("Get contact by ID")
+        .ReadOnly();
+
+    contact.Map("add", (string name, string email, IContactDb db) => db.Add(name, email))
+        .WithDescription("Add a new contact")
+        .WithDetails("""
+            Creates a new contact record.
+            The email must be unique across all contacts.
+            """)
+        .OpenWorld();
+
+    contact.Map("delete {id:guid}",
+        async (Guid id, IContactDb db, IReplInteractionChannel interaction, CancellationToken ct) =>
+        {
+            var contact = db.Get(id);
+            if (!await interaction.AskConfirmationAsync("confirm", $"Delete {contact.Name}?", options: new(ct)))
+                return Results.Cancelled("Aborted.");
+            return db.Delete(id);
+        })
+        .WithDescription("Delete a contact")
+        .Destructive();
+});
+
+// ── Long-running operations ────────────────────────────────────────
+
+app.Map("import", async (string file, IContactDb db, IReplInteractionChannel interaction, CancellationToken ct) =>
+    {
+        await interaction.WriteProgressAsync("Importing...", 0, ct);
+        var count = await db.ImportCsvAsync(file, ct);
+        return Results.Success($"Imported {count} contacts.");
+    })
+    .WithDescription("Import contacts from CSV")
+    .LongRunning()
+    .OpenWorld();
+
+// ── Prompts ────────────────────────────────────────────────────────
+// Prompts are reusable instruction templates that shape how an agent
+// approaches a task. The handler returns the text the agent should
+// use as its starting instructions.
+
+app.Map("troubleshoot {symptom}", (string symptom) =>
+        $"The user reports: '{symptom}'. " +
+        "Investigate using the available contact tools. " +
+        "Check if any contacts are missing or malformed. " +
+        "Summarize your findings and suggest a fix.")
+    .WithDescription("Guide the agent through diagnosing a contact issue")
+    .AsPrompt();
+
+// ── Interactive-only ───────────────────────────────────────────────
+
+app.Map("clear", async (IReplInteractionChannel ch, CancellationToken ct) =>
+    {
+        await ch.ClearScreenAsync(ct);
+        return Results.Ok("Screen cleared.");
+    })
+    .AutomationHidden();
+
+await app.RunAsync(args);
+```
+
+MCP exposure for this example:
+- **Tool** `contacts` + **Resource** `repl://contacts` (explicit `AsResource()`)
+- **Tool** `contact` + **Resource** `repl://contact` (auto-promoted via `ReadOnly`)
+- **Tool** `contact_add` (open world)
+- **Tool** `contact_delete` (destructive, confirmation via elicitation/sampling)
+- **Tool** `import` (long-running, progress notifications)
+- **Prompt** `troubleshoot` — guides the agent through diagnosing an issue using the contact tools
+- `clear` is **not exposed** (`AutomationHidden`)

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -59,11 +59,39 @@ app.Map("wizard", handler).AutomationHidden();                    // excluded fr
 | `.ReadOnly()` | `readOnlyHint: true` | Call autonomously, no confirmation needed |
 | `.Destructive()` | `destructiveHint: true` | Ask user for confirmation before calling |
 | `.Idempotent()` | `idempotentHint: true` | Safe to retry on transient failure |
-| `.OpenWorld()` | `openWorldHint: true` | Expects latency, may fail (external systems) |
-| `.LongRunning()` | _(task support — future)_ | Use task-based execution |
+| `.OpenWorld()` | `openWorldHint: true` | Interacts with external systems (see below) |
+| `.LongRunning()` | `execution.taskSupport: optional` | Enables call-now/poll-later pattern |
 | `.AutomationHidden()` | _(excluded from list)_ | Not visible to agents at all |
 
-Without annotations, agents must assume worst-case (destructive, non-idempotent), leading to excessive confirmation prompts. **Annotate every command exposed to agents.**
+**`OpenWorld`** signals that the tool reaches beyond the MCP server boundary — network calls, third-party APIs, filesystem, cloud resources. Agents use this for:
+- **Latency expectations** — the call may be slow, plan accordingly
+- **Failure handling** — the call may fail for reasons outside the agent's control (network, rate limits)
+- **Security scope** — the action has effects beyond the local app. An agent with strict policies may treat `OpenWorld` + `Destructive` (e.g. deleting a cloud resource) differently from a purely local `Destructive` operation
+
+**`LongRunning`** advertises [MCP task support](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#tool-annotations) — the agent can submit the call, receive a task ID, and poll for results instead of blocking. `WriteProgressAsync` reports real-time progress to the agent during execution. Note: MCP Tasks are experimental in the SDK; not all clients support them yet.
+
+### Why annotations matter
+
+When a tool has **no annotations**, agents must assume the worst case: potentially destructive, non-idempotent, stateful. This means:
+- Every call requires user confirmation
+- No parallel execution
+- No automatic retries
+
+Annotations unlock agent optimizations. Agents use them to decide **confirmation**, **parallelization**, and **retry** behavior:
+
+| Scenario | Annotations | Agent behavior |
+|---|---|---|
+| List contacts | `.ReadOnly()` | No confirmation, can run in parallel with other reads |
+| Add contact | `.OpenWorld().Idempotent()` | May confirm, but safe to retry and parallelize |
+| Delete contact | `.Destructive()` | Always confirms, sequential execution |
+| Deploy | `.Destructive().OpenWorld()` | Confirms, sequential, expects latency |
+| No annotations | _(none)_ | Assumes destructive — confirms everything, no parallelism |
+
+The key combination for parallelization is **`ReadOnly`** or **`Idempotent`** — these tell the agent that concurrent calls won't interfere with each other. `Destructive` tools are always serialized.
+
+See the [MCP specification on tool annotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#annotations) for the full semantics of each hint.
+
+**Annotate every command exposed to agents.** It's the difference between an agent that asks permission for everything and one that works efficiently.
 
 ## Rich descriptions
 
@@ -232,14 +260,14 @@ app.UseMcpServer(o =>
 
 Feature support varies across agent clients. The table below reflects the state as of **March 2025** — check [mcp-availability.com](https://mcp-availability.com/) for current data.
 
-| Feature | Claude Desktop | Claude Code | VS Code Copilot | Cursor | Continue |
-|---|---|---|---|---|---|
-| Tools | Yes | Yes | Yes | Yes | Yes |
-| Resources | Yes | — | Yes | Yes | — |
-| Prompts | Yes | — | Yes | — | Yes |
-| Discovery (`list_changed`) | — | Yes | — | — | — |
-| Sampling | — | — | Yes | — | — |
-| Elicitation | — | — | Yes | — | — |
+| Feature | Claude Desktop | Claude Code | Codex | VS Code Copilot | Cursor | Continue | Overall |
+|---|---|---|---|---|---|---|---|
+| Tools | Yes | Yes | Yes | Yes | Yes | Yes | ~100% |
+| Resources | Yes | — | — | Yes | Yes | — | ~39% |
+| Prompts | Yes | — | — | Yes | — | Yes | ~38% |
+| Discovery (`list_changed`) | — | Yes | — | — | — | — | ~19% |
+| Sampling | — | — | — | Yes | — | — | ~12% |
+| Elicitation | — | — | — | Yes | — | — | ~11% |
 
 **Implications:**
 - `PrefillThenFail` is the safest default (works with all clients)
@@ -257,10 +285,7 @@ Feature support varies across agent clients. The table below reflects the state 
   "mcpServers": {
     "myapp": {
       "command": "myapp",
-      "args": ["mcp", "serve"],
-      "env": {
-        "MYAPP_API_KEY": "..."
-      }
+      "args": ["mcp", "serve"]
     }
   }
 }

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -302,7 +302,7 @@ app.UseMcpServer(o =>
 ## Known limitations
 
 - **Collection parameters** (`List<T>`, `int[]`): MCP passes JSON arrays as a single element. The CLI binding layer expects repeated values (`--tag vip --tag priority`), so collection parameters are not correctly bound from MCP tool calls yet. Use string parameters with custom parsing as a workaround.
-- **Parameterized resources**: Commands with route parameters (e.g. `contact {id}`) marked `.AsResource()` are listed as resources but cannot be invoked via `resources/read` since the URI has no mechanism to pass parameters. Use parameterless commands for resources, or rely on the tool fallback (`ResourceFallbackToTools = true`).
+- **Parameterized resources**: Commands with route parameters (e.g. `config {env}`) marked `.AsResource()` are exposed as MCP resource templates with URI variables (e.g. `repl://config/{env}`). Agents read them via `resources/read` with the concrete URI (e.g. `repl://config/production`) and the parameters are passed to the command handler.
 
 ## Configuration options
 
@@ -548,7 +548,7 @@ await app.RunAsync(args);
 
 MCP exposure for this example:
 - **Tool** `contacts` + **Resource** `repl://contacts` (explicit `AsResource()`)
-- **Tool** `contact` + **Resource** `repl://contact` (auto-promoted via `ReadOnly`)
+- **Tool** `contact` + **Resource template** `repl://contact/{id}` (auto-promoted via `ReadOnly`)
 - **Tool** `contact_add` (open world)
 - **Tool** `contact_delete` (destructive, confirmation via elicitation/sampling)
 - **Tool** `import` (long-running, progress notifications)

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -299,6 +299,11 @@ app.UseMcpServer(o =>
 });
 ```
 
+## Known limitations
+
+- **Collection parameters** (`List<T>`, `int[]`): MCP passes JSON arrays as a single element. The CLI binding layer expects repeated values (`--tag vip --tag priority`), so collection parameters are not correctly bound from MCP tool calls yet. Use string parameters with custom parsing as a workaround.
+- **Parameterized resources**: Commands with route parameters (e.g. `contact {id}`) marked `.AsResource()` are listed as resources but cannot be invoked via `resources/read` since the URI has no mechanism to pass parameters. Use parameterless commands for resources, or rely on the tool fallback (`ResourceFallbackToTools = true`).
+
 ## Configuration options
 
 ```csharp

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -132,6 +132,31 @@ app.Map("deploy {env}", handler)
 - **Resource**: data sources an agent should consult before acting (`contacts`, `config`, `status`)
 - **Prompt**: reusable instruction templates that shape agent behavior (`summarize-data`, `review-changes`, `troubleshoot`)
 
+### How commands map to MCP primitives
+
+| Command markers | Tool? | Resource? | Prompt? |
+|---|---|---|---|
+| _(none)_ | Yes | No | No |
+| `.ReadOnly()` | Yes | Yes (auto-promoted) | No |
+| `.ReadOnly()` + `AutoPromoteReadOnlyToResources = false` | Yes | No | No |
+| `.AsResource()` | No | Yes | No |
+| `.AsResource()` + `ResourceFallbackToTools = true` | Yes | Yes | No |
+| `.ReadOnly().AsResource()` | Yes | Yes | No |
+| `.AsPrompt()` | No | No | Yes |
+| `.AsPrompt()` + `PromptFallbackToTools = true` | Yes | No | Yes |
+| `.AutomationHidden()` | No | No | No |
+
+> **Compatibility fallback:** Since only ~39% of clients support resources and ~38% support prompts, you can opt in to expose them as tools too. Enable `ResourceFallbackToTools` and/or `PromptFallbackToTools` in `ReplMcpServerOptions`. `AutoPromoteReadOnlyToResources` (default: `true`) controls whether `.ReadOnly()` commands are automatically exposed as resources.
+>
+> ```csharp
+> app.UseMcpServer(o =>
+> {
+>     o.ResourceFallbackToTools = true;               // resources also appear as read-only tools
+>     o.PromptFallbackToTools = true;                  // prompts also appear as tools
+>     o.AutoPromoteReadOnlyToResources = false;        // opt out of ReadOnly → resource auto-promotion
+> });
+> ```
+
 ## JSON Schema generation
 
 Route constraints and handler parameter types produce typed JSON Schema:
@@ -250,7 +275,8 @@ app.UseMcpServer(o =>
     o.ContextName = "mcp";                                      // myapp {ContextName} serve
     o.ToolNamingSeparator = ToolNamingSeparator.Underscore;     // contact_add
     o.InteractivityMode = InteractivityMode.PrefillThenFail;    // interaction degradation
-    o.ResourceFallbackToTools = true;                           // expose resources as tools when client doesn't support resources
+    o.ResourceFallbackToTools = false;                          // opt-in: also expose resources as tools
+    o.PromptFallbackToTools = false;                             // opt-in: also expose prompts as tools
     o.CommandFilter = cmd => true;                              // filter which commands become tools
     o.Prompt("summarize", (string topic) => ...);               // explicit prompt registration
 });

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -238,6 +238,40 @@ app.Map("import", async (IReplInteractionChannel interaction, CancellationToken 
 });
 ```
 
+## Writing output in MCP mode
+
+In MCP mode, each tool call runs in an isolated session with a captured output stream. Understanding where output goes is important for writing commands that work well with agents.
+
+| Output method | Where it goes | Recommendation |
+|---|---|---|
+| **Return value** | Serialized to JSON → `CallToolResult.Content` | **Preferred.** Clean, structured, always correct. |
+| **`IReplInteractionChannel`** | Intercepted by `McpInteractionChannel` | **Use for prompts and progress.** Maps to MCP primitives. |
+| **`ReplSessionIO.Output`** / `Console.WriteLine` | Captured in `StringWriter` → appended to tool result as text | Works, but produces raw text mixed with the serialized return value. Use intentionally. |
+| **`Console.OpenStandardOutput()`** | **Writes directly to the MCP stdio transport** | **Never use.** Corrupts the JSON-RPC protocol stream. |
+
+The key rule: **use return values and `IReplInteractionChannel`**. These are the designed integration points that produce clean, structured results for agents. Direct console writes are captured and won't crash anything, but they produce unstructured text that agents may struggle to parse.
+
+> **Token cost:** Everything returned in `CallToolResult.Content` is consumed by the LLM as input tokens. Verbose output (debug logs, large tables, raw dumps) translates directly into token cost and can degrade agent reasoning. Keep tool output concise and structured — return what the agent needs to act, not everything you'd show a human.
+
+```csharp
+// Good: structured return value
+app.Map("contacts", (IContactDb db) => db.GetAll()).ReadOnly();
+
+// Good: interaction channel for progress
+app.Map("import", async (IReplInteractionChannel ch, CancellationToken ct) =>
+{
+    await ch.WriteProgressAsync("Working...", 50, ct);
+    return Results.Success("Done.");
+});
+
+// Avoid: raw console output mixed with return value
+app.Map("status", () =>
+{
+    Console.WriteLine("Loading...");   // captured but messy
+    return new { Status = "ok" };      // agent sees "Loading...\n{...}"
+});
+```
+
 ## Dynamic tool discovery
 
 When `InvalidateRouting()` is called (module presence changes, session state changes), the MCP server automatically refreshes its tool list and emits `list_changed` notifications. Agents that support discovery refresh their available tools.

--- a/samples/08-mcp-server/McpServerSample.csproj
+++ b/samples/08-mcp-server/McpServerSample.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Repl\Repl.csproj" />
+    <ProjectReference Include="..\..\src\Repl.Mcp\Repl.Mcp.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/08-mcp-server/Program.cs
+++ b/samples/08-mcp-server/Program.cs
@@ -11,6 +11,8 @@ using Repl;
 
 var app = ReplApp.Create().UseDefaultInteractive();
 
+app.UseMcpServer(o => o.ServerName = "ContactManager");
+
 // ── Resources (data to consult) ────────────────────────────────────
 
 app.Map("contacts", () => new[]
@@ -22,41 +24,48 @@ app.Map("contacts", () => new[]
 	.ReadOnly()
 	.AsResource();
 
-// ── Tools (operations to perform) ──────────────────────────────────
+// ── Contact operations (grouped context) ───────────────────────────
 
-app.Map("contact {id:int}", ([Description("Contact numeric id")] int id) =>
-		new { Id = id, Name = id == 1 ? "Alice" : "Bob", Email = $"user{id}@example.com" })
-	.WithDescription("Get contact by ID")
-	.ReadOnly();
+app.Context("contact", contact =>
+{
+	contact.Map("{id:int}", ([Description("Contact numeric id")] int id) =>
+			new { Id = id, Name = id == 1 ? "Alice" : "Bob", Email = $"user{id}@example.com" })
+		.WithDescription("Get contact by ID")
+		.ReadOnly();
 
-app.Map("contact add", (string name, string email) =>
-		new { Name = name, Email = email, Status = "created" })
-	.WithDescription("Add a new contact")
-	.WithDetails("""
-		Creates a new contact record.
-		The email must be unique across all contacts.
-		""")
-	.OpenWorld()
-	.Idempotent();
+	contact.Map("add", (string name, string email) =>
+			new { Name = name, Email = email, Status = "created" })
+		.WithDescription("Add a new contact")
+		.WithDetails("""
+			Creates a new contact record.
+			The email must be unique across all contacts.
+			""")
+		.OpenWorld()
+		.Idempotent();
 
-app.Map("contact delete {id:int}",
-	async ([Description("Contact numeric id")] int id, Repl.Interaction.IReplInteractionChannel interaction, CancellationToken ct) =>
-	{
-		if (!await interaction.AskConfirmationAsync("confirm", $"Delete contact {id}?", options: new(ct)))
+	contact.Map("delete {id:int}",
+		async ([Description("Contact numeric id")] int id, Repl.Interaction.IReplInteractionChannel interaction, CancellationToken ct) =>
 		{
-			return Results.Cancelled("Delete cancelled by user.");
-		}
+			if (!await interaction.AskConfirmationAsync("confirm", $"Delete contact {id}?", options: new(ct)))
+			{
+				return Results.Cancelled("Delete cancelled by user.");
+			}
 
-		return Results.Success($"Contact {id} deleted.");
-	})
-	.WithDescription("Delete a contact")
-	.Destructive();
+			return Results.Success($"Contact {id} deleted.");
+		})
+		.WithDescription("Delete a contact")
+		.Destructive();
+});
 
-// ── Prompts (conversation starters) ────────────────────────────────
+// ── Prompts (reusable agent instructions) ──────────────────────────
+// The handler returns text that becomes the agent's starting instructions.
 
-app.Map("explain-error {code}", (string code) =>
-		$"Explain error code '{code}' in the context of the ContactManager application.")
-	.WithDescription("Explain a ContactManager error code")
+app.Map("troubleshoot {symptom}", (string symptom) =>
+		$"The user reports: '{symptom}'. " +
+		"Investigate using the available contact tools. " +
+		"Check if any contacts are missing or malformed. " +
+		"Summarize your findings and suggest a fix.")
+	.WithDescription("Guide the agent through diagnosing a contact issue")
 	.AsPrompt();
 
 // ── Interactive-only commands ──────────────────────────────────────
@@ -68,12 +77,5 @@ app.Map("clear", async (Repl.Interaction.IReplInteractionChannel interaction, Ca
 	})
 	.WithDescription("Clear the screen")
 	.AutomationHidden();
-
-// ── MCP server integration ─────────────────────────────────────────
-
-app.UseMcpServer(o =>
-{
-	o.ServerName = "ContactManager";
-});
 
 return app.Run(args);

--- a/samples/08-mcp-server/Program.cs
+++ b/samples/08-mcp-server/Program.cs
@@ -1,0 +1,79 @@
+using System.ComponentModel;
+using Repl;
+
+// ── A Repl app exposed as an MCP server for AI agents ──────────────
+//
+// Run interactively:  dotnet run
+// Run as MCP server:  dotnet run -- mcp serve
+//
+// Configure in Claude Desktop or VS Code:
+//   { "command": "dotnet", "args": ["run", "--project", "path/to/08-mcp-server", "--", "mcp", "serve"] }
+
+var app = ReplApp.Create().UseDefaultInteractive();
+
+// ── Resources (data to consult) ────────────────────────────────────
+
+app.Map("contacts", () => new[]
+	{
+		new { Name = "Alice", Email = "alice@example.com" },
+		new { Name = "Bob", Email = "bob@example.com" },
+	})
+	.WithDescription("List all contacts")
+	.ReadOnly()
+	.AsResource();
+
+// ── Tools (operations to perform) ──────────────────────────────────
+
+app.Map("contact {id:int}", ([Description("Contact numeric id")] int id) =>
+		new { Id = id, Name = id == 1 ? "Alice" : "Bob", Email = $"user{id}@example.com" })
+	.WithDescription("Get contact by ID")
+	.ReadOnly();
+
+app.Map("contact add", (string name, string email) =>
+		new { Name = name, Email = email, Status = "created" })
+	.WithDescription("Add a new contact")
+	.WithDetails("""
+		Creates a new contact record.
+		The email must be unique across all contacts.
+		""")
+	.OpenWorld()
+	.Idempotent();
+
+app.Map("contact delete {id:int}",
+	async ([Description("Contact numeric id")] int id, Repl.Interaction.IReplInteractionChannel interaction, CancellationToken ct) =>
+	{
+		if (!await interaction.AskConfirmationAsync("confirm", $"Delete contact {id}?", options: new(ct)))
+		{
+			return Results.Cancelled("Delete cancelled by user.");
+		}
+
+		return Results.Success($"Contact {id} deleted.");
+	})
+	.WithDescription("Delete a contact")
+	.Destructive();
+
+// ── Prompts (conversation starters) ────────────────────────────────
+
+app.Map("explain-error {code}", (string code) =>
+		$"Explain error code '{code}' in the context of the ContactManager application.")
+	.WithDescription("Explain a ContactManager error code")
+	.AsPrompt();
+
+// ── Interactive-only commands ──────────────────────────────────────
+
+app.Map("clear", async (Repl.Interaction.IReplInteractionChannel interaction, CancellationToken ct) =>
+	{
+		await interaction.ClearScreenAsync(ct);
+		return Results.Ok("Screen cleared.");
+	})
+	.WithDescription("Clear the screen")
+	.AutomationHidden();
+
+// ── MCP server integration ─────────────────────────────────────────
+
+app.UseMcpServer(o =>
+{
+	o.ServerName = "ContactManager";
+});
+
+return app.Run(args);

--- a/samples/08-mcp-server/README.md
+++ b/samples/08-mcp-server/README.md
@@ -1,0 +1,56 @@
+# 08 — MCP Server
+
+Expose a Repl command graph as an MCP server for AI agents.
+
+## What this sample shows
+
+- `app.UseMcpServer()` — one line to enable MCP stdio server
+- `.ReadOnly()` / `.Destructive()` / `.OpenWorld()` — behavioral annotations
+- `.AsResource()` — mark data-to-consult commands as MCP resources
+- `.AsPrompt()` — mark commands as MCP prompt sources
+- `.AutomationHidden()` — hide interactive-only commands from agents
+- `.WithDetails()` — rich descriptions that serve both `--help` and agents
+
+## Running
+
+**Interactive REPL:**
+```bash
+dotnet run
+```
+
+**MCP server mode:**
+```bash
+dotnet run -- mcp serve
+```
+
+**Test with MCP Inspector:**
+```bash
+npx @modelcontextprotocol/inspector dotnet run --project . -- mcp serve
+```
+
+## Agent configuration
+
+### Claude Desktop
+```json
+{
+  "mcpServers": {
+    "contacts": {
+      "command": "dotnet",
+      "args": ["run", "--project", "samples/08-mcp-server", "--", "mcp", "serve"]
+    }
+  }
+}
+```
+
+### VS Code (GitHub Copilot)
+```json
+{
+  "servers": {
+    "contacts": {
+      "type": "stdio",
+      "command": "dotnet",
+      "args": ["run", "--project", "samples/08-mcp-server", "--", "mcp", "serve"]
+    }
+  }
+}
+```

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,6 +13,7 @@
 	<ItemGroup Label="Runtime dependencies">
 		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3"/>
 		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.3"/>
+		<PackageVersion Include="ModelContextProtocol" Version="1.1.0"/>
 		<PackageVersion Include="Spectre.Console" Version="0.54.0"/>
 	</ItemGroup>
 

--- a/src/Repl.Core/CommandAnnotations.cs
+++ b/src/Repl.Core/CommandAnnotations.cs
@@ -1,0 +1,46 @@
+namespace Repl;
+
+/// <summary>
+/// Structured behavioral annotations for a command.
+/// Used by both human-facing surfaces (<c>--help</c>) and programmatic surfaces (MCP tool registration).
+/// </summary>
+public sealed record CommandAnnotations
+{
+	/// <summary>
+	/// Indicates the command modifies state (deletes, updates, etc.).
+	/// When exposed to agents, triggers a confirmation prompt before execution.
+	/// </summary>
+	public bool Destructive { get; init; }
+
+	/// <summary>
+	/// Indicates the command only reads data without side effects.
+	/// ReadOnly commands are auto-promoted to MCP resources.
+	/// </summary>
+	public bool ReadOnly { get; init; }
+
+	/// <summary>
+	/// Indicates the command can be called multiple times with the same result.
+	/// Agents may safely retry idempotent commands on transient failure.
+	/// </summary>
+	public bool Idempotent { get; init; }
+
+	/// <summary>
+	/// Indicates the command interacts with external systems beyond the app.
+	/// Helps agents anticipate latency and failure modes.
+	/// </summary>
+	public bool OpenWorld { get; init; }
+
+	/// <summary>
+	/// Indicates the command may take a long time to complete.
+	/// Enables task-based execution in programmatic clients.
+	/// </summary>
+	public bool LongRunning { get; init; }
+
+	/// <summary>
+	/// Hides the command from programmatic/automation surfaces.
+	/// Unlike <see cref="CommandBuilder.Hidden(bool)"/>, which hides from all surfaces,
+	/// this only suppresses programmatic discovery (e.g. MCP tool registration).
+	/// The command remains visible in interactive help and REPL.
+	/// </summary>
+	public bool AutomationHidden { get; init; }
+}

--- a/src/Repl.Core/CommandAnnotationsBuilder.cs
+++ b/src/Repl.Core/CommandAnnotationsBuilder.cs
@@ -1,0 +1,71 @@
+namespace Repl;
+
+/// <summary>
+/// Fluent builder for <see cref="CommandAnnotations"/>.
+/// Use as an escape hatch via <see cref="CommandBuilder.WithAnnotations"/> when
+/// multiple flags need to be set in a single expression.
+/// </summary>
+public sealed class CommandAnnotationsBuilder
+{
+	private bool _destructive;
+	private bool _readOnly;
+	private bool _idempotent;
+	private bool _openWorld;
+	private bool _longRunning;
+	private bool _automationHidden;
+
+	/// <summary>Marks the command as destructive (deletes, modifies state).</summary>
+	public CommandAnnotationsBuilder Destructive(bool value = true)
+	{
+		_destructive = value;
+		return this;
+	}
+
+	/// <summary>Marks the command as read-only (no side effects).</summary>
+	public CommandAnnotationsBuilder ReadOnly(bool value = true)
+	{
+		_readOnly = value;
+		return this;
+	}
+
+	/// <summary>Marks the command as safely retriable.</summary>
+	public CommandAnnotationsBuilder Idempotent(bool value = true)
+	{
+		_idempotent = value;
+		return this;
+	}
+
+	/// <summary>Marks the command as interacting with external systems.</summary>
+	public CommandAnnotationsBuilder OpenWorld(bool value = true)
+	{
+		_openWorld = value;
+		return this;
+	}
+
+	/// <summary>Marks the command as long-running (enables task-based execution).</summary>
+	public CommandAnnotationsBuilder LongRunning(bool value = true)
+	{
+		_longRunning = value;
+		return this;
+	}
+
+	/// <summary>Hides the command from programmatic/automation surfaces only.</summary>
+	public CommandAnnotationsBuilder AutomationHidden(bool value = true)
+	{
+		_automationHidden = value;
+		return this;
+	}
+
+	/// <summary>
+	/// Builds the immutable <see cref="CommandAnnotations"/> instance.
+	/// </summary>
+	internal CommandAnnotations Build() => new()
+	{
+		Destructive = _destructive,
+		ReadOnly = _readOnly,
+		Idempotent = _idempotent,
+		OpenWorld = _openWorld,
+		LongRunning = _longRunning,
+		AutomationHidden = _automationHidden,
+	};
+}

--- a/src/Repl.Core/CommandBuilder.cs
+++ b/src/Repl.Core/CommandBuilder.cs
@@ -66,6 +66,34 @@ public sealed class CommandBuilder
 	public Delegate? Banner { get; private set; }
 
 	/// <summary>
+	/// Gets the rich markdown description body.
+	/// Serves both human <c>--help --verbose</c> output and agent tool descriptions.
+	/// </summary>
+	public string? Details { get; private set; }
+
+	/// <summary>
+	/// Gets the structured behavioral annotations for this command.
+	/// </summary>
+	public CommandAnnotations? Annotations { get; private set; }
+
+	/// <summary>
+	/// Gets a value indicating whether this command is a resource (data to consult).
+	/// </summary>
+	public bool IsResource { get; private set; }
+
+	/// <summary>
+	/// Gets a value indicating whether this command is a prompt source.
+	/// </summary>
+	public bool IsPrompt { get; private set; }
+
+	/// <summary>
+	/// Gets generic metadata entries for extensibility.
+	/// </summary>
+	public IReadOnlyDictionary<string, object> Metadata => _metadata;
+
+	private readonly Dictionary<string, object> _metadata = new(StringComparer.OrdinalIgnoreCase);
+
+	/// <summary>
 	/// Sets a command description.
 	/// </summary>
 	/// <param name="text">Description text.</param>
@@ -168,6 +196,137 @@ public sealed class CommandBuilder
 	public CommandBuilder AsProtocolPassthrough()
 	{
 		IsProtocolPassthrough = true;
+		return this;
+	}
+
+	// ── Rich metadata ──────────────────────────────────────────────────
+
+	/// <summary>
+	/// Sets a rich markdown description body.
+	/// Dual-purpose: enriches human <c>--help --verbose</c> output
+	/// and agent tool descriptions.
+	/// </summary>
+	/// <param name="markdown">Markdown content.</param>
+	/// <returns>The same builder instance.</returns>
+	public CommandBuilder WithDetails(string markdown)
+	{
+		Details = string.IsNullOrWhiteSpace(markdown)
+			? throw new ArgumentException("Details cannot be empty.", nameof(markdown))
+			: markdown;
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a generic metadata entry.
+	/// </summary>
+	/// <param name="key">Metadata key.</param>
+	/// <param name="value">Metadata value.</param>
+	/// <returns>The same builder instance.</returns>
+	public CommandBuilder WithMetadata(string key, object value)
+	{
+		key = string.IsNullOrWhiteSpace(key)
+			? throw new ArgumentException("Metadata key cannot be empty.", nameof(key))
+			: key;
+		ArgumentNullException.ThrowIfNull(value);
+		_metadata[key] = value;
+		return this;
+	}
+
+	// ── Annotation shortcuts ───────────────────────────────────────────
+	// Same style as Hidden() — short, chainable, directly on CommandBuilder.
+	// Uses `with` expressions to preserve record immutability.
+
+	/// <summary>Marks the command as read-only (no side effects).</summary>
+	/// <param name="value">True to mark as read-only.</param>
+	/// <returns>The same builder instance.</returns>
+	public CommandBuilder ReadOnly(bool value = true)
+	{
+		Annotations = (Annotations ?? new CommandAnnotations()) with { ReadOnly = value };
+		return this;
+	}
+
+	/// <summary>Marks the command as destructive (deletes, modifies state).</summary>
+	/// <param name="value">True to mark as destructive.</param>
+	/// <returns>The same builder instance.</returns>
+	public CommandBuilder Destructive(bool value = true)
+	{
+		Annotations = (Annotations ?? new CommandAnnotations()) with { Destructive = value };
+		return this;
+	}
+
+	/// <summary>Marks the command as safely retriable.</summary>
+	/// <param name="value">True to mark as idempotent.</param>
+	/// <returns>The same builder instance.</returns>
+	public CommandBuilder Idempotent(bool value = true)
+	{
+		Annotations = (Annotations ?? new CommandAnnotations()) with { Idempotent = value };
+		return this;
+	}
+
+	/// <summary>Marks the command as interacting with external systems.</summary>
+	/// <param name="value">True to mark as open-world.</param>
+	/// <returns>The same builder instance.</returns>
+	public CommandBuilder OpenWorld(bool value = true)
+	{
+		Annotations = (Annotations ?? new CommandAnnotations()) with { OpenWorld = value };
+		return this;
+	}
+
+	/// <summary>Marks the command as long-running (enables task-based execution).</summary>
+	/// <param name="value">True to mark as long-running.</param>
+	/// <returns>The same builder instance.</returns>
+	public CommandBuilder LongRunning(bool value = true)
+	{
+		Annotations = (Annotations ?? new CommandAnnotations()) with { LongRunning = value };
+		return this;
+	}
+
+	/// <summary>Hides the command from programmatic/automation surfaces only.</summary>
+	/// <param name="value">True to hide from automation.</param>
+	/// <returns>The same builder instance.</returns>
+	public CommandBuilder AutomationHidden(bool value = true)
+	{
+		Annotations = (Annotations ?? new CommandAnnotations()) with { AutomationHidden = value };
+		return this;
+	}
+
+	/// <summary>
+	/// Configures annotations via builder — escape hatch for complex scenarios.
+	/// Overwrites any annotations set by individual shortcuts.
+	/// </summary>
+	/// <param name="configure">Builder configuration callback.</param>
+	/// <returns>The same builder instance.</returns>
+	public CommandBuilder WithAnnotations(Action<CommandAnnotationsBuilder> configure)
+	{
+		ArgumentNullException.ThrowIfNull(configure);
+		var builder = new CommandAnnotationsBuilder();
+		configure(builder);
+		Annotations = builder.Build();
+		return this;
+	}
+
+	// ── Semantic markers ───────────────────────────────────────────────
+
+	/// <summary>
+	/// Marks this command as a resource (data to consult, not an operation to perform).
+	/// Resources appear in a separate help section and are auto-exposed as MCP resources.
+	/// </summary>
+	/// <returns>The same builder instance.</returns>
+	public CommandBuilder AsResource()
+	{
+		IsResource = true;
+		return this;
+	}
+
+	/// <summary>
+	/// Marks this command as a prompt source.
+	/// The handler return value becomes the prompt message template.
+	/// Handler parameters become prompt arguments.
+	/// </summary>
+	/// <returns>The same builder instance.</returns>
+	public CommandBuilder AsPrompt()
+	{
+		IsPrompt = true;
 		return this;
 	}
 

--- a/src/Repl.Core/CommandBuilder.cs
+++ b/src/Repl.Core/CommandBuilder.cs
@@ -67,7 +67,7 @@ public sealed class CommandBuilder
 
 	/// <summary>
 	/// Gets the rich markdown description body.
-	/// Serves both human <c>--help --verbose</c> output and agent tool descriptions.
+	/// Used for agent tool descriptions and documentation export.
 	/// </summary>
 	public string? Details { get; private set; }
 
@@ -202,9 +202,8 @@ public sealed class CommandBuilder
 	// ── Rich metadata ──────────────────────────────────────────────────
 
 	/// <summary>
-	/// Sets a rich markdown description body.
-	/// Dual-purpose: enriches human <c>--help --verbose</c> output
-	/// and agent tool descriptions.
+	/// Sets a rich markdown description body for agent tool descriptions
+	/// and documentation export.
 	/// </summary>
 	/// <param name="markdown">Markdown content.</param>
 	/// <returns>The same builder instance.</returns>

--- a/src/Repl.Core/ConsoleInteractionChannel.cs
+++ b/src/Repl.Core/ConsoleInteractionChannel.cs
@@ -260,7 +260,7 @@ internal sealed partial class ConsoleInteractionChannel(
 	public async ValueTask<bool> AskConfirmationAsync(
 		string name,
 		string prompt,
-		bool defaultValue = false,
+		bool? defaultValue = null,
 		AskOptions? options = null)
 	{
 		_ = ValidateName(name);
@@ -276,8 +276,9 @@ internal sealed partial class ConsoleInteractionChannel(
 			return resolvedPrefilled;
 		}
 
+		var effectiveDefault = defaultValue ?? false;
 		var dispatched = await TryDispatchAsync(
-			new AskConfirmationRequest(name, prompt, defaultValue, options), effectiveCt).ConfigureAwait(false);
+			new AskConfirmationRequest(name, prompt, effectiveDefault, options), effectiveCt).ConfigureAwait(false);
 		if (dispatched.Handled)
 		{
 			return (bool)dispatched.Value!;
@@ -285,15 +286,15 @@ internal sealed partial class ConsoleInteractionChannel(
 
 		var line = await ReadPromptLineAsync(
 				name,
-				$"{prompt} [{(defaultValue ? "Y/n" : "y/N")}]",
+				$"{prompt} [{(effectiveDefault ? "Y/n" : "y/N")}]",
 				kind: "confirmation",
 				effectiveCt,
 				options?.Timeout,
-				defaultLabel: defaultValue ? "yes" : "no")
+				defaultLabel: effectiveDefault ? "yes" : "no")
 			.ConfigureAwait(false);
 		if (string.IsNullOrWhiteSpace(line))
 		{
-			return HandleMissingAnswer(defaultValue, "confirmation");
+			return HandleMissingAnswer(effectiveDefault, "confirmation");
 		}
 
 		if (string.Equals(line, "y", StringComparison.OrdinalIgnoreCase)
@@ -308,7 +309,7 @@ internal sealed partial class ConsoleInteractionChannel(
 			return false;
 		}
 
-		return HandleMissingAnswer(defaultValue, "confirmation");
+		return HandleMissingAnswer(effectiveDefault, "confirmation");
 	}
 
 	public async ValueTask<string> AskTextAsync(

--- a/src/Repl.Core/ContextDefinition.cs
+++ b/src/Repl.Core/ContextDefinition.cs
@@ -17,4 +17,6 @@ internal sealed class ContextDefinition(
 	public int ModuleId { get; } = moduleId;
 
 	public bool IsHidden { get; set; }
+
+	public string? Details { get; set; }
 }

--- a/src/Repl.Core/CoreReplApp.Documentation.cs
+++ b/src/Repl.Core/CoreReplApp.Documentation.cs
@@ -38,7 +38,8 @@ public sealed partial class CoreReplApp
 				Path: context.Template.Template,
 				Description: context.Description,
 				IsDynamic: context.Template.Segments.Any(segment => segment is DynamicRouteSegment),
-				IsHidden: context.IsHidden))
+				IsHidden: context.IsHidden,
+				Details: context.Details))
 			.ToArray();
 		var resourceDocs = commandDocs
 			.Where(cmd => cmd.IsResource || cmd.Annotations?.ReadOnly == true)
@@ -93,7 +94,8 @@ public sealed partial class CoreReplApp
 				Path: context.Template.Template,
 				Description: context.Description,
 				IsDynamic: context.Template.Segments.Any(segment => segment is DynamicRouteSegment),
-				IsHidden: context.IsHidden))
+				IsHidden: context.IsHidden,
+				Details: context.Details))
 			.ToArray();
 		var resourceDocs = commandDocs
 			.Where(cmd => cmd.IsResource || cmd.Annotations?.ReadOnly == true)

--- a/src/Repl.Core/CoreReplApp.Documentation.cs
+++ b/src/Repl.Core/CoreReplApp.Documentation.cs
@@ -7,7 +7,59 @@ namespace Repl;
 
 public sealed partial class CoreReplApp
 {
-	internal object CreateDocumentationModel(string? targetPath)
+	/// <inheritdoc />
+	public ReplDocumentationModel CreateDocumentationModel(string? targetPath = null)
+	{
+		var activeGraph = ResolveActiveRoutingGraph();
+		var normalizedTargetPath = NormalizePath(targetPath);
+		var targetTokens = string.IsNullOrWhiteSpace(normalizedTargetPath)
+			? []
+			: normalizedTargetPath
+				.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+		var discoverableRoutes = ResolveDiscoverableRoutes(
+			activeGraph.Routes,
+			activeGraph.Contexts,
+			targetTokens,
+			StringComparison.OrdinalIgnoreCase);
+		var discoverableContexts = ResolveDiscoverableContexts(
+			activeGraph.Contexts,
+			targetTokens,
+			StringComparison.OrdinalIgnoreCase);
+		var commands = SelectDocumentationCommands(
+			normalizedTargetPath,
+			discoverableRoutes,
+			discoverableContexts,
+			out _);
+
+		var contexts = SelectDocumentationContexts(normalizedTargetPath, commands, discoverableContexts);
+		var commandDocs = commands.Select(BuildDocumentationCommand).ToArray();
+		var contextDocs = contexts
+			.Select(context => new ReplDocContext(
+				Path: context.Template.Template,
+				Description: context.Description,
+				IsDynamic: context.Template.Segments.Any(segment => segment is DynamicRouteSegment),
+				IsHidden: context.IsHidden))
+			.ToArray();
+		var resourceDocs = commandDocs
+			.Where(cmd => cmd.IsResource || cmd.Annotations?.ReadOnly == true)
+			.Select(cmd => new ReplDocResource(
+				Path: cmd.Path,
+				Description: cmd.Description,
+				Details: cmd.Details,
+				Arguments: cmd.Arguments,
+				Options: cmd.Options))
+			.ToArray();
+		return new ReplDocumentationModel(
+			App: BuildDocumentationApp(),
+			Contexts: contextDocs,
+			Commands: commandDocs,
+			Resources: resourceDocs);
+	}
+
+	/// <summary>
+	/// Internal documentation model creation that supports not-found result for help rendering.
+	/// </summary>
+	internal object CreateDocumentationModelInternal(string? targetPath)
 	{
 		var activeGraph = ResolveActiveRoutingGraph();
 		var normalizedTargetPath = NormalizePath(targetPath);
@@ -43,10 +95,20 @@ public sealed partial class CoreReplApp
 				IsDynamic: context.Template.Segments.Any(segment => segment is DynamicRouteSegment),
 				IsHidden: context.IsHidden))
 			.ToArray();
+		var resourceDocs = commandDocs
+			.Where(cmd => cmd.IsResource || cmd.Annotations?.ReadOnly == true)
+			.Select(cmd => new ReplDocResource(
+				Path: cmd.Path,
+				Description: cmd.Description,
+				Details: cmd.Details,
+				Arguments: cmd.Arguments,
+				Options: cmd.Options))
+			.ToArray();
 		return new ReplDocumentationModel(
 			App: BuildDocumentationApp(),
 			Contexts: contextDocs,
-			Commands: commandDocs);
+			Commands: commandDocs,
+			Resources: resourceDocs);
 	}
 
 	private static RouteDefinition[] SelectDocumentationCommands(
@@ -137,15 +199,20 @@ public sealed partial class CoreReplApp
 		var routeParameterNames = dynamicSegments
 			.Select(segment => segment.Name)
 			.ToHashSet(StringComparer.OrdinalIgnoreCase);
-		var arguments = dynamicSegments
-			.Select(segment => new ReplDocArgument(
-				Name: segment.Name,
-				Type: GetConstraintTypeName(segment.ConstraintKind),
-				Required: !segment.IsOptional,
-				Description: null))
-			.ToArray();
-
 		var handlerParams = route.Command.Handler.Method.GetParameters();
+		var arguments = dynamicSegments
+			.Select(segment =>
+			{
+				var paramInfo = handlerParams.FirstOrDefault(p =>
+					string.Equals(p.Name, segment.Name, StringComparison.OrdinalIgnoreCase));
+				var description = paramInfo?.GetCustomAttribute<DescriptionAttribute>()?.Description;
+				return new ReplDocArgument(
+					Name: segment.Name,
+					Type: GetConstraintTypeName(segment.ConstraintKind),
+					Required: !segment.IsOptional,
+					Description: description);
+			})
+			.ToArray();
 		var regularOptions = handlerParams
 			.Where(parameter =>
 				!string.IsNullOrWhiteSpace(parameter.Name)
@@ -171,7 +238,12 @@ public sealed partial class CoreReplApp
 			Aliases: route.Command.Aliases,
 			IsHidden: route.Command.IsHidden,
 			Arguments: arguments,
-			Options: options);
+			Options: options,
+			Details: route.Command.Details,
+			Annotations: route.Command.Annotations,
+			Metadata: route.Command.Metadata.Count > 0 ? route.Command.Metadata : null,
+			IsResource: route.Command.IsResource,
+			IsPrompt: route.Command.IsPrompt);
 	}
 
 	private ReplDocApp BuildDocumentationApp()

--- a/src/Repl.Core/CoreReplApp.ScopedMap.cs
+++ b/src/Repl.Core/CoreReplApp.ScopedMap.cs
@@ -99,6 +99,9 @@ public sealed partial class CoreReplApp
 
 		void ICoreReplApp.InvalidateRouting() => _app.InvalidateRouting();
 
+		public Documentation.ReplDocumentationModel CreateDocumentationModel(string? targetPath = null) =>
+			_app.CreateDocumentationModel(targetPath);
+
 		IReplMap IReplMap.WithBanner(string text)
 		{
 			ArgumentException.ThrowIfNullOrWhiteSpace(text);
@@ -135,6 +138,14 @@ public sealed partial class CoreReplApp
 		public IContextBuilder Hidden(bool isHidden = true)
 		{
 			_context.IsHidden = isHidden;
+			return this;
+		}
+
+		public IContextBuilder WithDetails(string markdown)
+		{
+			_context.Details = string.IsNullOrWhiteSpace(markdown)
+				? throw new ArgumentException("Details cannot be empty.", nameof(markdown))
+				: markdown;
 			return this;
 		}
 	}

--- a/src/Repl.Core/CoreReplApp.cs
+++ b/src/Repl.Core/CoreReplApp.cs
@@ -666,6 +666,11 @@ public sealed partial class CoreReplApp : ICoreReplApp
 
 	private ReplRuntimeChannel ResolveCurrentRuntimeChannel()
 	{
+		if (ReplSessionIO.IsProgrammatic)
+		{
+			return ReplRuntimeChannel.Programmatic;
+		}
+
 		if (ReplSessionIO.IsHostedSession)
 		{
 			return ReplRuntimeChannel.Session;

--- a/src/Repl.Core/CoreReplApp.cs
+++ b/src/Repl.Core/CoreReplApp.cs
@@ -125,9 +125,19 @@ public sealed partial class CoreReplApp : ICoreReplApp
 	}
 
 	/// <summary>
+	/// Occurs after routing has been invalidated.
+	/// Subscribers can use this to refresh derived state (e.g. MCP tool lists).
+	/// </summary>
+	internal event EventHandler? RoutingInvalidated;
+
+	/// <summary>
 	/// Invalidates active routing cache so module presence predicates are re-evaluated on next resolution.
 	/// </summary>
-	public void InvalidateRouting() => Interlocked.Increment(ref _routingCacheVersion);
+	public void InvalidateRouting()
+	{
+		Interlocked.Increment(ref _routingCacheVersion);
+		RoutingInvalidated?.Invoke(this, EventArgs.Empty);
+	}
 
 	/// <summary>
 	/// Maps a route and command handler.

--- a/src/Repl.Core/Documentation/ReplDocCommand.cs
+++ b/src/Repl.Core/Documentation/ReplDocCommand.cs
@@ -9,4 +9,9 @@ public sealed record ReplDocCommand(
 	IReadOnlyList<string> Aliases,
 	bool IsHidden,
 	IReadOnlyList<ReplDocArgument> Arguments,
-	IReadOnlyList<ReplDocOption> Options);
+	IReadOnlyList<ReplDocOption> Options,
+	string? Details = null,
+	CommandAnnotations? Annotations = null,
+	IReadOnlyDictionary<string, object>? Metadata = null,
+	bool IsResource = false,
+	bool IsPrompt = false);

--- a/src/Repl.Core/Documentation/ReplDocContext.cs
+++ b/src/Repl.Core/Documentation/ReplDocContext.cs
@@ -7,4 +7,5 @@ public sealed record ReplDocContext(
 	string Path,
 	string? Description,
 	bool IsDynamic,
-	bool IsHidden);
+	bool IsHidden,
+	string? Details = null);

--- a/src/Repl.Core/Documentation/ReplDocResource.cs
+++ b/src/Repl.Core/Documentation/ReplDocResource.cs
@@ -1,0 +1,11 @@
+namespace Repl.Documentation;
+
+/// <summary>
+/// Resource metadata for commands marked as data sources.
+/// </summary>
+public sealed record ReplDocResource(
+	string Path,
+	string? Description,
+	string? Details,
+	IReadOnlyList<ReplDocArgument> Arguments,
+	IReadOnlyList<ReplDocOption> Options);

--- a/src/Repl.Core/Documentation/ReplDocumentationModel.cs
+++ b/src/Repl.Core/Documentation/ReplDocumentationModel.cs
@@ -6,4 +6,5 @@ namespace Repl.Documentation;
 public sealed record ReplDocumentationModel(
 	ReplDocApp App,
 	IReadOnlyList<ReplDocContext> Contexts,
-	IReadOnlyList<ReplDocCommand> Commands);
+	IReadOnlyList<ReplDocCommand> Commands,
+	IReadOnlyList<ReplDocResource> Resources);

--- a/src/Repl.Core/IContextBuilder.cs
+++ b/src/Repl.Core/IContextBuilder.cs
@@ -16,7 +16,7 @@ public interface IContextBuilder : IReplMap
 
 	/// <summary>
 	/// Sets a rich markdown description for the context.
-	/// Enriches human <c>--help --verbose</c> output and agent tool descriptions.
+	/// Used for agent tool descriptions and documentation export.
 	/// </summary>
 	/// <param name="markdown">Markdown content.</param>
 	/// <returns>The same context builder.</returns>

--- a/src/Repl.Core/IContextBuilder.cs
+++ b/src/Repl.Core/IContextBuilder.cs
@@ -13,4 +13,12 @@ public interface IContextBuilder : IReplMap
 	/// <param name="isHidden">True to hide the context from discovery output.</param>
 	/// <returns>The same context builder.</returns>
 	IContextBuilder Hidden(bool isHidden = true);
+
+	/// <summary>
+	/// Sets a rich markdown description for the context.
+	/// Enriches human <c>--help --verbose</c> output and agent tool descriptions.
+	/// </summary>
+	/// <param name="markdown">Markdown content.</param>
+	/// <returns>The same context builder.</returns>
+	IContextBuilder WithDetails(string markdown);
 }

--- a/src/Repl.Core/ICoreReplApp.cs
+++ b/src/Repl.Core/ICoreReplApp.cs
@@ -1,3 +1,5 @@
+using Repl.Documentation;
+
 namespace Repl;
 
 /// <summary>
@@ -47,4 +49,14 @@ public interface ICoreReplApp : IReplMap
 	/// Invalidates the active routing cache so module presence predicates are re-evaluated on next resolution.
 	/// </summary>
 	void InvalidateRouting();
+
+	/// <summary>
+	/// Builds a structured documentation model of the command graph.
+	/// </summary>
+	/// <param name="targetPath">
+	/// Optional target path to scope the model. When <c>null</c>, returns the full model.
+	/// When specified and not found, returns an empty model.
+	/// </param>
+	/// <returns>A structured documentation model.</returns>
+	ReplDocumentationModel CreateDocumentationModel(string? targetPath = null);
 }

--- a/src/Repl.Core/Interaction/Public/IReplInteractionChannel.cs
+++ b/src/Repl.Core/Interaction/Public/IReplInteractionChannel.cs
@@ -55,7 +55,7 @@ public interface IReplInteractionChannel
 	ValueTask<bool> AskConfirmationAsync(
 		string name,
 		string prompt,
-		bool defaultValue = false,
+		bool? defaultValue = null,
 		AskOptions? options = null);
 
 	/// <summary>

--- a/src/Repl.Core/InternalsVisibleTo.cs
+++ b/src/Repl.Core/InternalsVisibleTo.cs
@@ -5,3 +5,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Repl.Defaults")]
 [assembly: InternalsVisibleTo("Repl.Testing")]
 [assembly: InternalsVisibleTo("Repl.Spectre")]
+[assembly: InternalsVisibleTo("Repl.Mcp")]
+[assembly: InternalsVisibleTo("Repl.McpTests")]

--- a/src/Repl.Core/ReplDocumentationExtensions.cs
+++ b/src/Repl.Core/ReplDocumentationExtensions.cs
@@ -33,7 +33,7 @@ public static class ReplDocumentationExtensions
 				var targetPath = targetPathTokens is null or { Length: 0 }
 					? null
 					: string.Join(' ', targetPathTokens);
-				return app.CreateDocumentationModel(targetPath);
+				return app.CreateDocumentationModelInternal(targetPath);
 			});
 		if (options.HiddenByDefault)
 		{

--- a/src/Repl.Core/ReplRuntimeChannel.cs
+++ b/src/Repl.Core/ReplRuntimeChannel.cs
@@ -19,5 +19,10 @@ public enum ReplRuntimeChannel
 	/// Hosted session (for example websocket/telnet/remote terminal).
 	/// </summary>
 	Session = 2,
+
+	/// <summary>
+	/// Programmatic execution driven by an external agent, script, or API.
+	/// </summary>
+	Programmatic = 3,
 }
 

--- a/src/Repl.Core/ReplSessionIO.cs
+++ b/src/Repl.Core/ReplSessionIO.cs
@@ -27,6 +27,7 @@ internal static class ReplSessionIO
 	private static readonly AsyncLocal<TextReader?> s_input = new();
 	private static readonly AsyncLocal<IReplKeyReader?> s_keyReader = new();
 	private static readonly AsyncLocal<bool> s_isHostedSession = new();
+	private static readonly AsyncLocal<bool> s_isProgrammatic = new();
 	private static readonly AsyncLocal<string?> s_sessionId = new();
 	private static readonly ConcurrentDictionary<string, SessionMetadata> s_sessions = new(StringComparer.Ordinal);
 
@@ -63,6 +64,15 @@ internal static class ReplSessionIO
 	/// Gets a value indicating whether execution is currently running in a real hosted transport session.
 	/// </summary>
 	public static bool IsHostedSession => s_isHostedSession.Value;
+
+	/// <summary>
+	/// Gets a value indicating whether execution is driven by a programmatic agent or automation.
+	/// </summary>
+	internal static bool IsProgrammatic
+	{
+		get => s_isProgrammatic.Value;
+		set => s_isProgrammatic.Value = value;
+	}
 
 	/// <summary>
 	/// Gets the current hosted session identifier, when available.

--- a/src/Repl.Core/ReplSessionIO.cs
+++ b/src/Repl.Core/ReplSessionIO.cs
@@ -226,6 +226,7 @@ internal static class ReplSessionIO
 		var previousInput = s_input.Value;
 		var previousKeyReader = s_keyReader.Value;
 		var previousIsHostedSession = s_isHostedSession.Value;
+		var previousIsProgrammatic = s_isProgrammatic.Value;
 		var previousSessionId = s_sessionId.Value;
 
 		var resolvedSessionId = string.IsNullOrWhiteSpace(sessionId)
@@ -269,6 +270,7 @@ internal static class ReplSessionIO
 			previousInput,
 			previousKeyReader,
 			previousIsHostedSession,
+			previousIsProgrammatic,
 			previousSessionId,
 			removeSessionOnDispose: string.IsNullOrWhiteSpace(sessionId),
 			sessionIdToRemove: resolvedSessionId);
@@ -343,6 +345,7 @@ internal static class ReplSessionIO
 		TextReader? previousInput,
 		IReplKeyReader? previousKeyReader,
 		bool previousIsHostedSession,
+		bool previousIsProgrammatic,
 		string? previousSessionId,
 		bool removeSessionOnDispose,
 		string sessionIdToRemove) : IDisposable
@@ -355,6 +358,7 @@ internal static class ReplSessionIO
 			s_input.Value = previousInput;
 			s_keyReader.Value = previousKeyReader;
 			s_isHostedSession.Value = previousIsHostedSession;
+			s_isProgrammatic.Value = previousIsProgrammatic;
 			s_sessionId.Value = previousSessionId;
 
 			if (removeSessionOnDispose)

--- a/src/Repl.Defaults/DefaultsInteractionChannel.cs
+++ b/src/Repl.Defaults/DefaultsInteractionChannel.cs
@@ -34,7 +34,7 @@ internal sealed class DefaultsInteractionChannel : IReplInteractionChannel, ICom
 	public ValueTask<bool> AskConfirmationAsync(
 		string name,
 		string prompt,
-		bool defaultValue = false,
+		bool? defaultValue = null,
 		AskOptions? options = null) =>
 		_inner.AskConfirmationAsync(name, prompt, defaultValue, options);
 

--- a/src/Repl.Defaults/InternalsVisibleTo.cs
+++ b/src/Repl.Defaults/InternalsVisibleTo.cs
@@ -3,3 +3,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Repl.Tests")]
 [assembly: InternalsVisibleTo("Repl.IntegrationTests")]
 [assembly: InternalsVisibleTo("Repl.Testing")]
+[assembly: InternalsVisibleTo("Repl.Mcp")]
+[assembly: InternalsVisibleTo("Repl.McpTests")]

--- a/src/Repl.Defaults/ReplApp.cs
+++ b/src/Repl.Defaults/ReplApp.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Repl.Documentation;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -94,6 +95,10 @@ public sealed class ReplApp : IReplApp
 	/// Invalidates active routing cache so module presence predicates are re-evaluated on next resolution.
 	/// </summary>
 	public void InvalidateRouting() => _core.InvalidateRouting();
+
+	/// <inheritdoc />
+	public ReplDocumentationModel CreateDocumentationModel(string? targetPath = null) =>
+		_core.CreateDocumentationModel(targetPath);
 
 	/// <summary>
 	/// Maps a route and command handler.
@@ -716,6 +721,9 @@ public sealed class ReplApp : IReplApp
 		}
 
 		public void InvalidateRouting() => _map.InvalidateRouting();
+
+		public ReplDocumentationModel CreateDocumentationModel(string? targetPath = null) =>
+			_map.CreateDocumentationModel(targetPath);
 
 		IContextBuilder ICoreReplApp.Context(string segment, Action<ICoreReplApp> configure, Delegate? validation) =>
 			Context(segment, scoped => configure(scoped), validation);

--- a/src/Repl.Mcp/InteractivityMode.cs
+++ b/src/Repl.Mcp/InteractivityMode.cs
@@ -1,0 +1,19 @@
+namespace Repl;
+
+/// <summary>
+/// Controls how runtime interaction prompts are handled in MCP mode.
+/// </summary>
+public enum InteractivityMode
+{
+	/// <summary>Use prefilled values, fail with descriptive error if missing.</summary>
+	PrefillThenFail,
+
+	/// <summary>Use prefilled values, fall back to defaults if missing.</summary>
+	PrefillThenDefaults,
+
+	/// <summary>Use prefilled values, then elicitation, then sampling, then fail.</summary>
+	PrefillThenElicitation,
+
+	/// <summary>Use prefilled values, then sampling (skip elicitation), then fail.</summary>
+	PrefillThenSampling,
+}

--- a/src/Repl.Mcp/McpInteractionChannel.cs
+++ b/src/Repl.Mcp/McpInteractionChannel.cs
@@ -358,12 +358,6 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 			}
 		}
 
-		if (int.TryParse(value, System.Globalization.CultureInfo.InvariantCulture, out var index)
-			&& index >= 0 && index < choices.Count)
-		{
-			return index;
-		}
-
 		throw new McpInteractionException(
 			$"Cannot resolve choice '{value}'. Available: {string.Join(", ", choices)}");
 	}

--- a/src/Repl.Mcp/McpInteractionChannel.cs
+++ b/src/Repl.Mcp/McpInteractionChannel.cs
@@ -88,6 +88,13 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 			return ParseBool(sampled);
 		}
 
+		if (_mode == InteractivityMode.PrefillThenFail && !defaultValue)
+		{
+			throw new McpInteractionException(
+				$"Interactive prompt '{name}' requires a value. " +
+				$"Provide it as a tool argument 'answer:{name}' (true/false).");
+		}
+
 		return defaultValue;
 	}
 

--- a/src/Repl.Mcp/McpInteractionChannel.cs
+++ b/src/Repl.Mcp/McpInteractionChannel.cs
@@ -1,0 +1,191 @@
+using Repl.Interaction;
+
+namespace Repl.Mcp;
+
+/// <summary>
+/// Implements <see cref="IReplInteractionChannel"/> for MCP mode with progressive degradation.
+/// Tier 1: Prefill from tool arguments. Tier 2: Elicitation. Tier 3: Sampling. Tier 4: Default/Fail.
+/// </summary>
+internal sealed class McpInteractionChannel : IReplInteractionChannel
+{
+	private readonly IReadOnlyDictionary<string, string> _prefillAnswers;
+	private readonly InteractivityMode _mode;
+
+	public McpInteractionChannel(
+		IReadOnlyDictionary<string, string> prefillAnswers,
+		InteractivityMode mode)
+	{
+		_prefillAnswers = prefillAnswers;
+		_mode = mode;
+	}
+
+	public ValueTask<int> AskChoiceAsync(
+		string name,
+		string prompt,
+		IReadOnlyList<string> choices,
+		int? defaultIndex = null,
+		AskOptions? options = null)
+	{
+		if (_prefillAnswers.TryGetValue(name, out var prefill))
+		{
+			return ValueTask.FromResult(ResolveChoiceIndex(prefill, choices));
+		}
+
+		// Tier 2/3 (elicitation/sampling) deferred to future implementation.
+
+		if (defaultIndex.HasValue)
+		{
+			return ValueTask.FromResult(defaultIndex.Value);
+		}
+
+		if (_mode == InteractivityMode.PrefillThenDefaults)
+		{
+			return ValueTask.FromResult(0);
+		}
+
+		throw new McpInteractionException(
+			$"Interactive prompt '{name}' requires a value. " +
+			$"Provide it as a tool argument 'answer:{name}'. Choices: {string.Join(", ", choices)}");
+	}
+
+	public ValueTask<bool> AskConfirmationAsync(
+		string name,
+		string prompt,
+		bool defaultValue = false,
+		AskOptions? options = null)
+	{
+		if (_prefillAnswers.TryGetValue(name, out var prefill))
+		{
+			return ValueTask.FromResult(
+				string.Equals(prefill, "true", StringComparison.OrdinalIgnoreCase)
+				|| string.Equals(prefill, "yes", StringComparison.OrdinalIgnoreCase)
+				|| string.Equals(prefill, "y", StringComparison.OrdinalIgnoreCase)
+				|| string.Equals(prefill, "1", StringComparison.Ordinal));
+		}
+
+		if (_mode is InteractivityMode.PrefillThenDefaults)
+		{
+			return ValueTask.FromResult(defaultValue);
+		}
+
+		if (defaultValue || _mode is not InteractivityMode.PrefillThenFail)
+		{
+			return ValueTask.FromResult(defaultValue);
+		}
+
+		throw new McpInteractionException(
+			$"Interactive prompt '{name}' requires a value. " +
+			$"Provide it as a tool argument 'answer:{name}' (true/false).");
+	}
+
+	public ValueTask<string> AskTextAsync(
+		string name,
+		string prompt,
+		string? defaultValue = null,
+		AskOptions? options = null)
+	{
+		if (_prefillAnswers.TryGetValue(name, out var prefill))
+		{
+			return ValueTask.FromResult(prefill);
+		}
+
+		if (defaultValue is not null)
+		{
+			return ValueTask.FromResult(defaultValue);
+		}
+
+		if (_mode == InteractivityMode.PrefillThenDefaults)
+		{
+			return ValueTask.FromResult(string.Empty);
+		}
+
+		throw new McpInteractionException(
+			$"Interactive prompt '{name}' requires a value. " +
+			$"Provide it as a tool argument 'answer:{name}'.");
+	}
+
+	public ValueTask<string> AskSecretAsync(
+		string name,
+		string prompt,
+		AskSecretOptions? options = null)
+	{
+		// Secrets: prefill ONLY, never elicitation or sampling (security).
+		if (_prefillAnswers.TryGetValue(name, out var prefill))
+		{
+			return ValueTask.FromResult(prefill);
+		}
+
+		throw new McpInteractionException(
+			$"Secret prompt '{name}' requires a prefilled value. " +
+			$"Provide it as a tool argument 'answer:{name}'.");
+	}
+
+	public ValueTask<IReadOnlyList<int>> AskMultiChoiceAsync(
+		string name,
+		string prompt,
+		IReadOnlyList<string> choices,
+		IReadOnlyList<int>? defaultIndices = null,
+		AskMultiChoiceOptions? options = null)
+	{
+		if (_prefillAnswers.TryGetValue(name, out var prefill))
+		{
+			var indices = prefill
+				.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+				.Select(token => ResolveChoiceIndex(token, choices))
+				.ToArray();
+			return ValueTask.FromResult<IReadOnlyList<int>>(indices);
+		}
+
+		if (defaultIndices is { Count: > 0 })
+		{
+			return ValueTask.FromResult(defaultIndices);
+		}
+
+		if (_mode == InteractivityMode.PrefillThenDefaults)
+		{
+			return ValueTask.FromResult<IReadOnlyList<int>>([]);
+		}
+
+		throw new McpInteractionException(
+			$"Interactive prompt '{name}' requires a value. " +
+			$"Provide it as a tool argument 'answer:{name}' (comma-separated indices or values). " +
+			$"Choices: {string.Join(", ", choices)}");
+	}
+
+	public ValueTask WriteProgressAsync(string label, double? percent, CancellationToken cancellationToken) =>
+		ValueTask.CompletedTask;
+
+	public ValueTask WriteStatusAsync(string text, CancellationToken cancellationToken) =>
+		ValueTask.CompletedTask;
+
+	public ValueTask ClearScreenAsync(CancellationToken cancellationToken) =>
+		ValueTask.CompletedTask;
+
+	public ValueTask<TResult> DispatchAsync<TResult>(
+		InteractionRequest<TResult> request,
+		CancellationToken cancellationToken) =>
+		throw new NotSupportedException(
+			"Custom interaction dispatch is not supported in MCP mode. " +
+			"Consider marking the command as AutomationHidden().");
+
+	private static int ResolveChoiceIndex(string value, IReadOnlyList<string> choices)
+	{
+		// Try exact match by value.
+		for (var i = 0; i < choices.Count; i++)
+		{
+			if (string.Equals(choices[i], value, StringComparison.OrdinalIgnoreCase))
+			{
+				return i;
+			}
+		}
+
+		// Try numeric index.
+		if (int.TryParse(value, System.Globalization.CultureInfo.InvariantCulture, out var index) && index >= 0 && index < choices.Count)
+		{
+			return index;
+		}
+
+		throw new McpInteractionException(
+			$"Cannot resolve choice '{value}'. Available: {string.Join(", ", choices)}");
+	}
+}

--- a/src/Repl.Mcp/McpInteractionChannel.cs
+++ b/src/Repl.Mcp/McpInteractionChannel.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -28,7 +29,7 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 		_progressToken = progressToken;
 	}
 
-	public ValueTask<int> AskChoiceAsync(
+	public async ValueTask<int> AskChoiceAsync(
 		string name,
 		string prompt,
 		IReadOnlyList<string> choices,
@@ -37,19 +38,28 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 	{
 		if (_prefillAnswers.TryGetValue(name, out var prefill))
 		{
-			return ValueTask.FromResult(ResolveChoiceIndex(prefill, choices));
+			return ResolveChoiceIndex(prefill, choices);
 		}
 
-		// Tier 2/3 (elicitation/sampling) deferred to future implementation.
+		if (await TryElicitChoiceAsync(name, prompt, choices).ConfigureAwait(false) is { } elicited)
+		{
+			return ResolveChoiceIndex(elicited, choices);
+		}
+
+		if (await TrySampleAsync($"{prompt}\nChoose one: {string.Join(", ", choices)}")
+			.ConfigureAwait(false) is { } sampled)
+		{
+			return ResolveChoiceIndex(sampled, choices);
+		}
 
 		if (defaultIndex.HasValue)
 		{
-			return ValueTask.FromResult(defaultIndex.Value);
+			return defaultIndex.Value;
 		}
 
 		if (_mode == InteractivityMode.PrefillThenDefaults)
 		{
-			return ValueTask.FromResult(0);
+			return 0;
 		}
 
 		throw new McpInteractionException(
@@ -57,7 +67,7 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 			$"Provide it as a tool argument 'answer:{name}'. Choices: {string.Join(", ", choices)}");
 	}
 
-	public ValueTask<bool> AskConfirmationAsync(
+	public async ValueTask<bool> AskConfirmationAsync(
 		string name,
 		string prompt,
 		bool defaultValue = false,
@@ -65,29 +75,23 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 	{
 		if (_prefillAnswers.TryGetValue(name, out var prefill))
 		{
-			return ValueTask.FromResult(
-				string.Equals(prefill, "true", StringComparison.OrdinalIgnoreCase)
-				|| string.Equals(prefill, "yes", StringComparison.OrdinalIgnoreCase)
-				|| string.Equals(prefill, "y", StringComparison.OrdinalIgnoreCase)
-				|| string.Equals(prefill, "1", StringComparison.Ordinal));
+			return ParseBool(prefill);
 		}
 
-		if (_mode is InteractivityMode.PrefillThenDefaults)
+		if (await TryElicitBoolAsync(name, prompt, defaultValue).ConfigureAwait(false) is { } elicited)
 		{
-			return ValueTask.FromResult(defaultValue);
+			return elicited;
 		}
 
-		if (defaultValue || _mode is not InteractivityMode.PrefillThenFail)
+		if (await TrySampleAsync($"{prompt} (yes/no)").ConfigureAwait(false) is { } sampled)
 		{
-			return ValueTask.FromResult(defaultValue);
+			return ParseBool(sampled);
 		}
 
-		throw new McpInteractionException(
-			$"Interactive prompt '{name}' requires a value. " +
-			$"Provide it as a tool argument 'answer:{name}' (true/false).");
+		return defaultValue;
 	}
 
-	public ValueTask<string> AskTextAsync(
+	public async ValueTask<string> AskTextAsync(
 		string name,
 		string prompt,
 		string? defaultValue = null,
@@ -95,17 +99,27 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 	{
 		if (_prefillAnswers.TryGetValue(name, out var prefill))
 		{
-			return ValueTask.FromResult(prefill);
+			return prefill;
+		}
+
+		if (await TryElicitTextAsync(name, prompt, defaultValue).ConfigureAwait(false) is { } elicited)
+		{
+			return elicited;
+		}
+
+		if (await TrySampleAsync(prompt).ConfigureAwait(false) is { } sampled)
+		{
+			return sampled;
 		}
 
 		if (defaultValue is not null)
 		{
-			return ValueTask.FromResult(defaultValue);
+			return defaultValue;
 		}
 
 		if (_mode == InteractivityMode.PrefillThenDefaults)
 		{
-			return ValueTask.FromResult(string.Empty);
+			return string.Empty;
 		}
 
 		throw new McpInteractionException(
@@ -129,7 +143,7 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 			$"Provide it as a tool argument 'answer:{name}'.");
 	}
 
-	public ValueTask<IReadOnlyList<int>> AskMultiChoiceAsync(
+	public async ValueTask<IReadOnlyList<int>> AskMultiChoiceAsync(
 		string name,
 		string prompt,
 		IReadOnlyList<string> choices,
@@ -138,26 +152,28 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 	{
 		if (_prefillAnswers.TryGetValue(name, out var prefill))
 		{
-			var indices = prefill
-				.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-				.Select(token => ResolveChoiceIndex(token, choices))
-				.ToArray();
-			return ValueTask.FromResult<IReadOnlyList<int>>(indices);
+			return ParseMultiChoice(prefill, choices);
+		}
+
+		if (await TrySampleAsync($"{prompt}\nSelect from: {string.Join(", ", choices)}")
+			.ConfigureAwait(false) is { } sampled)
+		{
+			return ParseMultiChoice(sampled, choices);
 		}
 
 		if (defaultIndices is { Count: > 0 })
 		{
-			return ValueTask.FromResult(defaultIndices);
+			return defaultIndices;
 		}
 
 		if (_mode == InteractivityMode.PrefillThenDefaults)
 		{
-			return ValueTask.FromResult<IReadOnlyList<int>>([]);
+			return [];
 		}
 
 		throw new McpInteractionException(
 			$"Interactive prompt '{name}' requires a value. " +
-			$"Provide it as a tool argument 'answer:{name}' (comma-separated indices or values). " +
+			$"Provide it as a tool argument 'answer:{name}' (comma-separated). " +
 			$"Choices: {string.Join(", ", choices)}");
 	}
 
@@ -177,8 +193,22 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 		}
 	}
 
-	public ValueTask WriteStatusAsync(string text, CancellationToken cancellationToken) =>
-		ValueTask.CompletedTask;
+	public async ValueTask WriteStatusAsync(string text, CancellationToken cancellationToken)
+	{
+		if (_server is null)
+		{
+			return;
+		}
+
+		await _server.SendNotificationAsync(
+			NotificationMethods.LoggingMessageNotification,
+			new LoggingMessageNotificationParams
+			{
+				Level = LoggingLevel.Info,
+				Data = JsonSerializer.SerializeToElement(text, McpJsonContext.Default.String),
+			},
+			cancellationToken: cancellationToken).ConfigureAwait(false);
+	}
 
 	public ValueTask ClearScreenAsync(CancellationToken cancellationToken) =>
 		ValueTask.CompletedTask;
@@ -190,9 +220,129 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 			"Custom interaction dispatch is not supported in MCP mode. " +
 			"Consider marking the command as AutomationHidden().");
 
+	// ── Elicitation (Tier 2) ───────────────────────────────────────────
+
+	private async Task<string?> TryElicitChoiceAsync(string name, string prompt, IReadOnlyList<string> choices)
+	{
+		if (!CanElicit)
+		{
+			return null;
+		}
+
+		var result = await _server!.ElicitAsync(new ElicitRequestParams
+		{
+			Message = prompt,
+			RequestedSchema = new ElicitRequestParams.RequestSchema
+			{
+				Properties = new Dictionary<string, ElicitRequestParams.PrimitiveSchemaDefinition>(StringComparer.Ordinal)
+				{
+					[name] = new ElicitRequestParams.UntitledSingleSelectEnumSchema
+					{
+						Enum = choices.ToList(),
+					},
+				},
+			},
+		}).ConfigureAwait(false);
+
+		return ExtractElicitedString(result, name);
+	}
+
+	private async Task<bool?> TryElicitBoolAsync(string name, string prompt, bool defaultValue)
+	{
+		if (!CanElicit)
+		{
+			return null;
+		}
+
+		var result = await _server!.ElicitAsync(new ElicitRequestParams
+		{
+			Message = prompt,
+			RequestedSchema = new ElicitRequestParams.RequestSchema
+			{
+				Properties = new Dictionary<string, ElicitRequestParams.PrimitiveSchemaDefinition>(StringComparer.Ordinal)
+				{
+					[name] = new ElicitRequestParams.BooleanSchema(),
+				},
+			},
+		}).ConfigureAwait(false);
+
+		if (result.IsAccepted && result.Content?.TryGetValue(name, out var value) is true)
+		{
+			return value.ValueKind == JsonValueKind.True;
+		}
+
+		return null;
+	}
+
+	private async Task<string?> TryElicitTextAsync(string name, string prompt, string? defaultValue)
+	{
+		if (!CanElicit)
+		{
+			return null;
+		}
+
+		var result = await _server!.ElicitAsync(new ElicitRequestParams
+		{
+			Message = prompt,
+			RequestedSchema = new ElicitRequestParams.RequestSchema
+			{
+				Properties = new Dictionary<string, ElicitRequestParams.PrimitiveSchemaDefinition>(StringComparer.Ordinal)
+				{
+					[name] = new ElicitRequestParams.StringSchema(),
+				},
+			},
+		}).ConfigureAwait(false);
+
+		return ExtractElicitedString(result, name);
+	}
+
+	private bool CanElicit =>
+		_mode is InteractivityMode.PrefillThenElicitation
+		&& _server?.ClientCapabilities?.Elicitation is not null;
+
+	private static string? ExtractElicitedString(ElicitResult result, string name)
+	{
+		if (!result.IsAccepted || result.Content?.TryGetValue(name, out var value) is not true)
+		{
+			return null;
+		}
+
+		return value.ValueKind == JsonValueKind.String ? value.GetString() : value.GetRawText();
+	}
+
+	// ── Sampling (Tier 3) ──────────────────────────────────────────────
+
+	private async Task<string?> TrySampleAsync(string prompt)
+	{
+		if (!CanSample)
+		{
+			return null;
+		}
+
+		var result = await _server!.SampleAsync(new CreateMessageRequestParams
+		{
+			Messages =
+			[
+				new SamplingMessage
+				{
+					Role = Role.User,
+					Content = [new TextContentBlock { Text = prompt }],
+				},
+			],
+			MaxTokens = 100,
+		}).ConfigureAwait(false);
+
+		return result.Content?.OfType<TextContentBlock>().FirstOrDefault()?.Text;
+	}
+
+	private bool CanSample =>
+		_mode is InteractivityMode.PrefillThenElicitation or InteractivityMode.PrefillThenSampling
+		&& _server?.ClientCapabilities?.Sampling is not null;
+
+	// ── Helpers ─────────────────────────────────────────────────────────
+
 	private static int ResolveChoiceIndex(string value, IReadOnlyList<string> choices)
 	{
-		// Try exact match by value.
 		for (var i = 0; i < choices.Count; i++)
 		{
 			if (string.Equals(choices[i], value, StringComparison.OrdinalIgnoreCase))
@@ -201,8 +351,8 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 			}
 		}
 
-		// Try numeric index.
-		if (int.TryParse(value, System.Globalization.CultureInfo.InvariantCulture, out var index) && index >= 0 && index < choices.Count)
+		if (int.TryParse(value, System.Globalization.CultureInfo.InvariantCulture, out var index)
+			&& index >= 0 && index < choices.Count)
 		{
 			return index;
 		}
@@ -210,4 +360,15 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 		throw new McpInteractionException(
 			$"Cannot resolve choice '{value}'. Available: {string.Join(", ", choices)}");
 	}
+
+	private static bool ParseBool(string value) =>
+		string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)
+		|| string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase)
+		|| string.Equals(value, "y", StringComparison.OrdinalIgnoreCase)
+		|| string.Equals(value, "1", StringComparison.Ordinal);
+
+	private static int[] ParseMultiChoice(string value, IReadOnlyList<string> choices) =>
+		value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+			.Select(token => ResolveChoiceIndex(token, choices))
+			.ToArray();
 }

--- a/src/Repl.Mcp/McpInteractionChannel.cs
+++ b/src/Repl.Mcp/McpInteractionChannel.cs
@@ -1,3 +1,6 @@
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
 using Repl.Interaction;
 
 namespace Repl.Mcp;
@@ -10,13 +13,19 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 {
 	private readonly IReadOnlyDictionary<string, string> _prefillAnswers;
 	private readonly InteractivityMode _mode;
+	private readonly McpServer? _server;
+	private readonly ProgressToken? _progressToken;
 
 	public McpInteractionChannel(
 		IReadOnlyDictionary<string, string> prefillAnswers,
-		InteractivityMode mode)
+		InteractivityMode mode,
+		McpServer? server = null,
+		ProgressToken? progressToken = null)
 	{
 		_prefillAnswers = prefillAnswers;
 		_mode = mode;
+		_server = server;
+		_progressToken = progressToken;
 	}
 
 	public ValueTask<int> AskChoiceAsync(
@@ -152,8 +161,21 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 			$"Choices: {string.Join(", ", choices)}");
 	}
 
-	public ValueTask WriteProgressAsync(string label, double? percent, CancellationToken cancellationToken) =>
-		ValueTask.CompletedTask;
+	public async ValueTask WriteProgressAsync(string label, double? percent, CancellationToken cancellationToken)
+	{
+		if (_server is not null && _progressToken is { } token)
+		{
+			await _server.NotifyProgressAsync(
+				token,
+				new ProgressNotificationValue
+				{
+					Progress = (float)(percent ?? 0),
+					Total = 100f,
+					Message = label,
+				},
+				cancellationToken: cancellationToken).ConfigureAwait(false);
+		}
+	}
 
 	public ValueTask WriteStatusAsync(string text, CancellationToken cancellationToken) =>
 		ValueTask.CompletedTask;

--- a/src/Repl.Mcp/McpInteractionChannel.cs
+++ b/src/Repl.Mcp/McpInteractionChannel.cs
@@ -88,7 +88,7 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 			return ParseBool(sampled);
 		}
 
-		if (_mode == InteractivityMode.PrefillThenFail && !defaultValue)
+		if (_mode == InteractivityMode.PrefillThenFail)
 		{
 			throw new McpInteractionException(
 				$"Interactive prompt '{name}' requires a value. " +

--- a/src/Repl.Mcp/McpInteractionChannel.cs
+++ b/src/Repl.Mcp/McpInteractionChannel.cs
@@ -159,13 +159,13 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 	{
 		if (_prefillAnswers.TryGetValue(name, out var prefill))
 		{
-			return ParseMultiChoice(prefill, choices);
+			return ParseMultiChoice(prefill, choices, options);
 		}
 
 		if (await TrySampleAsync($"{prompt}\nSelect from: {string.Join(", ", choices)}")
 			.ConfigureAwait(false) is { } sampled)
 		{
-			return ParseMultiChoice(sampled, choices);
+			return ParseMultiChoice(sampled, choices, options);
 		}
 
 		if (defaultIndices is { Count: > 0 })
@@ -348,8 +348,13 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 
 	// ── Helpers ─────────────────────────────────────────────────────────
 
+	/// <summary>
+	/// Matches a choice value by exact name then unambiguous prefix — same logic as the
+	/// console interaction channel's MatchChoiceByName.
+	/// </summary>
 	private static int ResolveChoiceIndex(string value, IReadOnlyList<string> choices)
 	{
+		// Exact match.
 		for (var i = 0; i < choices.Count; i++)
 		{
 			if (string.Equals(choices[i], value, StringComparison.OrdinalIgnoreCase))
@@ -358,18 +363,74 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 			}
 		}
 
+		// Unambiguous prefix match.
+		var prefixMatch = -1;
+		for (var i = 0; i < choices.Count; i++)
+		{
+			if (choices[i].StartsWith(value, StringComparison.OrdinalIgnoreCase))
+			{
+				if (prefixMatch >= 0)
+				{
+					prefixMatch = -1;
+					break; // Ambiguous — more than one match.
+				}
+
+				prefixMatch = i;
+			}
+		}
+
+		if (prefixMatch >= 0)
+		{
+			return prefixMatch;
+		}
+
 		throw new McpInteractionException(
 			$"Cannot resolve choice '{value}'. Available: {string.Join(", ", choices)}");
 	}
 
-	private static bool ParseBool(string value) =>
-		string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)
-		|| string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase)
-		|| string.Equals(value, "y", StringComparison.OrdinalIgnoreCase)
-		|| string.Equals(value, "1", StringComparison.Ordinal);
+	private static bool ParseBool(string value)
+	{
+		if (string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(value, "y", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(value, "1", StringComparison.Ordinal))
+		{
+			return true;
+		}
 
-	private static int[] ParseMultiChoice(string value, IReadOnlyList<string> choices) =>
-		value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+		if (string.Equals(value, "false", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(value, "no", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(value, "n", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(value, "0", StringComparison.Ordinal))
+		{
+			return false;
+		}
+
+		throw new McpInteractionException(
+			$"Cannot parse '{value}' as boolean. Use yes/no, true/false, y/n, or 1/0.");
+	}
+
+	private static int[] ParseMultiChoice(
+		string value,
+		IReadOnlyList<string> choices,
+		AskMultiChoiceOptions? options = null)
+	{
+		var indices = value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
 			.Select(token => ResolveChoiceIndex(token, choices))
 			.ToArray();
+
+		if (options?.MinSelections is { } min && indices.Length < min)
+		{
+			throw new McpInteractionException(
+				$"At least {min} selection(s) required, but got {indices.Length}.");
+		}
+
+		if (options?.MaxSelections is { } max && indices.Length > max)
+		{
+			throw new McpInteractionException(
+				$"At most {max} selection(s) allowed, but got {indices.Length}.");
+		}
+
+		return indices;
+	}
 }

--- a/src/Repl.Mcp/McpInteractionChannel.cs
+++ b/src/Repl.Mcp/McpInteractionChannel.cs
@@ -70,7 +70,7 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 	public async ValueTask<bool> AskConfirmationAsync(
 		string name,
 		string prompt,
-		bool defaultValue = false,
+		bool? defaultValue = null,
 		AskOptions? options = null)
 	{
 		if (_prefillAnswers.TryGetValue(name, out var prefill))
@@ -78,7 +78,7 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 			return ParseBool(prefill);
 		}
 
-		if (await TryElicitBoolAsync(name, prompt, defaultValue).ConfigureAwait(false) is { } elicited)
+		if (await TryElicitBoolAsync(name, prompt, defaultValue ?? false).ConfigureAwait(false) is { } elicited)
 		{
 			return elicited;
 		}
@@ -88,14 +88,19 @@ internal sealed class McpInteractionChannel : IReplInteractionChannel
 			return ParseBool(sampled);
 		}
 
-		if (_mode == InteractivityMode.PrefillThenFail)
+		if (defaultValue.HasValue)
 		{
-			throw new McpInteractionException(
-				$"Interactive prompt '{name}' requires a value. " +
-				$"Provide it as a tool argument 'answer:{name}' (true/false).");
+			return defaultValue.Value;
 		}
 
-		return defaultValue;
+		if (_mode == InteractivityMode.PrefillThenDefaults)
+		{
+			return false;
+		}
+
+		throw new McpInteractionException(
+			$"Interactive prompt '{name}' requires a value. " +
+			$"Provide it as a tool argument 'answer:{name}' (true/false).");
 	}
 
 	public async ValueTask<string> AskTextAsync(

--- a/src/Repl.Mcp/McpInteractionException.cs
+++ b/src/Repl.Mcp/McpInteractionException.cs
@@ -1,0 +1,6 @@
+namespace Repl.Mcp;
+
+/// <summary>
+/// Thrown when an interactive prompt cannot be resolved in MCP mode.
+/// </summary>
+public sealed class McpInteractionException(string message) : InvalidOperationException(message);

--- a/src/Repl.Mcp/McpJsonContext.cs
+++ b/src/Repl.Mcp/McpJsonContext.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Repl.Mcp;
+
+/// <summary>
+/// Source-generated JSON serialization context for trim-safe serialization.
+/// </summary>
+[JsonSerializable(typeof(JsonObject))]
+internal sealed partial class McpJsonContext : JsonSerializerContext;

--- a/src/Repl.Mcp/McpJsonContext.cs
+++ b/src/Repl.Mcp/McpJsonContext.cs
@@ -7,4 +7,6 @@ namespace Repl.Mcp;
 /// Source-generated JSON serialization context for trim-safe serialization.
 /// </summary>
 [JsonSerializable(typeof(JsonObject))]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(bool))]
 internal sealed partial class McpJsonContext : JsonSerializerContext;

--- a/src/Repl.Mcp/McpModule.cs
+++ b/src/Repl.Mcp/McpModule.cs
@@ -1,0 +1,26 @@
+namespace Repl.Mcp;
+
+/// <summary>
+/// Registers the <c>mcp serve</c> command as a hidden protocol passthrough context.
+/// Follows the same pattern as <c>ShellCompletionModule</c>.
+/// </summary>
+internal sealed class McpModule(ReplMcpServerOptions options) : IReplModule
+{
+	public void Map(IReplMap map)
+	{
+		map.Context(options.CommandName, mcp =>
+		{
+			mcp.Map("serve",
+				async (IReplIoContext io, IServiceProvider services, ICoreReplApp app, CancellationToken ct) =>
+				{
+					var handler = new McpServerHandler(app, options, services);
+					await handler.RunAsync(io, ct).ConfigureAwait(false);
+					return Results.Exit(0);
+				})
+				.WithDescription("Start MCP stdio server for agent integration.")
+				.AsProtocolPassthrough()
+				.Hidden();
+		})
+		.Hidden();
+	}
+}

--- a/src/Repl.Mcp/McpModule.cs
+++ b/src/Repl.Mcp/McpModule.cs
@@ -13,7 +13,11 @@ internal sealed class McpModule(ReplMcpServerOptions options) : IReplModule
 			mcp.Map("serve",
 				async (IReplIoContext io, IServiceProvider services, ICoreReplApp app, CancellationToken ct) =>
 				{
-					var handler = new McpServerHandler(app, options, services);
+					// Prefer DI-registered options (from AddReplMcpServer) over the
+					// instance captured at registration time, so both configuration
+					// paths converge on a single options instance.
+					var resolved = services.GetService(typeof(ReplMcpServerOptions)) as ReplMcpServerOptions ?? options;
+					var handler = new McpServerHandler(app, resolved, services);
 					await handler.RunAsync(io, ct).ConfigureAwait(false);
 					return Results.Exit(0);
 				})

--- a/src/Repl.Mcp/McpModule.cs
+++ b/src/Repl.Mcp/McpModule.cs
@@ -8,7 +8,7 @@ internal sealed class McpModule(ReplMcpServerOptions options) : IReplModule
 {
 	public void Map(IReplMap map)
 	{
-		map.Context(options.CommandName, mcp =>
+		map.Context(options.ContextName, mcp =>
 		{
 			mcp.Map("serve",
 				async (IReplIoContext io, IServiceProvider services, ICoreReplApp app, CancellationToken ct) =>

--- a/src/Repl.Mcp/McpPromptRegistration.cs
+++ b/src/Repl.Mcp/McpPromptRegistration.cs
@@ -1,0 +1,6 @@
+namespace Repl;
+
+/// <summary>
+/// Registration entry for an explicit MCP prompt.
+/// </summary>
+internal sealed record McpPromptRegistration(string Name, Delegate Handler);

--- a/src/Repl.Mcp/McpReplExtensions.cs
+++ b/src/Repl.Mcp/McpReplExtensions.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.DependencyInjection;
+using Repl.Mcp;
+
+namespace Repl;
+
+/// <summary>
+/// Extension methods for integrating MCP server support into a Repl app.
+/// </summary>
+public static class McpReplExtensions
+{
+	/// <summary>
+	/// Registers MCP server services in the DI container.
+	/// </summary>
+	/// <param name="services">Service collection.</param>
+	/// <param name="configure">Optional configuration callback.</param>
+	/// <returns>The same service collection.</returns>
+	public static IServiceCollection AddReplMcpServer(
+		this IServiceCollection services,
+		Action<ReplMcpServerOptions>? configure = null)
+	{
+		var options = new ReplMcpServerOptions();
+		configure?.Invoke(options);
+		services.AddSingleton(options);
+		return services;
+	}
+
+	/// <summary>
+	/// Enables MCP server mode via <c>{commandName} serve</c>.
+	/// </summary>
+	/// <param name="app">Target Repl app.</param>
+	/// <param name="configure">Optional configuration callback.</param>
+	/// <returns>The same app instance.</returns>
+	public static ReplApp UseMcpServer(
+		this ReplApp app,
+		Action<ReplMcpServerOptions>? configure = null)
+	{
+		ArgumentNullException.ThrowIfNull(app);
+
+		var options = new ReplMcpServerOptions();
+		configure?.Invoke(options);
+
+		app.MapModule(
+			new McpModule(options),
+			static context => context.Channel is ReplRuntimeChannel.Cli);
+
+		return app;
+	}
+}

--- a/src/Repl.Mcp/McpReplExtensions.cs
+++ b/src/Repl.Mcp/McpReplExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
 using Repl.Mcp;
 
 namespace Repl;
@@ -44,5 +45,46 @@ public static class McpReplExtensions
 			static context => context.Channel is ReplRuntimeChannel.Cli);
 
 		return app;
+	}
+
+	/// <summary>
+	/// Builds <see cref="McpServerOptions"/> from the Repl app's command graph.
+	/// Use this to integrate with custom transports (WebSocket, HTTP) or ASP.NET Core
+	/// without going through the <c>mcp serve</c> CLI command.
+	/// </summary>
+	/// <param name="app">The core Repl app.</param>
+	/// <param name="configure">Optional MCP configuration callback.</param>
+	/// <param name="services">Optional service provider for DI during tool dispatch.</param>
+	/// <returns>Ready-to-use <see cref="McpServerOptions"/> for <c>McpServer.Create</c> or ASP.NET integration.</returns>
+	public static McpServerOptions BuildMcpServerOptions(
+		this ICoreReplApp app,
+		Action<ReplMcpServerOptions>? configure = null,
+		IServiceProvider? services = null)
+	{
+		ArgumentNullException.ThrowIfNull(app);
+
+		var options = new ReplMcpServerOptions();
+		configure?.Invoke(options);
+
+		var previousProgrammatic = ReplSessionIO.IsProgrammatic;
+		ReplSessionIO.IsProgrammatic = true;
+		try
+		{
+			var model = app.CreateDocumentationModel();
+			var adapter = new McpToolAdapter(app, options, services ?? EmptyServiceProvider.Instance);
+			var separator = McpToolNameFlattener.ResolveSeparator(options.ToolNamingSeparator);
+			var handler = new McpServerHandler(app, options, services ?? EmptyServiceProvider.Instance);
+			return handler.BuildServerOptions(model, adapter, separator);
+		}
+		finally
+		{
+			ReplSessionIO.IsProgrammatic = previousProgrammatic;
+		}
+	}
+
+	private sealed class EmptyServiceProvider : IServiceProvider
+	{
+		public static readonly EmptyServiceProvider Instance = new();
+		public object? GetService(Type serviceType) => null;
 	}
 }

--- a/src/Repl.Mcp/McpSchemaGenerator.cs
+++ b/src/Repl.Mcp/McpSchemaGenerator.cs
@@ -113,6 +113,20 @@ internal static class McpSchemaGenerator
 		var (jsonType, format) = MapType(replType);
 		var prop = new JsonObject { ["type"] = jsonType };
 
+		if (string.Equals(jsonType, "array", StringComparison.Ordinal))
+		{
+			// Extract inner type from List<T> or T[].
+			var innerType = ExtractCollectionItemType(replType);
+			var (itemType, itemFormat) = MapScalarType(innerType);
+			var itemSchema = new JsonObject { ["type"] = itemType };
+			if (itemFormat is not null)
+			{
+				itemSchema["format"] = itemFormat;
+			}
+
+			prop["items"] = itemSchema;
+		}
+
 		if (format is not null)
 		{
 			prop["format"] = format;
@@ -126,7 +140,40 @@ internal static class McpSchemaGenerator
 		return prop;
 	}
 
-	private static (string Type, string? Format) MapType(string replType) => replType.ToLowerInvariant() switch
+	private static (string Type, string? Format) MapType(string replType)
+	{
+		// Collection types: List<T>, IList<T>, T[], IReadOnlyList<T>, etc.
+		if (replType.EndsWith("[]", StringComparison.Ordinal)
+			|| replType.StartsWith("List<", StringComparison.OrdinalIgnoreCase)
+			|| replType.StartsWith("IList<", StringComparison.OrdinalIgnoreCase)
+			|| replType.StartsWith("IReadOnlyList<", StringComparison.OrdinalIgnoreCase))
+		{
+			return ("array", null);
+		}
+
+		return MapScalarType(replType);
+	}
+
+	private static string ExtractCollectionItemType(string replType)
+	{
+		// T[] → T
+		if (replType.EndsWith("[]", StringComparison.Ordinal))
+		{
+			return replType[..^2];
+		}
+
+		// List<T>, IList<T>, IReadOnlyList<T> → T
+		var openBracket = replType.IndexOf('<');
+		var closeBracket = replType.LastIndexOf('>');
+		if (openBracket >= 0 && closeBracket > openBracket)
+		{
+			return replType[(openBracket + 1)..closeBracket].Trim();
+		}
+
+		return "string";
+	}
+
+	private static (string Type, string? Format) MapScalarType(string replType) => replType.ToLowerInvariant() switch
 	{
 		"string" or "alpha" or "custom" => ("string", null),
 		"int" or "integer" => ("integer", null),

--- a/src/Repl.Mcp/McpSchemaGenerator.cs
+++ b/src/Repl.Mcp/McpSchemaGenerator.cs
@@ -74,8 +74,9 @@ internal static class McpSchemaGenerator
 	/// Maps <see cref="CommandAnnotations"/> to MCP <see cref="ToolAnnotations"/>.
 	/// </summary>
 	/// <remarks>
-	/// Repl defaults <c>Destructive = false</c> (opt-in), unlike the SDK default of <c>true</c>.
-	/// Only flags explicitly set to <c>true</c> are emitted.
+	/// Repl defaults <c>Destructive = false</c> (opt-in), unlike the MCP spec default of <c>true</c>.
+	/// When <c>ReadOnly</c> is set, <c>DestructiveHint</c> is explicitly emitted as <c>false</c>
+	/// so agents don't require confirmation for read-only tools.
 	/// </remarks>
 	public static ToolAnnotations? MapAnnotations(CommandAnnotations? annotations)
 	{
@@ -86,7 +87,7 @@ internal static class McpSchemaGenerator
 
 		return new ToolAnnotations
 		{
-			DestructiveHint = annotations.Destructive ? true : null,
+			DestructiveHint = annotations.Destructive ? true : annotations.ReadOnly ? false : null,
 			ReadOnlyHint = annotations.ReadOnly ? true : null,
 			IdempotentHint = annotations.Idempotent ? true : null,
 			OpenWorldHint = annotations.OpenWorld ? true : null,

--- a/src/Repl.Mcp/McpSchemaGenerator.cs
+++ b/src/Repl.Mcp/McpSchemaGenerator.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using ModelContextProtocol.Protocol;
+using Repl.Documentation;
+
+namespace Repl.Mcp;
+
+/// <summary>
+/// Generates JSON Schema from <see cref="ReplDocCommand"/> metadata
+/// and maps <see cref="CommandAnnotations"/> to MCP <see cref="ToolAnnotations"/>.
+/// </summary>
+internal static class McpSchemaGenerator
+{
+	/// <summary>
+	/// Builds a JSON Schema <c>inputSchema</c> from command arguments and options.
+	/// </summary>
+	public static JsonElement BuildInputSchema(ReplDocCommand command)
+	{
+		var properties = new JsonObject();
+		var required = new JsonArray();
+
+		foreach (var arg in command.Arguments)
+		{
+			var prop = CreatePropertySchema(arg.Type, arg.Description);
+			properties[arg.Name] = prop;
+			if (arg.Required)
+			{
+				required.Add((JsonNode)arg.Name);
+			}
+		}
+
+		foreach (var opt in command.Options)
+		{
+			var prop = CreatePropertySchema(opt.Type, opt.Description);
+
+			if (opt.EnumValues is { Count: > 0 })
+			{
+				var enumArray = new JsonArray();
+				foreach (var v in opt.EnumValues)
+				{
+					enumArray.Add((JsonNode)v);
+				}
+
+				prop["enum"] = enumArray;
+			}
+
+			if (opt.DefaultValue is not null)
+			{
+				prop["default"] = opt.DefaultValue;
+			}
+
+			properties[opt.Name] = prop;
+			if (opt.Required)
+			{
+				required.Add((JsonNode)opt.Name);
+			}
+		}
+
+		var schema = new JsonObject
+		{
+			["type"] = "object",
+			["properties"] = properties,
+		};
+
+		if (required.Count > 0)
+		{
+			schema["required"] = required;
+		}
+
+		return JsonSerializer.SerializeToElement(schema, McpJsonContext.Default.JsonObject);
+	}
+
+	/// <summary>
+	/// Maps <see cref="CommandAnnotations"/> to MCP <see cref="ToolAnnotations"/>.
+	/// </summary>
+	/// <remarks>
+	/// Repl defaults <c>Destructive = false</c> (opt-in), unlike the SDK default of <c>true</c>.
+	/// Only flags explicitly set to <c>true</c> are emitted.
+	/// </remarks>
+	public static ToolAnnotations? MapAnnotations(CommandAnnotations? annotations)
+	{
+		if (annotations is null)
+		{
+			return null;
+		}
+
+		return new ToolAnnotations
+		{
+			DestructiveHint = annotations.Destructive ? true : null,
+			ReadOnlyHint = annotations.ReadOnly ? true : null,
+			IdempotentHint = annotations.Idempotent ? true : null,
+			OpenWorldHint = annotations.OpenWorld ? true : null,
+		};
+	}
+
+	/// <summary>
+	/// Builds the MCP tool description from command metadata.
+	/// </summary>
+	public static string BuildDescription(ReplDocCommand command)
+	{
+		if (string.IsNullOrWhiteSpace(command.Details))
+		{
+			return command.Description ?? command.Path;
+		}
+
+		return string.IsNullOrWhiteSpace(command.Description)
+			? command.Details
+			: $"{command.Description}\n\n{command.Details}";
+	}
+
+	private static JsonObject CreatePropertySchema(string replType, string? description)
+	{
+		var (jsonType, format) = MapType(replType);
+		var prop = new JsonObject { ["type"] = jsonType };
+
+		if (format is not null)
+		{
+			prop["format"] = format;
+		}
+
+		if (description is not null)
+		{
+			prop["description"] = description;
+		}
+
+		return prop;
+	}
+
+	private static (string Type, string? Format) MapType(string replType) => replType.ToLowerInvariant() switch
+	{
+		"string" or "alpha" or "custom" => ("string", null),
+		"int" or "integer" => ("integer", null),
+		"long" => ("integer", null),
+		"bool" or "boolean" => ("boolean", null),
+		"double" or "decimal" => ("number", null),
+		"email" => ("string", "email"),
+		"guid" => ("string", "uuid"),
+		"date" => ("string", "date"),
+		"datetime" => ("string", "date-time"),
+		"datetimeoffset" => ("string", "date-time"),
+		"uri" or "url" => ("string", "uri"),
+		"urn" => ("string", "urn"),
+		"time" => ("string", "time"),
+		"timespan" => ("string", "duration"),
+		"date-range" => ("string", null),
+		"datetime-range" => ("string", null),
+		"datetimeoffset-range" => ("string", null),
+		_ => ("string", null),
+	};
+}

--- a/src/Repl.Mcp/McpSchemaGenerator.cs
+++ b/src/Repl.Mcp/McpSchemaGenerator.cs
@@ -142,11 +142,12 @@ internal static class McpSchemaGenerator
 
 	private static (string Type, string? Format) MapType(string replType)
 	{
-		// Collection types: List<T>, IList<T>, T[], IReadOnlyList<T>, etc.
+		// Collection types: List<T>, IList<T>, T[], IReadOnlyList<T>, IEnumerable<T>, etc.
 		if (replType.EndsWith("[]", StringComparison.Ordinal)
 			|| replType.StartsWith("List<", StringComparison.OrdinalIgnoreCase)
 			|| replType.StartsWith("IList<", StringComparison.OrdinalIgnoreCase)
-			|| replType.StartsWith("IReadOnlyList<", StringComparison.OrdinalIgnoreCase))
+			|| replType.StartsWith("IReadOnlyList<", StringComparison.OrdinalIgnoreCase)
+			|| replType.StartsWith("IEnumerable<", StringComparison.OrdinalIgnoreCase))
 		{
 			return ("array", null);
 		}

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -150,7 +150,8 @@ internal sealed class McpServerHandler
 					var result = await adapter.InvokeAsync(
 						resourceName,
 						new Dictionary<string, System.Text.Json.JsonElement>(StringComparer.Ordinal),
-						server: null!,
+						server: null,
+						progressToken: null,
 						ct).ConfigureAwait(false);
 
 					var text = result.Content?.FirstOrDefault() is TextContentBlock block

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -1,0 +1,123 @@
+using System.Diagnostics.CodeAnalysis;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Repl.Documentation;
+
+namespace Repl.Mcp;
+
+/// <summary>
+/// Orchestrates the MCP server lifecycle: builds the documentation model,
+/// generates MCP primitives, and runs the server until cancellation.
+/// </summary>
+internal sealed class McpServerHandler
+{
+	private readonly ICoreReplApp _app;
+	private readonly ReplMcpServerOptions _options;
+	private readonly IServiceProvider _services;
+
+	public McpServerHandler(
+		ICoreReplApp app,
+		ReplMcpServerOptions options,
+		IServiceProvider services)
+	{
+		_app = app;
+		_options = options;
+		_services = services;
+	}
+
+	[UnconditionalSuppressMessage(
+		"Trimming",
+		"IL2026",
+		Justification = "MCP server handler runs in a context where all types are preserved.")]
+	public async Task RunAsync(IReplIoContext io, CancellationToken ct)
+	{
+		var model = _app.CreateDocumentationModel();
+		var adapter = new McpToolAdapter(_app, _options, _services);
+		var separator = McpToolNameFlattener.ResolveSeparator(_options.ToolNamingSeparator);
+		var tools = GenerateTools(model, adapter, separator);
+
+		var serverName = _options.ServerName
+			?? model.App.Name
+			?? "repl-mcp-server";
+		var serverVersion = _options.ServerVersion ?? "1.0.0";
+
+		var toolCollection = new McpServerPrimitiveCollection<McpServerTool>();
+		foreach (var tool in tools)
+		{
+			toolCollection.Add(tool);
+		}
+
+		// Use StdioServerTransport for stdio-based MCP server.
+		// The IReplIoContext streams are passthrough (stdin/stdout) when AsProtocolPassthrough is active.
+		_ = io; // io.Input/Output are TextReader/TextWriter, SDK needs raw streams via StdioServerTransport.
+		var transport = new StdioServerTransport(serverName);
+		try
+		{
+			var server = McpServer.Create(transport, new McpServerOptions
+			{
+				ServerInfo = new Implementation
+				{
+					Name = serverName,
+					Version = serverVersion,
+				},
+				Capabilities = new ServerCapabilities
+				{
+					Tools = new ToolsCapability { ListChanged = true },
+				},
+				ToolCollection = toolCollection,
+			}, serviceProvider: _services);
+			try
+			{
+				await server.RunAsync(ct).ConfigureAwait(false);
+			}
+			finally
+			{
+				await server.DisposeAsync().ConfigureAwait(false);
+			}
+		}
+		finally
+		{
+			await transport.DisposeAsync().ConfigureAwait(false);
+		}
+	}
+
+	private List<McpServerTool> GenerateTools(
+		ReplDocumentationModel model,
+		McpToolAdapter adapter,
+		char separator)
+	{
+		var tools = new List<McpServerTool>();
+		var nameSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+		foreach (var command in model.Commands)
+		{
+			if (command.IsHidden)
+			{
+				continue;
+			}
+
+			if (command.Annotations?.AutomationHidden == true)
+			{
+				continue;
+			}
+
+			if (_options.CommandFilter is { } filter && !filter(command))
+			{
+				continue;
+			}
+
+			var toolName = McpToolNameFlattener.Flatten(command.Path, separator);
+			if (!nameSet.Add(toolName))
+			{
+				throw new InvalidOperationException(
+					$"MCP tool name collision: '{toolName}' from route '{command.Path}'. " +
+					"Consider a different ToolNamingSeparator or rename one of the commands.");
+			}
+
+			adapter.RegisterRoute(toolName, command);
+			tools.Add(new ReplMcpServerTool(command, toolName, adapter));
+		}
+
+		return tools;
+	}
+}

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -36,8 +36,7 @@ internal sealed class McpServerHandler
 		var separator = McpToolNameFlattener.ResolveSeparator(_options.ToolNamingSeparator);
 		var serverOptions = BuildServerOptions(model, adapter, separator);
 
-		// AsProtocolPassthrough reserves stdin/stdout for the transport.
-		_ = io;
+		_ = io; // AsProtocolPassthrough reserves stdin/stdout for the transport.
 		var serverName = serverOptions.ServerInfo?.Name ?? "repl-mcp-server";
 		var transport = new StdioServerTransport(serverName);
 		try
@@ -69,57 +68,33 @@ internal sealed class McpServerHandler
 		McpToolAdapter adapter,
 		char separator)
 	{
-		var tools = GenerateTools(model, adapter, separator);
+		var tools = GenerateAllTools(model, adapter, separator);
 		var resources = GenerateResources(model, adapter, separator);
 		var prompts = CollectPrompts(model, adapter, separator);
 
 		var serverName = _options.ServerName ?? model.App.Name ?? "repl-mcp-server";
 		var serverVersion = _options.ServerVersion ?? "1.0.0";
 
-		var toolCollection = new McpServerPrimitiveCollection<McpServerTool>();
-		foreach (var tool in tools)
-		{
-			toolCollection.Add(tool);
-		}
-
-		var resourceCollection = new McpServerResourceCollection();
-		foreach (var resource in resources)
-		{
-			resourceCollection.Add(resource);
-		}
-
-		var promptCollection = new McpServerPrimitiveCollection<McpServerPrompt>();
-		foreach (var prompt in prompts)
-		{
-			promptCollection.Add(prompt);
-		}
-
-		var capabilities = new ServerCapabilities
-		{
-			Tools = new ToolsCapability { ListChanged = true },
-		};
-
-		if (resources.Count > 0)
-		{
-			capabilities.Resources = new ResourcesCapability { ListChanged = true };
-		}
-
-		if (prompts.Count > 0)
-		{
-			capabilities.Prompts = new PromptsCapability { ListChanged = true };
-		}
-
 		return new McpServerOptions
 		{
 			ServerInfo = new Implementation { Name = serverName, Version = serverVersion },
-			Capabilities = capabilities,
-			ToolCollection = toolCollection,
-			ResourceCollection = resourceCollection,
-			PromptCollection = promptCollection,
+			Capabilities = BuildCapabilities(resources, prompts),
+			ToolCollection = ToCollection(tools),
+			ResourceCollection = ToResourceCollection(resources),
+			PromptCollection = ToCollection(prompts),
 		};
 	}
 
-	private List<McpServerTool> GenerateTools(
+	// ── Tool generation ────────────────────────────────────────────────
+
+	/// <summary>
+	/// Generates all tools: regular commands + resource fallback tools + prompt fallback tools.
+	/// Resources and prompts are always also exposed as tools so agents that don't support
+	/// the native primitives (~61% for resources, ~62% for prompts) can still access them.
+	/// Use <see cref="ReplMcpServerOptions.ResourceFallbackToTools"/> and
+	/// <see cref="ReplMcpServerOptions.PromptFallbackToTools"/> to disable.
+	/// </summary>
+	private List<McpServerTool> GenerateAllTools(
 		ReplDocumentationModel model,
 		McpToolAdapter adapter,
 		char separator)
@@ -127,6 +102,9 @@ internal sealed class McpServerHandler
 		var tools = new List<McpServerTool>();
 		var nameSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+		// 1. Regular commands. Resource-only and prompt-only commands are handled
+		//    separately as fallback tools (opt-in). ReadOnly+AsResource commands
+		//    are regular tools (they have a behavioral annotation, not just a marker).
 		foreach (var command in model.Commands)
 		{
 			if (!IsToolCandidate(command))
@@ -134,22 +112,68 @@ internal sealed class McpServerHandler
 				continue;
 			}
 
-			var toolName = McpToolNameFlattener.Flatten(command.Path, separator);
-			if (!nameSet.Add(toolName))
+			if (command.IsPrompt)
 			{
-				throw new InvalidOperationException(
-					$"MCP tool name collision: '{toolName}' from route '{command.Path}'. " +
-					"Consider a different ToolNamingSeparator or rename one of the commands.");
+				continue; // Handled in phase 3 (prompt fallback).
 			}
 
-			adapter.RegisterRoute(toolName, command);
-			tools.Add(new ReplMcpServerTool(command, toolName, adapter));
+			if (command.IsResource && command.Annotations?.ReadOnly != true)
+			{
+				continue; // Resource-only (no ReadOnly annotation) — handled in phase 2.
+			}
+
+			AddTool(command, tools, nameSet, adapter, separator);
+		}
+
+		// 2. Resource fallback: resource-only commands as tools.
+		if (_options.ResourceFallbackToTools)
+		{
+			foreach (var resource in model.Resources)
+			{
+				var docCommand = model.Commands.FirstOrDefault(c =>
+					string.Equals(c.Path, resource.Path, StringComparison.OrdinalIgnoreCase));
+				if (docCommand is not null && IsToolCandidate(docCommand))
+				{
+					AddTool(docCommand, tools, nameSet, adapter, separator);
+				}
+			}
+		}
+
+		// 3. Prompt fallback: prompt commands as tools.
+		if (_options.PromptFallbackToTools)
+		{
+			foreach (var command in model.Commands)
+			{
+				if (command.IsPrompt && IsToolCandidate(command))
+				{
+					AddTool(command, tools, nameSet, adapter, separator);
+				}
+			}
 		}
 
 		return tools;
 	}
 
-	private static List<McpServerResource> GenerateResources(
+	private static void AddTool(
+		ReplDocCommand command,
+		List<McpServerTool> tools,
+		HashSet<string> nameSet,
+		McpToolAdapter adapter,
+		char separator)
+	{
+		var toolName = McpToolNameFlattener.Flatten(command.Path, separator);
+		if (!nameSet.Add(toolName))
+		{
+			return; // Already registered (e.g. ReadOnly command is both a tool and a resource).
+		}
+
+		adapter.RegisterRoute(toolName, command);
+		tools.Add(new ReplMcpServerTool(command, toolName, adapter));
+	}
+
+	// ── Resource generation ────────────────────────────────────────────
+
+	private List<McpServerResource> GenerateResources(
 		ReplDocumentationModel model,
 		McpToolAdapter adapter,
 		char separator)
@@ -158,26 +182,30 @@ internal sealed class McpServerHandler
 
 		foreach (var resource in model.Resources)
 		{
+			// Skip auto-promoted ReadOnly resources when opt-out is active.
+			// Auto-promoted resources are those in the Resources list but not
+			// explicitly marked AsResource() — they got there via ReadOnly.
+			var docCommand = model.Commands.FirstOrDefault(c =>
+				string.Equals(c.Path, resource.Path, StringComparison.OrdinalIgnoreCase));
+			if (!_options.AutoPromoteReadOnlyToResources
+				&& docCommand is not null
+				&& !docCommand.IsResource
+				&& docCommand.Annotations?.ReadOnly == true)
+			{
+				continue;
+			}
 			var resourceName = McpToolNameFlattener.Flatten(resource.Path, separator);
 			var uriTemplate = $"repl://{resourceName}";
-
-			// Create a resource that dispatches through the tool adapter.
 			var capturedPath = resource.Path;
+
 			var mcpResource = McpServerResource.Create(
 				async (CancellationToken ct) =>
 				{
-					// Resources dispatch through the same pipeline as tools.
 					var result = await adapter.InvokeAsync(
 						resourceName,
 						new Dictionary<string, System.Text.Json.JsonElement>(StringComparer.Ordinal),
-						server: null,
-						progressToken: null,
-						ct).ConfigureAwait(false);
-
-					var text = result.Content?.FirstOrDefault() is TextContentBlock block
-						? block.Text ?? ""
-						: "";
-					return text;
+						server: null, progressToken: null, ct).ConfigureAwait(false);
+					return result.Content?.OfType<TextContentBlock>().FirstOrDefault()?.Text ?? "";
 				},
 				new McpServerResourceCreateOptions
 				{
@@ -186,9 +214,6 @@ internal sealed class McpServerHandler
 					UriTemplate = uriTemplate,
 				});
 
-			// Ensure the resource route is registered.
-			var docCommand = model.Commands.FirstOrDefault(c =>
-				string.Equals(c.Path, capturedPath, StringComparison.OrdinalIgnoreCase));
 			if (docCommand is not null)
 			{
 				adapter.RegisterRoute(resourceName, docCommand);
@@ -200,6 +225,8 @@ internal sealed class McpServerHandler
 		return resources;
 	}
 
+	// ── Prompt generation ──────────────────────────────────────────────
+
 	private List<McpServerPrompt> CollectPrompts(
 		ReplDocumentationModel model,
 		McpToolAdapter adapter,
@@ -207,7 +234,6 @@ internal sealed class McpServerHandler
 	{
 		var prompts = new Dictionary<string, McpServerPrompt>(StringComparer.OrdinalIgnoreCase);
 
-		// 1. Prompts from AsPrompt() commands — dispatch through the pipeline.
 		foreach (var command in model.Commands)
 		{
 			if (!command.IsPrompt)
@@ -220,7 +246,6 @@ internal sealed class McpServerHandler
 			prompts[promptName] = CreatePipelinePrompt(promptName, command, adapter);
 		}
 
-		// 2. Explicit registrations via options.Prompt() — override on collision.
 		foreach (var registration in _options.Prompts)
 		{
 			prompts[registration.Name] = McpServerPrompt.Create(
@@ -231,10 +256,6 @@ internal sealed class McpServerHandler
 		return [.. prompts.Values];
 	}
 
-	/// <summary>
-	/// Creates a prompt that dispatches through the Repl pipeline.
-	/// The handler executes with its arguments and the return value becomes the prompt message.
-	/// </summary>
 	private static McpServerPrompt CreatePipelinePrompt(
 		string promptName,
 		ReplDocCommand command,
@@ -248,8 +269,7 @@ internal sealed class McpServerHandler
 					.ConfigureAwait(false);
 
 				var text = result.Content?.OfType<TextContentBlock>().FirstOrDefault()?.Text
-					?? command.Description
-					?? promptName;
+					?? command.Description ?? promptName;
 
 				return new GetPromptResult
 				{
@@ -283,11 +303,57 @@ internal sealed class McpServerHandler
 		return jsonArgs;
 	}
 
+	// ── Helpers ─────────────────────────────────────────────────────────
+
 	private bool IsToolCandidate(ReplDocCommand command) =>
 		!command.IsHidden
-		&& !command.IsPrompt
 		&& command.Annotations?.AutomationHidden != true
 		&& (_options.CommandFilter is not { } filter || filter(command));
+
+	private static ServerCapabilities BuildCapabilities(
+		List<McpServerResource> resources,
+		List<McpServerPrompt> prompts)
+	{
+		var capabilities = new ServerCapabilities
+		{
+			Tools = new ToolsCapability { ListChanged = true },
+		};
+
+		if (resources.Count > 0)
+		{
+			capabilities.Resources = new ResourcesCapability { ListChanged = true };
+		}
+
+		if (prompts.Count > 0)
+		{
+			capabilities.Prompts = new PromptsCapability { ListChanged = true };
+		}
+
+		return capabilities;
+	}
+
+	private static McpServerPrimitiveCollection<T> ToCollection<T>(IReadOnlyList<T> items)
+		where T : IMcpServerPrimitive
+	{
+		var collection = new McpServerPrimitiveCollection<T>();
+		foreach (var item in items)
+		{
+			collection.Add(item);
+		}
+
+		return collection;
+	}
+
+	private static McpServerResourceCollection ToResourceCollection(IReadOnlyList<McpServerResource> items)
+	{
+		var collection = new McpServerResourceCollection();
+		foreach (var item in items)
+		{
+			collection.Add(item);
+		}
+
+		return collection;
+	}
 
 	// ── list_changed on routing invalidation ───────────────────────────
 
@@ -308,8 +374,7 @@ internal sealed class McpServerHandler
 		_routingChangedHandler = (_, _) =>
 		{
 			var newModel = _app.CreateDocumentationModel();
-
-			RefreshCollection(toolCollection, GenerateTools(newModel, adapter, separator));
+			RefreshCollection(toolCollection, GenerateAllTools(newModel, adapter, separator));
 			RefreshCollection(resourceCollection, GenerateResources(newModel, adapter, separator));
 			RefreshCollection(promptCollection, CollectPrompts(newModel, adapter, separator));
 		};

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -371,24 +371,43 @@ internal sealed class McpServerHandler
 		McpServerResourceCollection resourceCollection,
 		McpServerPrimitiveCollection<McpServerPrompt> promptCollection)
 	{
-		lock (_refreshLock)
+		try
 		{
+			// Optimistic concurrency: build new collections with a temporary adapter
+			// so existing routes remain live during rebuild. Only swap at the end.
+			var tempAdapter = new McpToolAdapter(_app, _options, _services);
 			var previousProgrammatic = ReplSessionIO.IsProgrammatic;
 			ReplSessionIO.IsProgrammatic = true;
+			List<McpServerTool> newTools;
+			List<McpServerResource> newResources;
+			List<McpServerPrompt> newPrompts;
 			try
 			{
-				adapter.ClearRoutes();
 				var newModel = _app.CreateDocumentationModel();
 				var newCommandsByPath = newModel.Commands.ToDictionary(
 					c => c.Path, c => c, StringComparer.OrdinalIgnoreCase);
-				RefreshCollection(toolCollection, GenerateAllTools(newModel, adapter, separator, newCommandsByPath));
-				RefreshCollection(resourceCollection, GenerateResources(newModel, adapter, separator, newCommandsByPath));
-				RefreshCollection(promptCollection, CollectPrompts(newModel, adapter, separator));
+				newTools = GenerateAllTools(newModel, tempAdapter, separator, newCommandsByPath);
+				newResources = GenerateResources(newModel, tempAdapter, separator, newCommandsByPath);
+				newPrompts = CollectPrompts(newModel, tempAdapter, separator);
 			}
 			finally
 			{
 				ReplSessionIO.IsProgrammatic = previousProgrammatic;
 			}
+
+			// Atomic swap: replace the adapter routes and collections in one lock.
+			lock (_refreshLock)
+			{
+				adapter.ReplaceRoutes(tempAdapter);
+				RefreshCollection(toolCollection, newTools);
+				RefreshCollection(resourceCollection, newResources);
+				RefreshCollection(promptCollection, newPrompts);
+			}
+		}
+		catch (Exception)
+		{
+			// Timer callbacks must not throw — an unhandled exception here would
+			// crash the process. The server continues with stale routes.
 		}
 	}
 

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -45,7 +45,11 @@ internal sealed class McpServerHandler
 			var server = McpServer.Create(transport, serverOptions, serviceProvider: _services);
 			try
 			{
-				SubscribeToRoutingChanges(server, adapter, separator, serverOptions.ToolCollection!);
+				SubscribeToRoutingChanges(
+					adapter, separator,
+					serverOptions.ToolCollection!,
+					serverOptions.ResourceCollection!,
+					serverOptions.PromptCollection!);
 				await server.RunAsync(ct).ConfigureAwait(false);
 			}
 			finally
@@ -289,28 +293,24 @@ internal sealed class McpServerHandler
 	private EventHandler? _routingChangedHandler;
 
 	private void SubscribeToRoutingChanges(
-		McpServer server,
 		McpToolAdapter adapter,
 		char separator,
-		McpServerPrimitiveCollection<McpServerTool> toolCollection)
+		McpServerPrimitiveCollection<McpServerTool> toolCollection,
+		McpServerResourceCollection resourceCollection,
+		McpServerPrimitiveCollection<McpServerPrompt> promptCollection)
 	{
 		if (_app is not CoreReplApp coreApp)
 		{
 			return;
 		}
 
-		_routingChangedHandler = (sender, args) =>
+		_routingChangedHandler = (_, _) =>
 		{
 			var newModel = _app.CreateDocumentationModel();
-			var newTools = GenerateTools(newModel, adapter, separator);
 
-			toolCollection.Clear();
-			foreach (var tool in newTools)
-			{
-				toolCollection.Add(tool);
-			}
-
-			// Collection mutations auto-emit list_changed via the SDK.
+			RefreshCollection(toolCollection, GenerateTools(newModel, adapter, separator));
+			RefreshCollection(resourceCollection, GenerateResources(newModel, adapter, separator));
+			RefreshCollection(promptCollection, CollectPrompts(newModel, adapter, separator));
 		};
 
 		coreApp.RoutingInvalidated += _routingChangedHandler;
@@ -322,6 +322,25 @@ internal sealed class McpServerHandler
 		{
 			coreApp.RoutingInvalidated -= _routingChangedHandler;
 			_routingChangedHandler = null;
+		}
+	}
+
+	private static void RefreshCollection<T>(McpServerPrimitiveCollection<T> collection, IReadOnlyList<T> items)
+		where T : IMcpServerPrimitive
+	{
+		collection.Clear();
+		foreach (var item in items)
+		{
+			collection.Add(item);
+		}
+	}
+
+	private static void RefreshCollection(McpServerResourceCollection collection, IReadOnlyList<McpServerResource> items)
+	{
+		collection.Clear();
+		foreach (var item in items)
+		{
+			collection.Add(item);
 		}
 	}
 }

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -40,9 +40,10 @@ internal sealed class McpServerHandler
 		var separator = McpToolNameFlattener.ResolveSeparator(_options.ToolNamingSeparator);
 		var serverOptions = BuildServerOptions(model, adapter, separator);
 
-		_ = io; // AsProtocolPassthrough reserves stdin/stdout for the transport.
 		var serverName = serverOptions.ServerInfo?.Name ?? "repl-mcp-server";
-		var transport = new StdioServerTransport(serverName);
+		var transport = _options.TransportFactory is { } factory
+			? factory(serverName, io)
+			: new StdioServerTransport(serverName);
 		try
 		{
 			var server = McpServer.Create(transport, serverOptions, serviceProvider: _services);

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -34,37 +34,45 @@ internal sealed class McpServerHandler
 	{
 		// Build the doc model with Programmatic channel so module presence
 		// predicates see the same channel as tool dispatch.
+		var previousProgrammatic = ReplSessionIO.IsProgrammatic;
 		ReplSessionIO.IsProgrammatic = true;
-		var model = _app.CreateDocumentationModel();
-		var adapter = new McpToolAdapter(_app, _options, _services);
-		var separator = McpToolNameFlattener.ResolveSeparator(_options.ToolNamingSeparator);
-		var serverOptions = BuildServerOptions(model, adapter, separator);
-
-		var serverName = serverOptions.ServerInfo?.Name ?? "repl-mcp-server";
-		var transport = _options.TransportFactory is { } factory
-			? factory(serverName, io)
-			: new StdioServerTransport(serverName);
 		try
 		{
-			var server = McpServer.Create(transport, serverOptions, serviceProvider: _services);
+			var model = _app.CreateDocumentationModel();
+			var adapter = new McpToolAdapter(_app, _options, _services);
+			var separator = McpToolNameFlattener.ResolveSeparator(_options.ToolNamingSeparator);
+			var serverOptions = BuildServerOptions(model, adapter, separator);
+
+			var serverName = serverOptions.ServerInfo?.Name ?? "repl-mcp-server";
+			var transport = _options.TransportFactory is { } factory
+				? factory(serverName, io)
+				: new StdioServerTransport(serverName);
 			try
 			{
-				SubscribeToRoutingChanges(
-					adapter, separator,
-					serverOptions.ToolCollection!,
-					serverOptions.ResourceCollection!,
-					serverOptions.PromptCollection!);
-				await server.RunAsync(ct).ConfigureAwait(false);
+				var server = McpServer.Create(transport, serverOptions, serviceProvider: _services);
+				try
+				{
+					SubscribeToRoutingChanges(
+						adapter, separator,
+						serverOptions.ToolCollection!,
+						serverOptions.ResourceCollection!,
+						serverOptions.PromptCollection!);
+					await server.RunAsync(ct).ConfigureAwait(false);
+				}
+				finally
+				{
+					UnsubscribeFromRoutingChanges();
+					await server.DisposeAsync().ConfigureAwait(false);
+				}
 			}
 			finally
 			{
-				UnsubscribeFromRoutingChanges();
-				await server.DisposeAsync().ConfigureAwait(false);
+				await transport.DisposeAsync().ConfigureAwait(false);
 			}
 		}
 		finally
 		{
-			await transport.DisposeAsync().ConfigureAwait(false);
+			ReplSessionIO.IsProgrammatic = previousProgrammatic;
 		}
 	}
 
@@ -73,8 +81,10 @@ internal sealed class McpServerHandler
 		McpToolAdapter adapter,
 		char separator)
 	{
-		var tools = GenerateAllTools(model, adapter, separator);
-		var resources = GenerateResources(model, adapter, separator);
+		var commandsByPath = model.Commands.ToDictionary(
+			c => c.Path, c => c, StringComparer.OrdinalIgnoreCase);
+		var tools = GenerateAllTools(model, adapter, separator, commandsByPath);
+		var resources = GenerateResources(model, adapter, separator, commandsByPath);
 		var prompts = CollectPrompts(model, adapter, separator);
 
 		var serverName = _options.ServerName ?? model.App.Name ?? "repl-mcp-server";
@@ -102,7 +112,8 @@ internal sealed class McpServerHandler
 	private List<McpServerTool> GenerateAllTools(
 		ReplDocumentationModel model,
 		McpToolAdapter adapter,
-		char separator)
+		char separator,
+		Dictionary<string, ReplDocCommand> commandsByPath)
 	{
 		var tools = new List<McpServerTool>();
 		var nameSet = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -135,9 +146,8 @@ internal sealed class McpServerHandler
 		{
 			foreach (var resource in model.Resources)
 			{
-				var docCommand = model.Commands.FirstOrDefault(c =>
-					string.Equals(c.Path, resource.Path, StringComparison.OrdinalIgnoreCase));
-				if (docCommand is not null && IsToolCandidate(docCommand))
+				if (commandsByPath.TryGetValue(resource.Path, out var docCommand)
+					&& IsToolCandidate(docCommand))
 				{
 					AddTool(docCommand, tools, nameSet, adapter, separator);
 				}
@@ -193,14 +203,14 @@ internal sealed class McpServerHandler
 	private List<McpServerResource> GenerateResources(
 		ReplDocumentationModel model,
 		McpToolAdapter adapter,
-		char separator)
+		char separator,
+		Dictionary<string, ReplDocCommand> commandsByPath)
 	{
 		var resources = new List<McpServerResource>();
 
 		foreach (var resource in model.Resources)
 		{
-			var docCommand = model.Commands.FirstOrDefault(c =>
-				string.Equals(c.Path, resource.Path, StringComparison.OrdinalIgnoreCase));
+			commandsByPath.TryGetValue(resource.Path, out var docCommand);
 
 			// Hidden and AutomationHidden commands are excluded from all MCP surfaces.
 			if (docCommand is not null && !IsToolCandidate(docCommand))
@@ -342,6 +352,9 @@ internal sealed class McpServerHandler
 	// ── list_changed on routing invalidation ───────────────────────────
 
 	private EventHandler? _routingChangedHandler;
+	private readonly Lock _refreshLock = new();
+	private Timer? _debounceTimer;
+	private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(100);
 
 	private void SubscribeToRoutingChanges(
 		McpToolAdapter adapter,
@@ -357,24 +370,48 @@ internal sealed class McpServerHandler
 
 		_routingChangedHandler = (_, _) =>
 		{
-			// Resolve doc model with Programmatic channel to match tool dispatch context.
+			// Debounce: coalesce rapid-fire invalidations (e.g. multiple Map() calls)
+			// into a single rebuild after activity settles.
+			lock (_refreshLock)
+			{
+				_debounceTimer?.Dispose();
+				_debounceTimer = new Timer(
+					_ => RebuildCollections(adapter, separator, toolCollection, resourceCollection, promptCollection),
+					state: null,
+					dueTime: DebounceDelay,
+					period: Timeout.InfiniteTimeSpan);
+			}
+		};
+
+		coreApp.RoutingInvalidated += _routingChangedHandler;
+	}
+
+	private void RebuildCollections(
+		McpToolAdapter adapter,
+		char separator,
+		McpServerPrimitiveCollection<McpServerTool> toolCollection,
+		McpServerResourceCollection resourceCollection,
+		McpServerPrimitiveCollection<McpServerPrompt> promptCollection)
+	{
+		lock (_refreshLock)
+		{
 			var previousProgrammatic = ReplSessionIO.IsProgrammatic;
 			ReplSessionIO.IsProgrammatic = true;
 			try
 			{
 				adapter.ClearRoutes();
 				var newModel = _app.CreateDocumentationModel();
-				RefreshCollection(toolCollection, GenerateAllTools(newModel, adapter, separator));
-				RefreshCollection(resourceCollection, GenerateResources(newModel, adapter, separator));
+				var newCommandsByPath = newModel.Commands.ToDictionary(
+					c => c.Path, c => c, StringComparer.OrdinalIgnoreCase);
+				RefreshCollection(toolCollection, GenerateAllTools(newModel, adapter, separator, newCommandsByPath));
+				RefreshCollection(resourceCollection, GenerateResources(newModel, adapter, separator, newCommandsByPath));
 				RefreshCollection(promptCollection, CollectPrompts(newModel, adapter, separator));
 			}
 			finally
 			{
 				ReplSessionIO.IsProgrammatic = previousProgrammatic;
 			}
-		};
-
-		coreApp.RoutingInvalidated += _routingChangedHandler;
+		}
 	}
 
 	private void UnsubscribeFromRoutingChanges()
@@ -383,6 +420,12 @@ internal sealed class McpServerHandler
 		{
 			coreApp.RoutingInvalidated -= _routingChangedHandler;
 			_routingChangedHandler = null;
+		}
+
+		lock (_refreshLock)
+		{
+			_debounceTimer?.Dispose();
+			_debounceTimer = null;
 		}
 	}
 

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -285,6 +285,7 @@ internal sealed class McpServerHandler
 
 	private bool IsToolCandidate(ReplDocCommand command) =>
 		!command.IsHidden
+		&& !command.IsPrompt
 		&& command.Annotations?.AutomationHidden != true
 		&& (_options.CommandFilter is not { } filter || filter(command));
 

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -81,7 +81,7 @@ internal sealed class McpServerHandler
 		return new McpServerOptions
 		{
 			ServerInfo = new Implementation { Name = serverName, Version = serverVersion },
-			Capabilities = BuildCapabilities(resources, prompts),
+			Capabilities = BuildCapabilities(),
 			ToolCollection = ToCollection(tools),
 			ResourceCollection = ToResourceCollection(resources),
 			PromptCollection = ToCollection(prompts),
@@ -253,6 +253,7 @@ internal sealed class McpServerHandler
 		char separator)
 	{
 		var prompts = new Dictionary<string, McpServerPrompt>(StringComparer.OrdinalIgnoreCase);
+		var promptSources = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
 		foreach (var command in model.Commands)
 		{
@@ -262,10 +263,20 @@ internal sealed class McpServerHandler
 			}
 
 			var promptName = McpToolNameFlattener.Flatten(command.Path, separator);
+
+			if (promptSources.TryGetValue(promptName, out var existingPath)
+				&& !string.Equals(existingPath, command.Path, StringComparison.OrdinalIgnoreCase))
+			{
+				throw new InvalidOperationException(
+					$"MCP prompt name collision: '{promptName}' from routes '{existingPath}' and '{command.Path}'.");
+			}
+
+			promptSources[promptName] = command.Path;
 			adapter.RegisterRoute(promptName, command);
 			prompts[promptName] = CreatePipelinePrompt(promptName, command, adapter);
 		}
 
+		// Explicit registrations via options.Prompt() — override on collision (by design).
 		foreach (var registration in _options.Prompts)
 		{
 			prompts[registration.Name] = McpServerPrompt.Create(
@@ -330,27 +341,17 @@ internal sealed class McpServerHandler
 		&& command.Annotations?.AutomationHidden != true
 		&& (_options.CommandFilter is not { } filter || filter(command));
 
-	private static ServerCapabilities BuildCapabilities(
-		List<McpServerResource> resources,
-		List<McpServerPrompt> prompts)
+	/// <summary>
+	/// Always advertise all capabilities, even when initial collections are empty.
+	/// Routing invalidation may add resources/prompts later, and capabilities cannot
+	/// be retroactively added after the initialize handshake.
+	/// </summary>
+	private static ServerCapabilities BuildCapabilities() => new()
 	{
-		var capabilities = new ServerCapabilities
-		{
-			Tools = new ToolsCapability { ListChanged = true },
-		};
-
-		if (resources.Count > 0)
-		{
-			capabilities.Resources = new ResourcesCapability { ListChanged = true };
-		}
-
-		if (prompts.Count > 0)
-		{
-			capabilities.Prompts = new PromptsCapability { ListChanged = true };
-		}
-
-		return capabilities;
-	}
+		Tools = new ToolsCapability { ListChanged = true },
+		Resources = new ResourcesCapability { ListChanged = true },
+		Prompts = new PromptsCapability { ListChanged = true },
+	};
 
 	private static McpServerPrimitiveCollection<T> ToCollection<T>(IReadOnlyList<T> items)
 		where T : IMcpServerPrimitive

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -229,32 +229,8 @@ internal sealed class McpServerHandler
 				continue;
 			}
 			var resourceName = McpToolNameFlattener.Flatten(resource.Path, separator);
-			var resourceUri = McpToolNameFlattener.Flatten(resource.Path, '/');
-			var uriTemplate = $"repl://{resourceUri}";
-
-			var mcpResource = McpServerResource.Create(
-				async (CancellationToken ct) =>
-				{
-					var result = await adapter.InvokeAsync(
-						resourceName,
-						new Dictionary<string, System.Text.Json.JsonElement>(StringComparer.Ordinal),
-						server: null, progressToken: null, ct).ConfigureAwait(false);
-
-					if (result.IsError == true)
-					{
-						var errorText = result.Content?.OfType<TextContentBlock>().FirstOrDefault()?.Text
-							?? "Resource read failed.";
-						throw new McpException(errorText);
-					}
-
-					return result.Content?.OfType<TextContentBlock>().FirstOrDefault()?.Text ?? "";
-				},
-				new McpServerResourceCreateOptions
-				{
-					Name = resourceName,
-					Description = resource.Description,
-					UriTemplate = uriTemplate,
-				});
+			var uriTemplate = McpToolNameFlattener.BuildResourceUri(resource.Path);
+			var mcpResource = new ReplMcpServerResource(resource, resourceName, uriTemplate, adapter);
 
 			if (docCommand is not null)
 			{

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -31,6 +31,9 @@ internal sealed class McpServerHandler
 		Justification = "MCP server handler runs in a context where all types are preserved.")]
 	public async Task RunAsync(IReplIoContext io, CancellationToken ct)
 	{
+		// Build the doc model with Programmatic channel so module presence
+		// predicates see the same channel as tool dispatch.
+		ReplSessionIO.IsProgrammatic = true;
 		var model = _app.CreateDocumentationModel();
 		var adapter = new McpToolAdapter(_app, _options, _services);
 		var separator = McpToolNameFlattener.ResolveSeparator(_options.ToolNamingSeparator);
@@ -372,10 +375,20 @@ internal sealed class McpServerHandler
 
 		_routingChangedHandler = (_, _) =>
 		{
-			var newModel = _app.CreateDocumentationModel();
-			RefreshCollection(toolCollection, GenerateAllTools(newModel, adapter, separator));
-			RefreshCollection(resourceCollection, GenerateResources(newModel, adapter, separator));
-			RefreshCollection(promptCollection, CollectPrompts(newModel, adapter, separator));
+			// Resolve doc model with Programmatic channel to match tool dispatch context.
+			var previousProgrammatic = ReplSessionIO.IsProgrammatic;
+			ReplSessionIO.IsProgrammatic = true;
+			try
+			{
+				var newModel = _app.CreateDocumentationModel();
+				RefreshCollection(toolCollection, GenerateAllTools(newModel, adapter, separator));
+				RefreshCollection(resourceCollection, GenerateResources(newModel, adapter, separator));
+				RefreshCollection(promptCollection, CollectPrompts(newModel, adapter, separator));
+			}
+			finally
+			{
+				ReplSessionIO.IsProgrammatic = previousProgrammatic;
+			}
 		};
 
 		coreApp.RoutingInvalidated += _routingChangedHandler;

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -229,7 +229,7 @@ internal sealed class McpServerHandler
 				continue;
 			}
 			var resourceName = McpToolNameFlattener.Flatten(resource.Path, separator);
-			var uriTemplate = McpToolNameFlattener.BuildResourceUri(resource.Path);
+			var uriTemplate = McpToolNameFlattener.BuildResourceUri(resource.Path, _options.ResourceUriScheme);
 			var mcpResource = new ReplMcpServerResource(resource, resourceName, uriTemplate, adapter);
 
 			if (docCommand is not null)

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -15,6 +15,7 @@ internal sealed class McpServerHandler
 	private readonly ICoreReplApp _app;
 	private readonly ReplMcpServerOptions _options;
 	private readonly IServiceProvider _services;
+	private readonly TimeProvider _timeProvider;
 
 	public McpServerHandler(
 		ICoreReplApp app,
@@ -24,6 +25,7 @@ internal sealed class McpServerHandler
 		_app = app;
 		_options = options;
 		_services = services;
+		_timeProvider = services.GetService(typeof(TimeProvider)) as TimeProvider ?? TimeProvider.System;
 	}
 
 	[UnconditionalSuppressMessage(
@@ -353,7 +355,7 @@ internal sealed class McpServerHandler
 
 	private EventHandler? _routingChangedHandler;
 	private readonly Lock _refreshLock = new();
-	private Timer? _debounceTimer;
+	private ITimer? _debounceTimer;
 	private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(100);
 
 	private void SubscribeToRoutingChanges(
@@ -375,7 +377,7 @@ internal sealed class McpServerHandler
 			lock (_refreshLock)
 			{
 				_debounceTimer?.Dispose();
-				_debounceTimer = new Timer(
+				_debounceTimer = _timeProvider.CreateTimer(
 					_ => RebuildCollections(adapter, separator, toolCollection, resourceCollection, promptCollection),
 					state: null,
 					dueTime: DebounceDelay,

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -45,10 +45,12 @@ internal sealed class McpServerHandler
 			var server = McpServer.Create(transport, serverOptions, serviceProvider: _services);
 			try
 			{
+				SubscribeToRoutingChanges(server, adapter, separator, serverOptions.ToolCollection!);
 				await server.RunAsync(ct).ConfigureAwait(false);
 			}
 			finally
 			{
+				UnsubscribeFromRoutingChanges();
 				await server.DisposeAsync().ConfigureAwait(false);
 			}
 		}
@@ -230,4 +232,45 @@ internal sealed class McpServerHandler
 		!command.IsHidden
 		&& command.Annotations?.AutomationHidden != true
 		&& (_options.CommandFilter is not { } filter || filter(command));
+
+	// ── list_changed on routing invalidation ───────────────────────────
+
+	private EventHandler? _routingChangedHandler;
+
+	private void SubscribeToRoutingChanges(
+		McpServer server,
+		McpToolAdapter adapter,
+		char separator,
+		McpServerPrimitiveCollection<McpServerTool> toolCollection)
+	{
+		if (_app is not CoreReplApp coreApp)
+		{
+			return;
+		}
+
+		_routingChangedHandler = (sender, args) =>
+		{
+			var newModel = _app.CreateDocumentationModel();
+			var newTools = GenerateTools(newModel, adapter, separator);
+
+			toolCollection.Clear();
+			foreach (var tool in newTools)
+			{
+				toolCollection.Add(tool);
+			}
+
+			// Collection mutations auto-emit list_changed via the SDK.
+		};
+
+		coreApp.RoutingInvalidated += _routingChangedHandler;
+	}
+
+	private void UnsubscribeFromRoutingChanges()
+	{
+		if (_routingChangedHandler is not null && _app is CoreReplApp coreApp)
+		{
+			coreApp.RoutingInvalidated -= _routingChangedHandler;
+			_routingChangedHandler = null;
+		}
+	}
 }

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -66,7 +66,7 @@ internal sealed class McpServerHandler
 		}
 	}
 
-	private McpServerOptions BuildServerOptions(
+	internal McpServerOptions BuildServerOptions(
 		ReplDocumentationModel model,
 		McpToolAdapter adapter,
 		char separator)

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Repl.Documentation;
@@ -225,6 +226,14 @@ internal sealed class McpServerHandler
 						resourceName,
 						new Dictionary<string, System.Text.Json.JsonElement>(StringComparer.Ordinal),
 						server: null, progressToken: null, ct).ConfigureAwait(false);
+
+					if (result.IsError == true)
+					{
+						var errorText = result.Content?.OfType<TextContentBlock>().FirstOrDefault()?.Text
+							?? "Resource read failed.";
+						throw new McpException(errorText);
+					}
+
 					return result.Content?.OfType<TextContentBlock>().FirstOrDefault()?.Text ?? "";
 				},
 				new McpServerResourceCreateOptions
@@ -352,6 +361,7 @@ internal sealed class McpServerHandler
 			ReplSessionIO.IsProgrammatic = true;
 			try
 			{
+				adapter.ClearRoutes();
 				var newModel = _app.CreateDocumentationModel();
 				RefreshCollection(toolCollection, GenerateAllTools(newModel, adapter, separator));
 				RefreshCollection(resourceCollection, GenerateResources(newModel, adapter, separator));

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -273,7 +273,7 @@ internal sealed class McpServerHandler
 
 			promptSources[promptName] = command.Path;
 			adapter.RegisterRoute(promptName, command);
-			prompts[promptName] = CreatePipelinePrompt(promptName, command, adapter);
+			prompts[promptName] = new ReplMcpServerPrompt(command, promptName, adapter);
 		}
 
 		// Explicit registrations via options.Prompt() — override on collision (by design).
@@ -285,53 +285,6 @@ internal sealed class McpServerHandler
 		}
 
 		return [.. prompts.Values];
-	}
-
-	private static McpServerPrompt CreatePipelinePrompt(
-		string promptName,
-		ReplDocCommand command,
-		McpToolAdapter adapter) =>
-		McpServerPrompt.Create(
-			async (IDictionary<string, string?>? arguments, CancellationToken ct) =>
-			{
-				var jsonArgs = ConvertPromptArguments(arguments);
-				var result = await adapter.InvokeAsync(
-					promptName, jsonArgs, server: null, progressToken: null, ct)
-					.ConfigureAwait(false);
-
-				var text = result.Content?.OfType<TextContentBlock>().FirstOrDefault()?.Text
-					?? command.Description ?? promptName;
-
-				return new GetPromptResult
-				{
-					Messages =
-					[
-						new PromptMessage
-						{
-							Role = Role.User,
-							Content = new TextContentBlock { Text = text },
-						},
-					],
-				};
-			},
-			new McpServerPromptCreateOptions { Name = promptName, Description = command.Description });
-
-	private static Dictionary<string, System.Text.Json.JsonElement> ConvertPromptArguments(
-		IDictionary<string, string?>? arguments)
-	{
-		var jsonArgs = new Dictionary<string, System.Text.Json.JsonElement>(StringComparer.Ordinal);
-		if (arguments is null)
-		{
-			return jsonArgs;
-		}
-
-		foreach (var (key, value) in arguments)
-		{
-			jsonArgs[key] = System.Text.Json.JsonSerializer.SerializeToElement(
-				value, McpJsonContext.Default.String);
-		}
-
-		return jsonArgs;
 	}
 
 	// ── Helpers ─────────────────────────────────────────────────────────

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -196,7 +196,6 @@ internal sealed class McpServerHandler
 			}
 			var resourceName = McpToolNameFlattener.Flatten(resource.Path, separator);
 			var uriTemplate = $"repl://{resourceName}";
-			var capturedPath = resource.Path;
 
 			var mcpResource = McpServerResource.Create(
 				async (CancellationToken ct) =>

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -215,7 +215,8 @@ internal sealed class McpServerHandler
 				continue;
 			}
 			var resourceName = McpToolNameFlattener.Flatten(resource.Path, separator);
-			var uriTemplate = $"repl://{resourceName}";
+			var resourceUri = McpToolNameFlattener.Flatten(resource.Path, '/');
+			var uriTemplate = $"repl://{resourceUri}";
 
 			var mcpResource = McpServerResource.Create(
 				async (CancellationToken ct) =>

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -34,38 +34,15 @@ internal sealed class McpServerHandler
 		var model = _app.CreateDocumentationModel();
 		var adapter = new McpToolAdapter(_app, _options, _services);
 		var separator = McpToolNameFlattener.ResolveSeparator(_options.ToolNamingSeparator);
-		var tools = GenerateTools(model, adapter, separator);
+		var serverOptions = BuildServerOptions(model, adapter, separator);
 
-		var serverName = _options.ServerName
-			?? model.App.Name
-			?? "repl-mcp-server";
-		var serverVersion = _options.ServerVersion ?? "1.0.0";
-
-		var toolCollection = new McpServerPrimitiveCollection<McpServerTool>();
-		foreach (var tool in tools)
-		{
-			toolCollection.Add(tool);
-		}
-
-		// Use StdioServerTransport for stdio-based MCP server.
-		// The IReplIoContext streams are passthrough (stdin/stdout) when AsProtocolPassthrough is active.
-		_ = io; // io.Input/Output are TextReader/TextWriter, SDK needs raw streams via StdioServerTransport.
+		// AsProtocolPassthrough reserves stdin/stdout for the transport.
+		_ = io;
+		var serverName = serverOptions.ServerInfo?.Name ?? "repl-mcp-server";
 		var transport = new StdioServerTransport(serverName);
 		try
 		{
-			var server = McpServer.Create(transport, new McpServerOptions
-			{
-				ServerInfo = new Implementation
-				{
-					Name = serverName,
-					Version = serverVersion,
-				},
-				Capabilities = new ServerCapabilities
-				{
-					Tools = new ToolsCapability { ListChanged = true },
-				},
-				ToolCollection = toolCollection,
-			}, serviceProvider: _services);
+			var server = McpServer.Create(transport, serverOptions, serviceProvider: _services);
 			try
 			{
 				await server.RunAsync(ct).ConfigureAwait(false);
@@ -81,6 +58,47 @@ internal sealed class McpServerHandler
 		}
 	}
 
+	private McpServerOptions BuildServerOptions(
+		ReplDocumentationModel model,
+		McpToolAdapter adapter,
+		char separator)
+	{
+		var tools = GenerateTools(model, adapter, separator);
+		var resources = GenerateResources(model, adapter, separator);
+		var prompts = CollectPrompts(model, separator);
+
+		var serverName = _options.ServerName ?? model.App.Name ?? "repl-mcp-server";
+		var serverVersion = _options.ServerVersion ?? "1.0.0";
+
+		var toolCollection = new McpServerPrimitiveCollection<McpServerTool>();
+		foreach (var tool in tools)
+		{
+			toolCollection.Add(tool);
+		}
+
+		var capabilities = new ServerCapabilities
+		{
+			Tools = new ToolsCapability { ListChanged = true },
+		};
+
+		if (resources.Count > 0)
+		{
+			capabilities.Resources = new ResourcesCapability { ListChanged = true };
+		}
+
+		if (prompts.Count > 0)
+		{
+			capabilities.Prompts = new PromptsCapability { ListChanged = true };
+		}
+
+		return new McpServerOptions
+		{
+			ServerInfo = new Implementation { Name = serverName, Version = serverVersion },
+			Capabilities = capabilities,
+			ToolCollection = toolCollection,
+		};
+	}
+
 	private List<McpServerTool> GenerateTools(
 		ReplDocumentationModel model,
 		McpToolAdapter adapter,
@@ -91,17 +109,7 @@ internal sealed class McpServerHandler
 
 		foreach (var command in model.Commands)
 		{
-			if (command.IsHidden)
-			{
-				continue;
-			}
-
-			if (command.Annotations?.AutomationHidden == true)
-			{
-				continue;
-			}
-
-			if (_options.CommandFilter is { } filter && !filter(command))
+			if (!IsToolCandidate(command))
 			{
 				continue;
 			}
@@ -120,4 +128,105 @@ internal sealed class McpServerHandler
 
 		return tools;
 	}
+
+	private static List<McpServerResource> GenerateResources(
+		ReplDocumentationModel model,
+		McpToolAdapter adapter,
+		char separator)
+	{
+		var resources = new List<McpServerResource>();
+
+		foreach (var resource in model.Resources)
+		{
+			var resourceName = McpToolNameFlattener.Flatten(resource.Path, separator);
+			var uriTemplate = $"repl://{resourceName}";
+
+			// Create a resource that dispatches through the tool adapter.
+			var capturedPath = resource.Path;
+			var mcpResource = McpServerResource.Create(
+				async (CancellationToken ct) =>
+				{
+					// Resources dispatch through the same pipeline as tools.
+					var result = await adapter.InvokeAsync(
+						resourceName,
+						new Dictionary<string, System.Text.Json.JsonElement>(StringComparer.Ordinal),
+						server: null!,
+						ct).ConfigureAwait(false);
+
+					var text = result.Content?.FirstOrDefault() is TextContentBlock block
+						? block.Text ?? ""
+						: "";
+					return text;
+				},
+				new McpServerResourceCreateOptions
+				{
+					Name = resourceName,
+					Description = resource.Description,
+					UriTemplate = uriTemplate,
+				});
+
+			// Ensure the resource route is registered.
+			var docCommand = model.Commands.FirstOrDefault(c =>
+				string.Equals(c.Path, capturedPath, StringComparison.OrdinalIgnoreCase));
+			if (docCommand is not null)
+			{
+				adapter.RegisterRoute(resourceName, docCommand);
+			}
+
+			resources.Add(mcpResource);
+		}
+
+		return resources;
+	}
+
+	private List<McpServerPrompt> CollectPrompts(
+		ReplDocumentationModel model,
+		char separator)
+	{
+		var prompts = new Dictionary<string, McpServerPrompt>(StringComparer.OrdinalIgnoreCase);
+
+		// 1. Prompts from AsPrompt() commands.
+		foreach (var command in model.Commands)
+		{
+			if (!command.IsPrompt)
+			{
+				continue;
+			}
+
+			var promptName = McpToolNameFlattener.Flatten(command.Path, separator);
+			var description = command.Description ?? promptName;
+			var prompt = McpServerPrompt.Create(
+				(string? args) => new GetPromptResult
+				{
+					Messages =
+					[
+						new PromptMessage
+						{
+							Role = Role.User,
+							Content = new TextContentBlock { Text = description },
+						},
+					],
+				},
+				new McpServerPromptCreateOptions { Name = promptName, Description = command.Description });
+
+			prompts[promptName] = prompt;
+		}
+
+		// 2. Explicit registrations via options.Prompt() — override on collision.
+		foreach (var registration in _options.Prompts)
+		{
+			var prompt = McpServerPrompt.Create(
+				registration.Handler,
+				new McpServerPromptCreateOptions { Name = registration.Name });
+
+			prompts[registration.Name] = prompt;
+		}
+
+		return [.. prompts.Values];
+	}
+
+	private bool IsToolCandidate(ReplDocCommand command) =>
+		!command.IsHidden
+		&& command.Annotations?.AutomationHidden != true
+		&& (_options.CommandFilter is not { } filter || filter(command));
 }

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -103,7 +103,7 @@ internal sealed class McpServerHandler
 		char separator)
 	{
 		var tools = new List<McpServerTool>();
-		var nameSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		var nameSet = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
 		// 1. Regular commands. Resource-only and prompt-only commands are handled
 		//    separately as fallback tools (opt-in). ReadOnly+AsResource commands
@@ -160,15 +160,27 @@ internal sealed class McpServerHandler
 	private static void AddTool(
 		ReplDocCommand command,
 		List<McpServerTool> tools,
-		HashSet<string> nameSet,
+		Dictionary<string, string> nameSet,
 		McpToolAdapter adapter,
 		char separator)
 	{
 		var toolName = McpToolNameFlattener.Flatten(command.Path, separator);
-		if (!nameSet.Add(toolName))
+		if (nameSet.TryGetValue(toolName, out var existingPath))
 		{
-			return; // Already registered (e.g. ReadOnly command is both a tool and a resource).
+			// Same command registered from multiple phases (e.g. ReadOnly is both
+			// a core tool and a resource fallback) — skip silently.
+			if (string.Equals(command.Path, existingPath, StringComparison.OrdinalIgnoreCase))
+			{
+				return;
+			}
+
+			// Different routes collapsed to the same name — surface at startup.
+			throw new InvalidOperationException(
+				$"MCP tool name collision: '{toolName}' from routes '{existingPath}' and '{command.Path}'. " +
+				"Consider a different ToolNamingSeparator or rename one of the commands.");
 		}
+
+		nameSet[toolName] = command.Path;
 
 		adapter.RegisterRoute(toolName, command);
 		tools.Add(new ReplMcpServerTool(command, toolName, adapter));
@@ -185,11 +197,16 @@ internal sealed class McpServerHandler
 
 		foreach (var resource in model.Resources)
 		{
-			// Skip auto-promoted ReadOnly resources when opt-out is active.
-			// Auto-promoted resources are those in the Resources list but not
-			// explicitly marked AsResource() — they got there via ReadOnly.
 			var docCommand = model.Commands.FirstOrDefault(c =>
 				string.Equals(c.Path, resource.Path, StringComparison.OrdinalIgnoreCase));
+
+			// Hidden and AutomationHidden commands are excluded from all MCP surfaces.
+			if (docCommand is not null && !IsToolCandidate(docCommand))
+			{
+				continue;
+			}
+
+			// Skip auto-promoted ReadOnly resources when opt-out is active.
 			if (!_options.AutoPromoteReadOnlyToResources
 				&& docCommand is not null
 				&& !docCommand.IsResource
@@ -238,7 +255,7 @@ internal sealed class McpServerHandler
 
 		foreach (var command in model.Commands)
 		{
-			if (!command.IsPrompt)
+			if (!command.IsPrompt || !IsToolCandidate(command))
 			{
 				continue;
 			}

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -67,7 +67,7 @@ internal sealed class McpServerHandler
 	{
 		var tools = GenerateTools(model, adapter, separator);
 		var resources = GenerateResources(model, adapter, separator);
-		var prompts = CollectPrompts(model, separator);
+		var prompts = CollectPrompts(model, adapter, separator);
 
 		var serverName = _options.ServerName ?? model.App.Name ?? "repl-mcp-server";
 		var serverVersion = _options.ServerVersion ?? "1.0.0";
@@ -76,6 +76,18 @@ internal sealed class McpServerHandler
 		foreach (var tool in tools)
 		{
 			toolCollection.Add(tool);
+		}
+
+		var resourceCollection = new McpServerResourceCollection();
+		foreach (var resource in resources)
+		{
+			resourceCollection.Add(resource);
+		}
+
+		var promptCollection = new McpServerPrimitiveCollection<McpServerPrompt>();
+		foreach (var prompt in prompts)
+		{
+			promptCollection.Add(prompt);
 		}
 
 		var capabilities = new ServerCapabilities
@@ -98,6 +110,8 @@ internal sealed class McpServerHandler
 			ServerInfo = new Implementation { Name = serverName, Version = serverVersion },
 			Capabilities = capabilities,
 			ToolCollection = toolCollection,
+			ResourceCollection = resourceCollection,
+			PromptCollection = promptCollection,
 		};
 	}
 
@@ -184,11 +198,12 @@ internal sealed class McpServerHandler
 
 	private List<McpServerPrompt> CollectPrompts(
 		ReplDocumentationModel model,
+		McpToolAdapter adapter,
 		char separator)
 	{
 		var prompts = new Dictionary<string, McpServerPrompt>(StringComparer.OrdinalIgnoreCase);
 
-		// 1. Prompts from AsPrompt() commands.
+		// 1. Prompts from AsPrompt() commands — dispatch through the pipeline.
 		foreach (var command in model.Commands)
 		{
 			if (!command.IsPrompt)
@@ -197,35 +212,71 @@ internal sealed class McpServerHandler
 			}
 
 			var promptName = McpToolNameFlattener.Flatten(command.Path, separator);
-			var description = command.Description ?? promptName;
-			var prompt = McpServerPrompt.Create(
-				(string? args) => new GetPromptResult
+			adapter.RegisterRoute(promptName, command);
+			prompts[promptName] = CreatePipelinePrompt(promptName, command, adapter);
+		}
+
+		// 2. Explicit registrations via options.Prompt() — override on collision.
+		foreach (var registration in _options.Prompts)
+		{
+			prompts[registration.Name] = McpServerPrompt.Create(
+				registration.Handler,
+				new McpServerPromptCreateOptions { Name = registration.Name });
+		}
+
+		return [.. prompts.Values];
+	}
+
+	/// <summary>
+	/// Creates a prompt that dispatches through the Repl pipeline.
+	/// The handler executes with its arguments and the return value becomes the prompt message.
+	/// </summary>
+	private static McpServerPrompt CreatePipelinePrompt(
+		string promptName,
+		ReplDocCommand command,
+		McpToolAdapter adapter) =>
+		McpServerPrompt.Create(
+			async (IDictionary<string, string?>? arguments, CancellationToken ct) =>
+			{
+				var jsonArgs = ConvertPromptArguments(arguments);
+				var result = await adapter.InvokeAsync(
+					promptName, jsonArgs, server: null, progressToken: null, ct)
+					.ConfigureAwait(false);
+
+				var text = result.Content?.OfType<TextContentBlock>().FirstOrDefault()?.Text
+					?? command.Description
+					?? promptName;
+
+				return new GetPromptResult
 				{
 					Messages =
 					[
 						new PromptMessage
 						{
 							Role = Role.User,
-							Content = new TextContentBlock { Text = description },
+							Content = new TextContentBlock { Text = text },
 						},
 					],
-				},
-				new McpServerPromptCreateOptions { Name = promptName, Description = command.Description });
+				};
+			},
+			new McpServerPromptCreateOptions { Name = promptName, Description = command.Description });
 
-			prompts[promptName] = prompt;
-		}
-
-		// 2. Explicit registrations via options.Prompt() — override on collision.
-		foreach (var registration in _options.Prompts)
+	private static Dictionary<string, System.Text.Json.JsonElement> ConvertPromptArguments(
+		IDictionary<string, string?>? arguments)
+	{
+		var jsonArgs = new Dictionary<string, System.Text.Json.JsonElement>(StringComparer.Ordinal);
+		if (arguments is null)
 		{
-			var prompt = McpServerPrompt.Create(
-				registration.Handler,
-				new McpServerPromptCreateOptions { Name = registration.Name });
-
-			prompts[registration.Name] = prompt;
+			return jsonArgs;
 		}
 
-		return [.. prompts.Values];
+		foreach (var (key, value) in arguments)
+		{
+			jsonArgs[key] = System.Text.Json.JsonSerializer.SerializeToElement(
+				value, McpJsonContext.Default.String);
+		}
+
+		return jsonArgs;
 	}
 
 	private bool IsToolCandidate(ReplDocCommand command) =>

--- a/src/Repl.Mcp/McpServiceProviderOverlay.cs
+++ b/src/Repl.Mcp/McpServiceProviderOverlay.cs
@@ -1,0 +1,21 @@
+using Repl.Interaction;
+
+namespace Repl.Mcp;
+
+/// <summary>
+/// Service provider overlay that injects MCP-specific services (interaction channel).
+/// </summary>
+internal sealed class McpServiceProviderOverlay(
+	IServiceProvider inner,
+	IReplInteractionChannel interactionChannel) : IServiceProvider
+{
+	public object? GetService(Type serviceType)
+	{
+		if (serviceType == typeof(IReplInteractionChannel))
+		{
+			return interactionChannel;
+		}
+
+		return inner.GetService(serviceType);
+	}
+}

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -31,6 +31,19 @@ internal sealed partial class McpToolAdapter
 	public void ClearRoutes() => _toolRoutes.Clear();
 
 	/// <summary>
+	/// Atomically replaces all routes from another adapter instance.
+	/// Used for optimistic concurrency during routing invalidation.
+	/// </summary>
+	public void ReplaceRoutes(McpToolAdapter source)
+	{
+		_toolRoutes.Clear();
+		foreach (var (key, value) in source._toolRoutes)
+		{
+			_toolRoutes[key] = value;
+		}
+	}
+
+	/// <summary>
 	/// Registers a tool name → command mapping for dispatch.
 	/// </summary>
 	public void RegisterRoute(string toolName, ReplDocCommand command)

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Repl.Documentation;
+
+namespace Repl.Mcp;
+
+/// <summary>
+/// Dispatches MCP tool calls through the Repl pipeline.
+/// Each call creates CLI tokens from the route template + JSON arguments,
+/// then executes through standard Repl routing, binding, and middleware.
+/// </summary>
+internal sealed partial class McpToolAdapter
+{
+	private readonly ICoreReplApp _app;
+	private readonly ReplMcpServerOptions _options;
+	private readonly IServiceProvider _services;
+	private readonly Dictionary<string, ReplDocCommand> _toolRoutes = new(StringComparer.OrdinalIgnoreCase);
+
+	public McpToolAdapter(ICoreReplApp app, ReplMcpServerOptions options, IServiceProvider services)
+	{
+		_app = app;
+		_options = options;
+		_services = services;
+	}
+
+	/// <summary>
+	/// Registers a tool name → command mapping for dispatch.
+	/// </summary>
+	public void RegisterRoute(string toolName, ReplDocCommand command)
+	{
+		_toolRoutes[toolName] = command;
+	}
+
+	/// <summary>
+	/// Invokes a Repl command through the pipeline for an MCP tool call.
+	/// </summary>
+	public async Task<CallToolResult> InvokeAsync(
+		string toolName,
+		IDictionary<string, JsonElement> arguments,
+		McpServer server,
+		CancellationToken ct)
+	{
+		if (!_toolRoutes.TryGetValue(toolName, out var command))
+		{
+			return new CallToolResult
+			{
+				Content = [new TextContentBlock { Text = $"Unknown tool: {toolName}" }],
+				IsError = true,
+			};
+		}
+
+		var stringArgs = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+		foreach (var (key, value) in arguments)
+		{
+			stringArgs[key] = value.ValueKind == JsonValueKind.String
+				? value.GetString()
+				: value.GetRawText();
+		}
+
+		var tokens = ReconstructTokens(command.Path, stringArgs);
+
+		// Phase 2: Create a scoped execution context with:
+		// - New IServiceProvider scope (one per tool call for isolation)
+		// - In-memory IReplIoContext with StringWriter output capture
+		// - McpInteractionChannel (prefill → elicitation → sampling → fail)
+		// - ReplRuntimeChannel.Programmatic
+		// Then execute through the Repl pipeline and capture output.
+		_ = ct;
+
+		var output = $"Tool '{toolName}' dispatched with tokens: [{string.Join(", ", tokens)}]";
+		return await Task.FromResult(new CallToolResult
+		{
+			Content = [new TextContentBlock { Text = output }],
+			IsError = false,
+		}).ConfigureAwait(false);
+	}
+
+	/// <summary>
+	/// Reconstructs CLI tokens from a route template and MCP arguments.
+	/// </summary>
+	internal static List<string> ReconstructTokens(
+		string routePath,
+		IDictionary<string, object?> arguments)
+	{
+		var tokens = new List<string>();
+		var consumedArgs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		var parts = routePath.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+		foreach (var part in parts)
+		{
+			var match = DynamicSegmentPattern().Match(part);
+			if (match.Success)
+			{
+				var argName = match.Groups["name"].Value;
+				if (arguments.TryGetValue(argName, out var value))
+				{
+					tokens.Add(value?.ToString() ?? "");
+				}
+				else
+				{
+					tokens.Add("");
+				}
+
+				consumedArgs.Add(argName);
+			}
+			else
+			{
+				tokens.Add(part);
+			}
+		}
+
+		// Remaining arguments → named options (--key value)
+		foreach (var (key, value) in arguments)
+		{
+			if (consumedArgs.Contains(key))
+			{
+				continue;
+			}
+
+			if (key.StartsWith("answer:", StringComparison.OrdinalIgnoreCase))
+			{
+				continue;
+			}
+
+			tokens.Add($"--{key}");
+			tokens.Add(value?.ToString() ?? "");
+		}
+
+		// Interaction prefills → --answer:name=value tokens
+		foreach (var (key, value) in arguments)
+		{
+			if (!key.StartsWith("answer:", StringComparison.OrdinalIgnoreCase))
+			{
+				continue;
+			}
+
+			tokens.Add($"--{key}={value}");
+		}
+
+		return tokens;
+	}
+
+	[GeneratedRegex(@"^\{(?<name>\w+)(?::\w+)?\}$", RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 1000)]
+	private static partial Regex DynamicSegmentPattern();
+}

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -76,6 +76,7 @@ internal sealed partial class McpToolAdapter
 			sessionId: $"mcp-{Guid.NewGuid():N}",
 			isHostedSession: true))
 		{
+			ReplSessionIO.IsProgrammatic = true;
 			var exitCode = await coreApp.RunWithServicesAsync(
 				tokens.ToArray(), mcpServices, ct).ConfigureAwait(false);
 

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -16,7 +16,7 @@ internal sealed partial class McpToolAdapter
 	private readonly ICoreReplApp _app;
 	private readonly ReplMcpServerOptions _options;
 	private readonly IServiceProvider _services;
-	private readonly Dictionary<string, ReplDocCommand> _toolRoutes = new(StringComparer.OrdinalIgnoreCase);
+	private readonly System.Collections.Concurrent.ConcurrentDictionary<string, ReplDocCommand> _toolRoutes = new(StringComparer.OrdinalIgnoreCase);
 
 	public McpToolAdapter(ICoreReplApp app, ReplMcpServerOptions options, IServiceProvider services)
 	{

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -136,8 +136,17 @@ internal sealed partial class McpToolAdapter
 			if (match.Success)
 			{
 				var argName = match.Groups["name"].Value;
-				tokens.Add(arguments.TryGetValue(argName, out var value) ? value?.ToString() ?? "" : "");
 				consumedArgs.Add(argName);
+				if (arguments.TryGetValue(argName, out var value) && value is not null)
+				{
+					var strValue = value.ToString() ?? "";
+					if (strValue.Length > 0)
+					{
+						tokens.Add(strValue);
+					}
+
+					// Omit token entirely for missing optional segments.
+				}
 			}
 			else
 			{

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -44,37 +44,74 @@ internal sealed partial class McpToolAdapter
 	{
 		if (!_toolRoutes.TryGetValue(toolName, out var command))
 		{
+			return ErrorResult($"Unknown tool: {toolName}");
+		}
+
+		var (tokens, prefills) = PrepareExecution(command.Path, arguments);
+		return await ExecuteThroughPipelineAsync(tokens, prefills, ct).ConfigureAwait(false);
+	}
+
+	private async Task<CallToolResult> ExecuteThroughPipelineAsync(
+		List<string> tokens,
+		Dictionary<string, string> prefills,
+		CancellationToken ct)
+	{
+		var coreApp = _app as CoreReplApp
+			?? throw new InvalidOperationException("MCP tool adapter requires CoreReplApp.");
+
+		var outputWriter = new StringWriter();
+		var inputReader = new StringReader(string.Empty);
+		var interactionChannel = new McpInteractionChannel(prefills, _options.InteractivityMode);
+		var mcpServices = new McpServiceProviderOverlay(_services, interactionChannel);
+
+		using (ReplSessionIO.SetSession(
+			output: outputWriter,
+			input: inputReader,
+			ansiMode: Rendering.AnsiMode.Never,
+			sessionId: $"mcp-{Guid.NewGuid():N}",
+			isHostedSession: true))
+		{
+			var exitCode = await coreApp.RunWithServicesAsync(
+				tokens.ToArray(), mcpServices, ct).ConfigureAwait(false);
+
+			var output = outputWriter.ToString().Trim();
+			if (string.IsNullOrWhiteSpace(output))
+			{
+				output = exitCode == 0 ? "OK" : $"Command failed with exit code {exitCode}.";
+			}
+
 			return new CallToolResult
 			{
-				Content = [new TextContentBlock { Text = $"Unknown tool: {toolName}" }],
-				IsError = true,
+				Content = [new TextContentBlock { Text = output }],
+				IsError = exitCode != 0,
 			};
 		}
+	}
 
+	private static (List<string> Tokens, Dictionary<string, string> Prefills) PrepareExecution(
+		string routePath,
+		IDictionary<string, JsonElement> arguments)
+	{
 		var stringArgs = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+		var prefills = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
 		foreach (var (key, value) in arguments)
 		{
-			stringArgs[key] = value.ValueKind == JsonValueKind.String
-				? value.GetString()
+			var strValue = value.ValueKind == JsonValueKind.String
+				? value.GetString() ?? ""
 				: value.GetRawText();
+
+			if (key.StartsWith("answer:", StringComparison.OrdinalIgnoreCase))
+			{
+				prefills[key["answer:".Length..]] = strValue;
+			}
+			else
+			{
+				stringArgs[key] = strValue;
+			}
 		}
 
-		var tokens = ReconstructTokens(command.Path, stringArgs);
-
-		// Phase 2: Create a scoped execution context with:
-		// - New IServiceProvider scope (one per tool call for isolation)
-		// - In-memory IReplIoContext with StringWriter output capture
-		// - McpInteractionChannel (prefill → elicitation → sampling → fail)
-		// - ReplRuntimeChannel.Programmatic
-		// Then execute through the Repl pipeline and capture output.
-		_ = ct;
-
-		var output = $"Tool '{toolName}' dispatched with tokens: [{string.Join(", ", tokens)}]";
-		return await Task.FromResult(new CallToolResult
-		{
-			Content = [new TextContentBlock { Text = output }],
-			IsError = false,
-		}).ConfigureAwait(false);
+		return (ReconstructTokens(routePath, stringArgs), prefills);
 	}
 
 	/// <summary>
@@ -86,23 +123,14 @@ internal sealed partial class McpToolAdapter
 	{
 		var tokens = new List<string>();
 		var consumedArgs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-		var parts = routePath.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 
-		foreach (var part in parts)
+		foreach (var part in routePath.Split(' ', StringSplitOptions.RemoveEmptyEntries))
 		{
 			var match = DynamicSegmentPattern().Match(part);
 			if (match.Success)
 			{
 				var argName = match.Groups["name"].Value;
-				if (arguments.TryGetValue(argName, out var value))
-				{
-					tokens.Add(value?.ToString() ?? "");
-				}
-				else
-				{
-					tokens.Add("");
-				}
-
+				tokens.Add(arguments.TryGetValue(argName, out var value) ? value?.ToString() ?? "" : "");
 				consumedArgs.Add(argName);
 			}
 			else
@@ -111,7 +139,6 @@ internal sealed partial class McpToolAdapter
 			}
 		}
 
-		// Remaining arguments → named options (--key value)
 		foreach (var (key, value) in arguments)
 		{
 			if (consumedArgs.Contains(key))
@@ -128,19 +155,22 @@ internal sealed partial class McpToolAdapter
 			tokens.Add(value?.ToString() ?? "");
 		}
 
-		// Interaction prefills → --answer:name=value tokens
 		foreach (var (key, value) in arguments)
 		{
-			if (!key.StartsWith("answer:", StringComparison.OrdinalIgnoreCase))
+			if (key.StartsWith("answer:", StringComparison.OrdinalIgnoreCase))
 			{
-				continue;
+				tokens.Add($"--{key}={value}");
 			}
-
-			tokens.Add($"--{key}={value}");
 		}
 
 		return tokens;
 	}
+
+	private static CallToolResult ErrorResult(string message) => new()
+	{
+		Content = [new TextContentBlock { Text = message }],
+		IsError = true,
+	};
 
 	[GeneratedRegex(@"^\{(?<name>\w+)(?::\w+)?\}$", RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 1000)]
 	private static partial Regex DynamicSegmentPattern();

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -39,7 +39,8 @@ internal sealed partial class McpToolAdapter
 	public async Task<CallToolResult> InvokeAsync(
 		string toolName,
 		IDictionary<string, JsonElement> arguments,
-		McpServer server,
+		McpServer? server,
+		ProgressToken? progressToken,
 		CancellationToken ct)
 	{
 		if (!_toolRoutes.TryGetValue(toolName, out var command))
@@ -48,12 +49,15 @@ internal sealed partial class McpToolAdapter
 		}
 
 		var (tokens, prefills) = PrepareExecution(command.Path, arguments);
-		return await ExecuteThroughPipelineAsync(tokens, prefills, ct).ConfigureAwait(false);
+		return await ExecuteThroughPipelineAsync(tokens, prefills, server, progressToken, ct)
+			.ConfigureAwait(false);
 	}
 
 	private async Task<CallToolResult> ExecuteThroughPipelineAsync(
 		List<string> tokens,
 		Dictionary<string, string> prefills,
+		McpServer? server,
+		ProgressToken? progressToken,
 		CancellationToken ct)
 	{
 		var coreApp = _app as CoreReplApp
@@ -61,7 +65,8 @@ internal sealed partial class McpToolAdapter
 
 		var outputWriter = new StringWriter();
 		var inputReader = new StringReader(string.Empty);
-		var interactionChannel = new McpInteractionChannel(prefills, _options.InteractivityMode);
+		var interactionChannel = new McpInteractionChannel(
+			prefills, _options.InteractivityMode, server, progressToken);
 		var mcpServices = new McpServiceProviderOverlay(_services, interactionChannel);
 
 		using (ReplSessionIO.SetSession(

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -145,27 +145,15 @@ internal sealed partial class McpToolAdapter
 			}
 		}
 
+		// Remaining arguments become named options.
+		// Note: answer: prefixes are separated by PrepareExecution upstream
+		// and never reach this method.
 		foreach (var (key, value) in arguments)
 		{
-			if (consumedArgs.Contains(key))
+			if (!consumedArgs.Contains(key))
 			{
-				continue;
-			}
-
-			if (key.StartsWith("answer:", StringComparison.OrdinalIgnoreCase))
-			{
-				continue;
-			}
-
-			tokens.Add($"--{key}");
-			tokens.Add(value?.ToString() ?? "");
-		}
-
-		foreach (var (key, value) in arguments)
-		{
-			if (key.StartsWith("answer:", StringComparison.OrdinalIgnoreCase))
-			{
-				tokens.Add($"--{key}={value}");
+				tokens.Add($"--{key}");
+				tokens.Add(value?.ToString() ?? "");
 			}
 		}
 

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -26,6 +26,11 @@ internal sealed partial class McpToolAdapter
 	}
 
 	/// <summary>
+	/// Clears all registered routes. Called before rebuilding on routing invalidation.
+	/// </summary>
+	public void ClearRoutes() => _toolRoutes.Clear();
+
+	/// <summary>
 	/// Registers a tool name → command mapping for dispatch.
 	/// </summary>
 	public void RegisterRoute(string toolName, ReplDocCommand command)

--- a/src/Repl.Mcp/McpToolNameFlattener.cs
+++ b/src/Repl.Mcp/McpToolNameFlattener.cs
@@ -38,8 +38,9 @@ internal static partial class McpToolNameFlattener
 	/// preserving dynamic segments as RFC 6570 template variables.
 	/// </summary>
 	/// <param name="routePath">Route template (e.g. <c>contact {id:guid} show</c>).</param>
+	/// <param name="scheme">URI scheme (default: <c>repl</c>).</param>
 	/// <returns>URI template (e.g. <c>repl://contact/{id}/show</c>).</returns>
-	public static string BuildResourceUri(string routePath)
+	public static string BuildResourceUri(string routePath, string scheme = "repl")
 	{
 		var segments = routePath.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 		var parts = new List<string>(segments.Length);
@@ -59,7 +60,7 @@ internal static partial class McpToolNameFlattener
 			}
 		}
 
-		return $"repl://{string.Join('/', parts)}";
+		return $"{scheme}://{string.Join('/', parts)}";
 	}
 
 	/// <summary>

--- a/src/Repl.Mcp/McpToolNameFlattener.cs
+++ b/src/Repl.Mcp/McpToolNameFlattener.cs
@@ -1,0 +1,49 @@
+using System.Text.RegularExpressions;
+
+namespace Repl.Mcp;
+
+/// <summary>
+/// Converts Repl route templates into flat MCP tool names.
+/// Dynamic segments (<c>{name}</c>, <c>{name:constraint}</c>) are removed
+/// from the tool name and become required input properties on the JSON Schema.
+/// </summary>
+internal static partial class McpToolNameFlattener
+{
+	/// <summary>
+	/// Flattens a route template into an MCP tool name.
+	/// </summary>
+	/// <param name="routePath">Route template (e.g. <c>contact {id:guid} show</c>).</param>
+	/// <param name="separator">Separator character between segments.</param>
+	/// <returns>Flattened tool name (e.g. <c>contact_show</c>).</returns>
+	public static string Flatten(string routePath, char separator)
+	{
+		var segments = routePath.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+		var parts = new List<string>(segments.Length);
+
+		foreach (var segment in segments)
+		{
+			if (DynamicSegmentPattern().IsMatch(segment))
+			{
+				continue;
+			}
+
+			parts.Add(segment);
+		}
+
+		return string.Join(separator, parts);
+	}
+
+	/// <summary>
+	/// Resolves the separator character from the <see cref="ToolNamingSeparator"/> enum.
+	/// </summary>
+	public static char ResolveSeparator(ToolNamingSeparator separator) => separator switch
+	{
+		ToolNamingSeparator.Underscore => '_',
+		ToolNamingSeparator.Slash => '/',
+		ToolNamingSeparator.Dot => '.',
+		_ => '_',
+	};
+
+	[GeneratedRegex(@"^\{\w+(?::\w+)?\}$", RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 1000)]
+	private static partial Regex DynamicSegmentPattern();
+}

--- a/src/Repl.Mcp/McpToolNameFlattener.cs
+++ b/src/Repl.Mcp/McpToolNameFlattener.cs
@@ -34,6 +34,35 @@ internal static partial class McpToolNameFlattener
 	}
 
 	/// <summary>
+	/// Builds an MCP resource URI template from a route template,
+	/// preserving dynamic segments as RFC 6570 template variables.
+	/// </summary>
+	/// <param name="routePath">Route template (e.g. <c>contact {id:guid} show</c>).</param>
+	/// <returns>URI template (e.g. <c>repl://contact/{id}/show</c>).</returns>
+	public static string BuildResourceUri(string routePath)
+	{
+		var segments = routePath.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+		var parts = new List<string>(segments.Length);
+
+		foreach (var segment in segments)
+		{
+			var match = DynamicSegmentPattern().Match(segment);
+			if (match.Success)
+			{
+				// Strip the constraint: {name:constraint} → {name}
+				var name = segment.TrimStart('{').TrimEnd('}').Split(':')[0];
+				parts.Add($"{{{name}}}");
+			}
+			else
+			{
+				parts.Add(segment);
+			}
+		}
+
+		return $"repl://{string.Join('/', parts)}";
+	}
+
+	/// <summary>
 	/// Resolves the separator character from the <see cref="ToolNamingSeparator"/> enum.
 	/// </summary>
 	public static char ResolveSeparator(ToolNamingSeparator separator) => separator switch

--- a/src/Repl.Mcp/README.md
+++ b/src/Repl.Mcp/README.md
@@ -1,30 +1,37 @@
 # Repl.Mcp
 
-MCP server integration for [Repl Toolkit](https://github.com/yllibed/repl): expose your command graph as AI agent tools, resources, and prompts via the [Model Context Protocol](https://modelcontextprotocol.io).
+MCP server integration for [Repl Toolkit](https://github.com/yllibed/repl) — expose your command graph as AI agent tools via the [Model Context Protocol](https://modelcontextprotocol.io).
 
-## Quick start
+## One line to add
 
 ```csharp
-using Repl;
-
-var app = ReplApp.Create();
-app.Map("greet {name}", (string name) => $"Hello, {name}!");
 app.UseMcpServer();
-await app.RunAsync(args);
 ```
+
+Your commands become MCP tools. Route constraints become JSON Schema. Annotations become safety hints.
 
 ```bash
-myapp mcp serve   # starts MCP stdio server
+myapp mcp serve   # AI agents connect here
+myapp              # still a CLI / interactive REPL
 ```
 
-## Features
+## What agents see
 
-- Auto-derive MCP tools from the command graph with typed JSON Schema
-- Behavioral annotations (`.ReadOnly()`, `.Destructive()`, `.Idempotent()`, `.OpenWorld()`) map to MCP tool hints
-- `.AsResource()` marks data commands as MCP resources
-- `.AsPrompt()` marks commands as MCP prompt templates
-- Progressive interaction degradation (prefill, elicitation, sampling)
-- Real-time progress notifications
-- Dynamic tool discovery via `list_changed`
+| You write | Agents get |
+|---|---|
+| `.ReadOnly()` | `readOnlyHint` — call autonomously |
+| `.Destructive()` | `destructiveHint` — ask for confirmation |
+| `.AsResource()` | MCP resource with `repl://` URI |
+| `.AsPrompt()` | MCP prompt template |
+| `.AutomationHidden()` | Not visible to agents |
+| `{id:guid}` | `{ "type": "string", "format": "uuid" }` |
+| `[Description("...")]` | Schema `description` field |
 
-See the [sample](https://github.com/yllibed/repl/tree/main/samples/08-mcp-server) and the [main README](https://github.com/yllibed/repl) for full documentation.
+## Works with
+
+Claude Desktop, Claude Code, VS Code Copilot, Cursor, and any MCP-compatible agent.
+
+## Learn more
+
+- [Full documentation](https://github.com/yllibed/repl/blob/main/docs/mcp-server.md) — annotations, interaction degradation, client compatibility matrix, agent configuration, NuGet publishing
+- [Sample app](https://github.com/yllibed/repl/tree/main/samples/08-mcp-server) — resources, tools, prompts, and annotations in action

--- a/src/Repl.Mcp/README.md
+++ b/src/Repl.Mcp/README.md
@@ -1,0 +1,30 @@
+# Repl.Mcp
+
+MCP server integration for [Repl Toolkit](https://github.com/yllibed/repl): expose your command graph as AI agent tools, resources, and prompts via the [Model Context Protocol](https://modelcontextprotocol.io).
+
+## Quick start
+
+```csharp
+using Repl;
+
+var app = ReplApp.Create();
+app.Map("greet {name}", (string name) => $"Hello, {name}!");
+app.UseMcpServer();
+await app.RunAsync(args);
+```
+
+```bash
+myapp mcp serve   # starts MCP stdio server
+```
+
+## Features
+
+- Auto-derive MCP tools from the command graph with typed JSON Schema
+- Behavioral annotations (`.ReadOnly()`, `.Destructive()`, `.Idempotent()`, `.OpenWorld()`) map to MCP tool hints
+- `.AsResource()` marks data commands as MCP resources
+- `.AsPrompt()` marks commands as MCP prompt templates
+- Progressive interaction degradation (prefill, elicitation, sampling)
+- Real-time progress notifications
+- Dynamic tool discovery via `list_changed`
+
+See the [sample](https://github.com/yllibed/repl/tree/main/samples/08-mcp-server) and the [main README](https://github.com/yllibed/repl) for full documentation.

--- a/src/Repl.Mcp/Repl.Mcp.csproj
+++ b/src/Repl.Mcp/Repl.Mcp.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<Description>MCP server integration for Repl Toolkit: expose commands as AI agent tools, resources, and prompts.</Description>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<InternalsVisibleTo Include="Repl.McpTests" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Repl.Defaults\Repl.Defaults.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="ModelContextProtocol" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="README.md" Pack="true" PackagePath="" Condition="Exists('README.md')" />
+	</ItemGroup>
+
+</Project>

--- a/src/Repl.Mcp/Repl.Mcp.csproj
+++ b/src/Repl.Mcp/Repl.Mcp.csproj
@@ -19,7 +19,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Include="README.md" Pack="true" PackagePath="" Condition="Exists('README.md')" />
+		<None Include="README.md" Pack="true" PackagePath="" />
 	</ItemGroup>
 
 </Project>

--- a/src/Repl.Mcp/ReplMcpServerOptions.cs
+++ b/src/Repl.Mcp/ReplMcpServerOptions.cs
@@ -45,11 +45,25 @@ public sealed class ReplMcpServerOptions
 	public Func<ReplDocCommand, bool>? CommandFilter { get; set; }
 
 	/// <summary>
-	/// When <c>true</c> (default), resources are also exposed as read-only tools when the client
-	/// does not advertise resource support in its capabilities during the MCP <c>initialize</c> handshake.
+	/// When <c>true</c> (default), commands annotated <c>.ReadOnly()</c> are automatically
+	/// exposed as MCP resources in addition to being tools.
+	/// Set to <c>false</c> to require explicit <c>.AsResource()</c> marking.
 	/// </summary>
-	/// <remarks>Reserved for future implementation. The option is accepted but not yet wired.</remarks>
-	public bool ResourceFallbackToTools { get; set; } = true;
+	public bool AutoPromoteReadOnlyToResources { get; set; } = true;
+
+	/// <summary>
+	/// When <c>true</c>, resources are also exposed as read-only tools.
+	/// This is a compatibility fallback for clients that don't support MCP resources (~61% as of March 2025).
+	/// Default is <c>false</c> — opt in when your target agents lack resource support.
+	/// </summary>
+	public bool ResourceFallbackToTools { get; set; }
+
+	/// <summary>
+	/// When <c>true</c>, prompts are also exposed as tools.
+	/// This is a compatibility fallback for clients that don't support MCP prompts (~62% as of March 2025).
+	/// Default is <c>false</c> — opt in when your target agents lack prompt support.
+	/// </summary>
+	public bool PromptFallbackToTools { get; set; }
 
 	private readonly List<McpPromptRegistration> _prompts = [];
 

--- a/src/Repl.Mcp/ReplMcpServerOptions.cs
+++ b/src/Repl.Mcp/ReplMcpServerOptions.cs
@@ -1,0 +1,73 @@
+using Repl.Documentation;
+
+namespace Repl;
+
+/// <summary>
+/// Configuration for the Repl MCP server integration.
+/// </summary>
+/// <remarks>
+/// Named <c>ReplMcpServerOptions</c> to avoid collision with the SDK's
+/// <c>ModelContextProtocol.Server.McpServerOptions</c>.
+/// </remarks>
+public sealed class ReplMcpServerOptions
+{
+	/// <summary>
+	/// Server name reported in the MCP <c>initialize</c> response.
+	/// Defaults to the assembly product name.
+	/// </summary>
+	public string? ServerName { get; set; }
+
+	/// <summary>
+	/// Server version reported in the MCP <c>initialize</c> response.
+	/// </summary>
+	public string? ServerVersion { get; set; }
+
+	/// <summary>
+	/// Command name for the MCP context (default: <c>"mcp"</c>).
+	/// The serve subcommand becomes: <c>myapp {CommandName} serve</c>.
+	/// </summary>
+	public string CommandName { get; set; } = "mcp";
+
+	/// <summary>
+	/// Separator used when flattening context paths into MCP tool names.
+	/// </summary>
+	public ToolNamingSeparator ToolNamingSeparator { get; set; } = ToolNamingSeparator.Underscore;
+
+	/// <summary>
+	/// Controls how runtime interaction prompts are handled in MCP mode.
+	/// </summary>
+	public InteractivityMode InteractivityMode { get; set; } = InteractivityMode.PrefillThenFail;
+
+	/// <summary>
+	/// Optional filter controlling which commands are exposed as MCP tools.
+	/// When <c>null</c>, all non-hidden, non-<see cref="CommandAnnotations.AutomationHidden"/> commands are exposed.
+	/// </summary>
+	public Func<ReplDocCommand, bool>? CommandFilter { get; set; }
+
+	/// <summary>
+	/// When <c>true</c> (default), resources are also exposed as read-only tools when the client
+	/// does not advertise resource support in its capabilities during the MCP <c>initialize</c> handshake.
+	/// </summary>
+	public bool ResourceFallbackToTools { get; set; } = true;
+
+	private readonly List<McpPromptRegistration> _prompts = [];
+
+	/// <summary>
+	/// Registers an MCP prompt with a DI-injectable handler.
+	/// </summary>
+	/// <param name="name">Prompt name (must be unique).</param>
+	/// <param name="handler">Handler delegate.</param>
+	/// <returns>The same options instance.</returns>
+	public ReplMcpServerOptions Prompt(string name, Delegate handler)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(name);
+		ArgumentNullException.ThrowIfNull(handler);
+		_prompts.Add(new McpPromptRegistration(name, handler));
+		return this;
+	}
+
+	/// <summary>
+	/// Gets the registered prompt definitions.
+	/// </summary>
+	internal IReadOnlyList<McpPromptRegistration> Prompts => _prompts;
+}

--- a/src/Repl.Mcp/ReplMcpServerOptions.cs
+++ b/src/Repl.Mcp/ReplMcpServerOptions.cs
@@ -23,10 +23,10 @@ public sealed class ReplMcpServerOptions
 	public string? ServerVersion { get; set; }
 
 	/// <summary>
-	/// Command name for the MCP context (default: <c>"mcp"</c>).
-	/// The serve subcommand becomes: <c>myapp {CommandName} serve</c>.
+	/// Context name for the MCP subcommands (default: <c>"mcp"</c>).
+	/// The serve subcommand becomes: <c>myapp {ContextName} serve</c>.
 	/// </summary>
-	public string CommandName { get; set; } = "mcp";
+	public string ContextName { get; set; } = "mcp";
 
 	/// <summary>
 	/// Separator used when flattening context paths into MCP tool names.

--- a/src/Repl.Mcp/ReplMcpServerOptions.cs
+++ b/src/Repl.Mcp/ReplMcpServerOptions.cs
@@ -1,3 +1,4 @@
+using ModelContextProtocol.Protocol;
 using Repl.Documentation;
 
 namespace Repl;
@@ -57,6 +58,13 @@ public sealed class ReplMcpServerOptions
 	/// Default is <c>false</c> — opt in when your target agents lack resource support.
 	/// </summary>
 	public bool ResourceFallbackToTools { get; set; }
+
+	/// <summary>
+	/// Optional factory for creating custom MCP transports (e.g. WebSocket, SSE).
+	/// When <c>null</c> (default), the server uses <c>StdioServerTransport</c>.
+	/// The factory receives the server name and the I/O context for stream access.
+	/// </summary>
+	public Func<string, IReplIoContext, ITransport>? TransportFactory { get; set; }
 
 	/// <summary>
 	/// When <c>true</c>, prompts are also exposed as tools.

--- a/src/Repl.Mcp/ReplMcpServerOptions.cs
+++ b/src/Repl.Mcp/ReplMcpServerOptions.cs
@@ -48,6 +48,7 @@ public sealed class ReplMcpServerOptions
 	/// When <c>true</c> (default), resources are also exposed as read-only tools when the client
 	/// does not advertise resource support in its capabilities during the MCP <c>initialize</c> handshake.
 	/// </summary>
+	/// <remarks>Reserved for future implementation. The option is accepted but not yet wired.</remarks>
 	public bool ResourceFallbackToTools { get; set; } = true;
 
 	private readonly List<McpPromptRegistration> _prompts = [];

--- a/src/Repl.Mcp/ReplMcpServerOptions.cs
+++ b/src/Repl.Mcp/ReplMcpServerOptions.cs
@@ -35,6 +35,12 @@ public sealed class ReplMcpServerOptions
 	public ToolNamingSeparator ToolNamingSeparator { get; set; } = ToolNamingSeparator.Underscore;
 
 	/// <summary>
+	/// URI scheme used for MCP resource URIs (default: <c>"repl"</c>).
+	/// Resources are exposed as <c>{scheme}://{path}</c>.
+	/// </summary>
+	public string ResourceUriScheme { get; set; } = "repl";
+
+	/// <summary>
 	/// Controls how runtime interaction prompts are handled in MCP mode.
 	/// </summary>
 	public InteractivityMode InteractivityMode { get; set; } = InteractivityMode.PrefillThenFail;

--- a/src/Repl.Mcp/ReplMcpServerPrompt.cs
+++ b/src/Repl.Mcp/ReplMcpServerPrompt.cs
@@ -70,7 +70,7 @@ internal sealed class ReplMcpServerPrompt : McpServerPrompt
 			: new Dictionary<string, System.Text.Json.JsonElement>(StringComparer.Ordinal);
 
 		var result = await _adapter.InvokeAsync(
-			_protocolPrompt.Name, jsonArgs, server: null, progressToken: null, cancellationToken)
+			_protocolPrompt.Name, jsonArgs, request.Server, progressToken: null, cancellationToken)
 			.ConfigureAwait(false);
 
 		// Surface errors as MCP exceptions so clients can distinguish failures.

--- a/src/Repl.Mcp/ReplMcpServerPrompt.cs
+++ b/src/Repl.Mcp/ReplMcpServerPrompt.cs
@@ -64,15 +64,10 @@ internal sealed class ReplMcpServerPrompt : McpServerPrompt
 		RequestContext<GetPromptRequestParams> request,
 		CancellationToken cancellationToken = default)
 	{
-		var jsonArgs = new Dictionary<string, System.Text.Json.JsonElement>(StringComparer.Ordinal);
-		if (request.Params?.Arguments is { } args)
-		{
-			foreach (var (key, value) in args)
-			{
-				jsonArgs[key] = System.Text.Json.JsonSerializer.SerializeToElement(
-					value, McpJsonContext.Default.String);
-			}
-		}
+		// Prompt arguments are already JsonElement — pass through directly.
+		var jsonArgs = request.Params?.Arguments is { } args
+			? new Dictionary<string, System.Text.Json.JsonElement>(args, StringComparer.Ordinal)
+			: new Dictionary<string, System.Text.Json.JsonElement>(StringComparer.Ordinal);
 
 		var result = await _adapter.InvokeAsync(
 			_protocolPrompt.Name, jsonArgs, server: null, progressToken: null, cancellationToken)

--- a/src/Repl.Mcp/ReplMcpServerPrompt.cs
+++ b/src/Repl.Mcp/ReplMcpServerPrompt.cs
@@ -1,0 +1,105 @@
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Repl.Documentation;
+
+namespace Repl.Mcp;
+
+/// <summary>
+/// Custom <see cref="McpServerPrompt"/> subclass that derives prompt arguments from
+/// the Repl documentation model and dispatches through the Repl pipeline.
+/// </summary>
+internal sealed class ReplMcpServerPrompt : McpServerPrompt
+{
+	private readonly McpToolAdapter _adapter;
+	private readonly ReplDocCommand _command;
+	private readonly Prompt _protocolPrompt;
+
+	public ReplMcpServerPrompt(
+		ReplDocCommand command,
+		string promptName,
+		McpToolAdapter adapter)
+	{
+		_adapter = adapter;
+		_command = command;
+
+		// Build prompt arguments from the command's route arguments and options.
+		var arguments = new List<PromptArgument>();
+		foreach (var arg in command.Arguments)
+		{
+			arguments.Add(new PromptArgument
+			{
+				Name = arg.Name,
+				Description = arg.Description,
+				Required = false, // MCP spec: all prompt arguments must be optional.
+			});
+		}
+
+		foreach (var opt in command.Options)
+		{
+			arguments.Add(new PromptArgument
+			{
+				Name = opt.Name,
+				Description = opt.Description,
+				Required = false,
+			});
+		}
+
+		_protocolPrompt = new Prompt
+		{
+			Name = promptName,
+			Description = command.Description,
+			Arguments = arguments,
+		};
+	}
+
+	/// <inheritdoc />
+	public override Prompt ProtocolPrompt => _protocolPrompt;
+
+	/// <inheritdoc />
+	public override IReadOnlyList<object> Metadata { get; } = [];
+
+	/// <inheritdoc />
+	public override async ValueTask<GetPromptResult> GetAsync(
+		RequestContext<GetPromptRequestParams> request,
+		CancellationToken cancellationToken = default)
+	{
+		var jsonArgs = new Dictionary<string, System.Text.Json.JsonElement>(StringComparer.Ordinal);
+		if (request.Params?.Arguments is { } args)
+		{
+			foreach (var (key, value) in args)
+			{
+				jsonArgs[key] = System.Text.Json.JsonSerializer.SerializeToElement(
+					value, McpJsonContext.Default.String);
+			}
+		}
+
+		var result = await _adapter.InvokeAsync(
+			_protocolPrompt.Name, jsonArgs, server: null, progressToken: null, cancellationToken)
+			.ConfigureAwait(false);
+
+		// Surface errors as MCP exceptions so clients can distinguish failures.
+		if (result.IsError == true)
+		{
+			var errorText = result.Content?.OfType<TextContentBlock>().FirstOrDefault()?.Text
+				?? "Prompt execution failed.";
+			throw new McpException(errorText);
+		}
+
+		var text = result.Content?.OfType<TextContentBlock>().FirstOrDefault()?.Text
+			?? _command.Description
+			?? _protocolPrompt.Name;
+
+		return new GetPromptResult
+		{
+			Messages =
+			[
+				new PromptMessage
+				{
+					Role = Role.User,
+					Content = new TextContentBlock { Text = text },
+				},
+			],
+		};
+	}
+}

--- a/src/Repl.Mcp/ReplMcpServerResource.cs
+++ b/src/Repl.Mcp/ReplMcpServerResource.cs
@@ -1,0 +1,164 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Repl.Documentation;
+
+namespace Repl.Mcp;
+
+/// <summary>
+/// Custom <see cref="McpServerResource"/> subclass that extracts URI template variables
+/// and dispatches reads through the Repl pipeline via <see cref="McpToolAdapter"/>.
+/// </summary>
+internal sealed partial class ReplMcpServerResource : McpServerResource
+{
+	private readonly string _resourceName;
+	private readonly McpToolAdapter _adapter;
+	private readonly ResourceTemplate _protocolResourceTemplate;
+	private readonly Regex? _uriParser;
+	private readonly string[] _variableNames;
+
+	public ReplMcpServerResource(
+		ReplDocResource resource,
+		string resourceName,
+		string uriTemplate,
+		McpToolAdapter adapter)
+	{
+		_resourceName = resourceName;
+		_adapter = adapter;
+		_protocolResourceTemplate = new ResourceTemplate
+		{
+			Name = resourceName,
+			Description = resource.Description,
+			UriTemplate = uriTemplate,
+			MimeType = "text/plain",
+		};
+
+		// Build a regex to extract template variables from the URI.
+		// Each {varName} becomes (?<varName>[^/]+), literals are Regex.Escape'd.
+		_variableNames = BuildUriParser(uriTemplate, out _uriParser);
+	}
+
+	/// <inheritdoc />
+	public override ResourceTemplate ProtocolResourceTemplate => _protocolResourceTemplate;
+
+	/// <inheritdoc />
+	public override IReadOnlyList<object> Metadata { get; } = [];
+
+	/// <inheritdoc />
+	public override bool IsMatch(string uri)
+	{
+		ArgumentNullException.ThrowIfNull(uri);
+
+		if (_uriParser is not null)
+		{
+			return _uriParser.IsMatch(uri);
+		}
+
+		return string.Equals(uri, _protocolResourceTemplate.UriTemplate, StringComparison.OrdinalIgnoreCase);
+	}
+
+	/// <inheritdoc />
+	public override async ValueTask<ReadResourceResult> ReadAsync(
+		RequestContext<ReadResourceRequestParams> request,
+		CancellationToken cancellationToken = default)
+	{
+		var arguments = ExtractArguments(request.Params!.Uri);
+
+		var result = await _adapter.InvokeAsync(
+			_resourceName, arguments, request.Server, progressToken: null, cancellationToken)
+			.ConfigureAwait(false);
+
+		if (result.IsError == true)
+		{
+			var errorText = result.Content?.OfType<TextContentBlock>().FirstOrDefault()?.Text
+				?? "Resource read failed.";
+			throw new McpException(errorText);
+		}
+
+		var text = result.Content?.OfType<TextContentBlock>().FirstOrDefault()?.Text ?? "";
+		return new ReadResourceResult
+		{
+			Contents =
+			[
+				new TextResourceContents
+				{
+					Uri = request.Params.Uri,
+					MimeType = "text/plain",
+					Text = text,
+				},
+			],
+		};
+	}
+
+	private Dictionary<string, JsonElement> ExtractArguments(string uri)
+	{
+		var arguments = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+
+		if (_uriParser is null)
+		{
+			return arguments;
+		}
+
+		var match = _uriParser.Match(uri);
+		if (!match.Success)
+		{
+			return arguments;
+		}
+
+		foreach (var name in _variableNames)
+		{
+			if (match.Groups[name] is { Success: true } group)
+			{
+				var value = Uri.UnescapeDataString(group.Value);
+				arguments[name] = JsonSerializer.SerializeToElement(value, McpJsonContext.Default.String);
+			}
+		}
+
+		return arguments;
+	}
+
+	private static string[] BuildUriParser(string uriTemplate, out Regex? parser)
+	{
+		var variableNames = new List<string>();
+		var regexParts = new System.Text.StringBuilder("^");
+
+		var remaining = uriTemplate.AsSpan();
+		while (remaining.Length > 0)
+		{
+			var braceIndex = remaining.IndexOf('{');
+			if (braceIndex < 0)
+			{
+				regexParts.Append(Regex.Escape(remaining.ToString()));
+				break;
+			}
+
+			// Literal before the brace.
+			if (braceIndex > 0)
+			{
+				regexParts.Append(Regex.Escape(remaining[..braceIndex].ToString()));
+			}
+
+			var closeIndex = remaining.IndexOf('}');
+			var name = remaining[(braceIndex + 1)..closeIndex].ToString();
+			variableNames.Add(name);
+			regexParts.Append($"(?<{name}>[^/]+)");
+			remaining = remaining[(closeIndex + 1)..];
+		}
+
+		regexParts.Append('$');
+
+		if (variableNames.Count == 0)
+		{
+			parser = null;
+			return [];
+		}
+
+		parser = new Regex(
+			regexParts.ToString(),
+			RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture,
+			TimeSpan.FromSeconds(1));
+		return [.. variableNames];
+	}
+}

--- a/src/Repl.Mcp/ReplMcpServerTool.cs
+++ b/src/Repl.Mcp/ReplMcpServerTool.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Repl.Documentation;
+
+namespace Repl.Mcp;
+
+/// <summary>
+/// Custom <see cref="McpServerTool"/> subclass that generates schema from Repl's
+/// documentation model and dispatches calls through the Repl pipeline.
+/// </summary>
+internal sealed class ReplMcpServerTool : McpServerTool
+{
+	private readonly McpToolAdapter _adapter;
+	private readonly Tool _protocolTool;
+
+	public ReplMcpServerTool(
+		ReplDocCommand command,
+		string toolName,
+		McpToolAdapter adapter)
+	{
+		_adapter = adapter;
+		_protocolTool = new Tool
+		{
+			Name = toolName,
+			Description = McpSchemaGenerator.BuildDescription(command),
+			InputSchema = McpSchemaGenerator.BuildInputSchema(command),
+			Annotations = McpSchemaGenerator.MapAnnotations(command.Annotations),
+		};
+	}
+
+	/// <inheritdoc />
+	public override Tool ProtocolTool => _protocolTool;
+
+	/// <inheritdoc />
+	public override IReadOnlyList<object> Metadata { get; } = [];
+
+	/// <inheritdoc />
+	public override async ValueTask<CallToolResult> InvokeAsync(
+		RequestContext<CallToolRequestParams> request,
+		CancellationToken cancellationToken = default)
+	{
+		var arguments = request.Params?.Arguments ?? new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+		return await _adapter.InvokeAsync(
+			_protocolTool.Name, arguments, request.Server, cancellationToken)
+			.ConfigureAwait(false);
+	}
+}

--- a/src/Repl.Mcp/ReplMcpServerTool.cs
+++ b/src/Repl.Mcp/ReplMcpServerTool.cs
@@ -14,6 +14,10 @@ internal sealed class ReplMcpServerTool : McpServerTool
 	private readonly McpToolAdapter _adapter;
 	private readonly Tool _protocolTool;
 
+	// MCP Tasks are experimental in the SDK (MCPEXP001) but part of the MCP spec.
+	// LongRunning commands advertise optional task support so agents can use
+	// the call-now/poll-later pattern instead of blocking on slow operations.
+#pragma warning disable MCPEXP001
 	public ReplMcpServerTool(
 		ReplDocCommand command,
 		string toolName,
@@ -26,8 +30,12 @@ internal sealed class ReplMcpServerTool : McpServerTool
 			Description = McpSchemaGenerator.BuildDescription(command),
 			InputSchema = McpSchemaGenerator.BuildInputSchema(command),
 			Annotations = McpSchemaGenerator.MapAnnotations(command.Annotations),
+			Execution = command.Annotations?.LongRunning == true
+				? new ToolExecution { TaskSupport = ToolTaskSupport.Optional }
+				: null,
 		};
 	}
+#pragma warning restore MCPEXP001
 
 	/// <inheritdoc />
 	public override Tool ProtocolTool => _protocolTool;

--- a/src/Repl.Mcp/ReplMcpServerTool.cs
+++ b/src/Repl.Mcp/ReplMcpServerTool.cs
@@ -40,9 +40,12 @@ internal sealed class ReplMcpServerTool : McpServerTool
 		RequestContext<CallToolRequestParams> request,
 		CancellationToken cancellationToken = default)
 	{
-		var arguments = request.Params?.Arguments ?? new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+		var arguments = request.Params?.Arguments
+			?? new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+		var progressToken = request.Params?.ProgressToken;
+
 		return await _adapter.InvokeAsync(
-			_protocolTool.Name, arguments, request.Server, cancellationToken)
+			_protocolTool.Name, arguments, request.Server, progressToken, cancellationToken)
 			.ConfigureAwait(false);
 	}
 }

--- a/src/Repl.Mcp/ToolNamingSeparator.cs
+++ b/src/Repl.Mcp/ToolNamingSeparator.cs
@@ -1,0 +1,16 @@
+namespace Repl;
+
+/// <summary>
+/// Separator style for flattening context paths into MCP tool names.
+/// </summary>
+public enum ToolNamingSeparator
+{
+	/// <summary>Underscore: <c>contact_add</c>.</summary>
+	Underscore,
+
+	/// <summary>Slash: <c>contact/add</c>.</summary>
+	Slash,
+
+	/// <summary>Dot: <c>contact.add</c>.</summary>
+	Dot,
+}

--- a/src/Repl.McpTests/Given_McpConcurrentSessions.cs
+++ b/src/Repl.McpTests/Given_McpConcurrentSessions.cs
@@ -1,0 +1,72 @@
+using ModelContextProtocol.Protocol;
+
+namespace Repl.McpTests;
+
+[TestClass]
+public sealed class Given_McpConcurrentSessions
+{
+	[TestMethod]
+	[Description("Two independent MCP sessions can run concurrently without interference.")]
+	public async Task When_TwoSessionsRunConcurrently_Then_EachSeesOwnTools()
+	{
+		var session1 = await McpTestFixture.CreateAsync(app =>
+		{
+			app.Map("alpha", () => "a");
+		}).ConfigureAwait(false);
+
+		await using (session1.ConfigureAwait(false))
+		{
+			var session2 = await McpTestFixture.CreateAsync(app =>
+			{
+				app.Map("beta", () => "b");
+				app.Map("gamma", () => "c");
+			}).ConfigureAwait(false);
+
+			await using (session2.ConfigureAwait(false))
+			{
+				var tools1 = await session1.Client.ListToolsAsync().ConfigureAwait(false);
+				var tools2 = await session2.Client.ListToolsAsync().ConfigureAwait(false);
+
+				tools1.Should().ContainSingle(t => string.Equals(t.Name, "alpha", StringComparison.Ordinal));
+				tools1.Should().NotContain(t => string.Equals(t.Name, "beta", StringComparison.Ordinal));
+
+				tools2.Should().NotContain(t => string.Equals(t.Name, "alpha", StringComparison.Ordinal));
+				tools2.Should().HaveCount(2);
+			}
+		}
+	}
+
+	[TestMethod]
+	[Description("Concurrent tool invocations on separate sessions do not cross-contaminate output.")]
+	public async Task When_ToolsInvokedConcurrently_Then_OutputIsIsolated()
+	{
+		var session1 = await McpTestFixture.CreateAsync(app =>
+		{
+			app.Map("echo {msg}", (string msg) => $"s1:{msg}");
+		}).ConfigureAwait(false);
+
+		await using (session1.ConfigureAwait(false))
+		{
+			var session2 = await McpTestFixture.CreateAsync(app =>
+			{
+				app.Map("echo {msg}", (string msg) => $"s2:{msg}");
+			}).ConfigureAwait(false);
+
+			await using (session2.ConfigureAwait(false))
+			{
+				var result1 = await session1.Client.CallToolAsync(
+					"echo", new Dictionary<string, object?>(StringComparer.Ordinal) { ["msg"] = "hello" })
+					.ConfigureAwait(false);
+				var result2 = await session2.Client.CallToolAsync(
+					"echo", new Dictionary<string, object?>(StringComparer.Ordinal) { ["msg"] = "hello" })
+					.ConfigureAwait(false);
+
+				var text1 = result1.Content.OfType<TextContentBlock>().First().Text;
+				var text2 = result2.Content.OfType<TextContentBlock>().First().Text;
+
+				text1.Should().Contain("s1:hello");
+				text2.Should().Contain("s2:hello");
+			}
+		}
+	}
+}

--- a/src/Repl.McpTests/Given_McpDebounce.cs
+++ b/src/Repl.McpTests/Given_McpDebounce.cs
@@ -1,0 +1,127 @@
+using System.IO.Pipelines;
+using Microsoft.Extensions.Time.Testing;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Repl.Mcp;
+
+namespace Repl.McpTests;
+
+[TestClass]
+public sealed class Given_McpDebounce
+{
+	[TestMethod]
+	[Description("Multiple rapid routing invalidations are coalesced into a single rebuild after debounce delay.")]
+	public void When_MultipleInvalidations_Then_SingleRebuildAfterDebounce()
+	{
+		var fakeTime = new FakeTimeProvider();
+		using var fixture = CreateServerFixture(fakeTime);
+
+		// Verify initial state.
+		var tools = SyncWait(fixture.Client.ListToolsAsync().AsTask());
+		tools.Should().ContainSingle(t => string.Equals(t.Name, "initial", StringComparison.Ordinal));
+
+		// Fire 5 rapid invalidations — debounce timer resets each time, no rebuild yet.
+		for (var i = 0; i < 5; i++)
+		{
+			fixture.App.Core.InvalidateRouting();
+		}
+
+		// Add a new command so the rebuild produces a visible change.
+		fixture.App.Map("added-after", () => "new");
+		fixture.App.Core.InvalidateRouting();
+
+		// FakeTimeProvider.Advance() fires timer callbacks synchronously in the
+		// calling thread — no Thread.Sleep or polling needed.
+		fakeTime.Advance(TimeSpan.FromMilliseconds(150));
+
+		// Verify the rebuild happened — new tool should be visible.
+		var updatedTools = SyncWait(fixture.Client.ListToolsAsync().AsTask());
+		updatedTools.Should().Contain(
+			t => string.Equals(t.Name, "added-after", StringComparison.Ordinal),
+			"debounce should have triggered a rebuild that includes the new command");
+	}
+
+	// ── Sync-over-async helper ──────────────────────────────────────────
+	// FakeTimeProvider requires synchronous test control — timer callbacks
+	// fire during Advance(), so the test method must be sync. Async calls
+	// (MCP client) are awaited via bounded Wait() to fail fast on deadlock.
+
+#pragma warning disable VSTHRD002 // Intentional sync-over-async for deterministic time tests.
+	private static T SyncWait<T>(Task<T> task)
+	{
+		if (!task.Wait(TimeSpan.FromSeconds(10)))
+		{
+			throw new TimeoutException("Task did not complete — possible deadlock.");
+		}
+
+		return task.GetAwaiter().GetResult();
+	}
+#pragma warning restore VSTHRD002
+
+	// ── Fixture ─────────────────────────────────────────────────────────
+
+	private static ServerFixture CreateServerFixture(TimeProvider timeProvider)
+	{
+		var app = ReplApp.Create();
+		app.UseMcpServer();
+		app.Map("initial", () => "ok");
+
+		var clientToServer = new Pipe();
+		var serverToClient = new Pipe();
+		var options = new ReplMcpServerOptions
+		{
+			TransportFactory = (name, _) => new StreamServerTransport(
+				clientToServer.Reader.AsStream(),
+				serverToClient.Writer.AsStream(), name),
+		};
+		var services = new FakeServiceProvider(timeProvider);
+		var handler = new McpServerHandler(app.Core, options, services);
+		var cts = new CancellationTokenSource();
+
+		// RunAsync subscribes to RoutingInvalidated and blocks on the transport.
+		var serverTask = handler.RunAsync(new NullIoContext(), cts.Token);
+		var client = SyncWait(McpClient.CreateAsync(
+			new StreamClientTransport(
+				clientToServer.Writer.AsStream(),
+				serverToClient.Reader.AsStream())));
+
+		return new ServerFixture(app, client, cts, clientToServer, serverToClient, serverTask);
+	}
+
+	private sealed class ServerFixture(
+		ReplApp app, McpClient client,
+		CancellationTokenSource cts, Pipe c2s, Pipe s2c, Task serverTask) : IDisposable
+	{
+		public ReplApp App => app;
+		public McpClient Client => client;
+
+#pragma warning disable VSTHRD002
+		public void Dispose()
+		{
+			client.DisposeAsync().AsTask().GetAwaiter().GetResult();
+			cts.Cancel();
+			c2s.Writer.Complete();
+			s2c.Writer.Complete();
+			try { serverTask.GetAwaiter().GetResult(); }
+			catch (OperationCanceledException) { }
+			cts.Dispose();
+		}
+#pragma warning restore VSTHRD002
+	}
+
+	private sealed class FakeServiceProvider(TimeProvider timeProvider) : IServiceProvider
+	{
+		public object? GetService(Type serviceType) =>
+			serviceType == typeof(TimeProvider) ? timeProvider : null;
+	}
+
+	private sealed class NullIoContext : IReplIoContext
+	{
+		public TextReader Input => TextReader.Null;
+		public TextWriter Output => TextWriter.Null;
+		public TextWriter Error => TextWriter.Null;
+		public bool IsHostedSession => false;
+		public string? SessionId => null;
+	}
+}

--- a/src/Repl.McpTests/Given_McpDebounce.cs
+++ b/src/Repl.McpTests/Given_McpDebounce.cs
@@ -42,6 +42,29 @@ public sealed class Given_McpDebounce
 			"debounce should have triggered a rebuild that includes the new command");
 	}
 
+	[TestMethod]
+	[Description("Exception during routing rebuild does not crash the server.")]
+	public void When_RebuildThrows_Then_ServerContinuesWithStaleRoutes()
+	{
+		var fakeTime = new FakeTimeProvider();
+		using var fixture = CreateServerFixture(fakeTime);
+
+		// Verify initial state — tool is available.
+		var tools = SyncWait(fixture.Client.ListToolsAsync().AsTask());
+		tools.Should().ContainSingle(t => string.Equals(t.Name, "initial", StringComparison.Ordinal));
+
+		// Add a command filter that will throw during the next rebuild.
+		fixture.Options.CommandFilter = _ => throw new InvalidOperationException("Simulated rebuild failure");
+		fixture.App.Core.InvalidateRouting();
+
+		// Advance time to trigger the rebuild — should not crash.
+		fakeTime.Advance(TimeSpan.FromMilliseconds(150));
+
+		// Server should still respond — existing tools remain.
+		var toolsAfter = SyncWait(fixture.Client.ListToolsAsync().AsTask());
+		toolsAfter.Should().NotBeEmpty("server should continue with stale routes after rebuild failure");
+	}
+
 	// ── Sync-over-async helper ──────────────────────────────────────────
 	// FakeTimeProvider requires synchronous test control — timer callbacks
 	// fire during Advance(), so the test method must be sync. Async calls
@@ -86,14 +109,15 @@ public sealed class Given_McpDebounce
 				clientToServer.Writer.AsStream(),
 				serverToClient.Reader.AsStream())));
 
-		return new ServerFixture(app, client, cts, clientToServer, serverToClient, serverTask);
+		return new ServerFixture(app, options, client, cts, clientToServer, serverToClient, serverTask);
 	}
 
 	private sealed class ServerFixture(
-		ReplApp app, McpClient client,
+		ReplApp app, ReplMcpServerOptions options, McpClient client,
 		CancellationTokenSource cts, Pipe c2s, Pipe s2c, Task serverTask) : IDisposable
 	{
 		public ReplApp App => app;
+		public ReplMcpServerOptions Options => options;
 		public McpClient Client => client;
 
 #pragma warning disable VSTHRD002
@@ -104,7 +128,7 @@ public sealed class Given_McpDebounce
 			c2s.Writer.Complete();
 			s2c.Writer.Complete();
 			try { serverTask.GetAwaiter().GetResult(); }
-			catch (OperationCanceledException) { }
+			catch (OperationCanceledException) { /* Expected: server RunAsync cancelled during shutdown. */ }
 			cts.Dispose();
 		}
 #pragma warning restore VSTHRD002

--- a/src/Repl.McpTests/Given_McpFallbackEndToEnd.cs
+++ b/src/Repl.McpTests/Given_McpFallbackEndToEnd.cs
@@ -1,0 +1,143 @@
+using ModelContextProtocol.Protocol;
+
+namespace Repl.McpTests;
+
+/// <summary>
+/// End-to-end tests for resource→tool and prompt→tool fallback behavior.
+/// Uses the real McpServerHandler pipeline via McpTestFixture.
+/// </summary>
+[TestClass]
+public sealed class Given_McpFallbackEndToEnd
+{
+	// ── Resource fallback ──────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Resource-only command is NOT a tool when ResourceFallbackToTools is disabled.")]
+	public async Task When_ResourceFallbackDisabled_Then_ResourceNotInTools()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(
+			app => app.Map("config", () => "data").AsResource(),
+			configureOptions: null);
+
+		var tools = await fixture.Client.ListToolsAsync();
+
+		tools.Should().NotContain(t => string.Equals(t.Name, "config", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	[Description("Resource-only command IS a tool when ResourceFallbackToTools is enabled.")]
+	public async Task When_ResourceFallbackEnabled_Then_ResourceAlsoInTools()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(
+			app => app.Map("config", () => "data").AsResource(),
+			configureOptions: o => o.ResourceFallbackToTools = true);
+
+		var tools = await fixture.Client.ListToolsAsync();
+
+		tools.Should().ContainSingle(t => string.Equals(t.Name, "config", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	[Description("ReadOnly+AsResource command is always a tool regardless of fallback setting.")]
+	public async Task When_ReadOnlyAsResource_Then_AlwaysATool()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(
+			app => app.Map("status", () => "ok").ReadOnly().AsResource(),
+			configureOptions: null);
+
+		var tools = await fixture.Client.ListToolsAsync();
+
+		tools.Should().ContainSingle(t => string.Equals(t.Name, "status", StringComparison.Ordinal));
+	}
+
+	// ── Prompt fallback ────────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Prompt-only command is NOT a tool when PromptFallbackToTools is disabled.")]
+	public async Task When_PromptFallbackDisabled_Then_PromptNotInTools()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(
+			app => app.Map("explain {topic}", (string topic) => $"Explain {topic}").AsPrompt(),
+			configureOptions: null);
+
+		var tools = await fixture.Client.ListToolsAsync();
+
+		tools.Should().NotContain(t => string.Equals(t.Name, "explain", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	[Description("Prompt-only command IS a tool when PromptFallbackToTools is enabled.")]
+	public async Task When_PromptFallbackEnabled_Then_PromptAlsoInTools()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(
+			app => app.Map("explain {topic}", (string topic) => $"Explain {topic}").AsPrompt(),
+			configureOptions: o => o.PromptFallbackToTools = true);
+
+		var tools = await fixture.Client.ListToolsAsync();
+
+		tools.Should().ContainSingle(t => string.Equals(t.Name, "explain", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	[Description("Prompt is in prompts/list regardless of PromptFallbackToTools.")]
+	public async Task When_PromptFallbackEnabled_Then_StillInPromptsList()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(
+			app => app.Map("explain {topic}", (string topic) => $"Explain {topic}").AsPrompt(),
+			configureOptions: o => o.PromptFallbackToTools = true);
+
+		var prompts = await fixture.Client.ListPromptsAsync();
+
+		prompts.Should().ContainSingle(p => string.Equals(p.Name, "explain", StringComparison.Ordinal));
+	}
+
+	// ── Mixed scenarios ────────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("With both fallbacks enabled, all commands are visible as tools.")]
+	public async Task When_BothFallbacksEnabled_Then_AllCommandsAreTools()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(
+			app =>
+			{
+				app.Map("list", () => "items").ReadOnly();
+				app.Map("config", () => "data").AsResource();
+				app.Map("explain {topic}", (string topic) => $"Explain {topic}").AsPrompt();
+			},
+			configureOptions: o =>
+			{
+				o.ResourceFallbackToTools = true;
+				o.PromptFallbackToTools = true;
+			});
+
+		var tools = await fixture.Client.ListToolsAsync();
+
+		tools.Should().Contain(t => string.Equals(t.Name, "list", StringComparison.Ordinal));
+		tools.Should().Contain(t => string.Equals(t.Name, "config", StringComparison.Ordinal));
+		tools.Should().Contain(t => string.Equals(t.Name, "explain", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	[Description("AutomationHidden commands are excluded even with fallbacks enabled.")]
+	public async Task When_AutomationHiddenWithFallbacks_Then_StillExcluded()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(
+			app =>
+			{
+				app.Map("visible", () => "ok").ReadOnly();
+				app.Map("hidden-resource", () => "secret").AsResource().AutomationHidden();
+				app.Map("hidden-prompt {x}", (string x) => x).AsPrompt().AutomationHidden();
+			},
+			configureOptions: o =>
+			{
+				o.ResourceFallbackToTools = true;
+				o.PromptFallbackToTools = true;
+			});
+
+		var tools = await fixture.Client.ListToolsAsync();
+
+		tools.Should().ContainSingle(t => string.Equals(t.Name, "visible", StringComparison.Ordinal));
+		tools.Should().NotContain(t => string.Equals(t.Name, "hidden-resource", StringComparison.Ordinal));
+		tools.Should().NotContain(t => string.Equals(t.Name, "hidden-prompt", StringComparison.Ordinal));
+	}
+}

--- a/src/Repl.McpTests/Given_McpFallbackOptions.cs
+++ b/src/Repl.McpTests/Given_McpFallbackOptions.cs
@@ -125,8 +125,86 @@ public sealed class Given_McpFallbackOptions
 			new ReplMcpServerOptions { ResourceFallbackToTools = true, PromptFallbackToTools = true });
 
 		tools.Should().BeEmpty();
-		// Resources are generated from the doc model, which includes AutomationHidden.
-		// But they won't be callable since the tool adapter won't route them.
+		// AutomationHidden commands are excluded from all MCP surfaces.
+		prompts.Should().BeEmpty();
+	}
+
+	// ── Hidden/AutomationHidden filtering on resources and prompts ──────
+
+	[TestMethod]
+	[Description("Hidden resource commands are excluded from resources/list.")]
+	public void When_HiddenResource_Then_ExcludedFromResources()
+	{
+		var (_, resources, _) = Generate(
+			app => app.Map("secret-config", () => "ok").AsResource().Hidden(),
+			new ReplMcpServerOptions());
+
+		resources.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	[Description("AutomationHidden resource commands are excluded from resources/list.")]
+	public void When_AutomationHiddenResource_Then_ExcludedFromResources()
+	{
+		var (_, resources, _) = Generate(
+			app => app.Map("debug-state", () => "ok").AsResource().AutomationHidden(),
+			new ReplMcpServerOptions());
+
+		resources.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	[Description("Hidden prompt commands are excluded from prompts/list.")]
+	public void When_HiddenPrompt_Then_ExcludedFromPrompts()
+	{
+		var (_, _, prompts) = Generate(
+			app => app.Map("internal-prompt {x}", (string x) => x).AsPrompt().Hidden(),
+			new ReplMcpServerOptions());
+
+		prompts.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	[Description("AutomationHidden prompt commands are excluded from prompts/list.")]
+	public void When_AutomationHiddenPrompt_Then_ExcludedFromPrompts()
+	{
+		var (_, _, prompts) = Generate(
+			app => app.Map("wizard-prompt {x}", (string x) => x).AsPrompt().AutomationHidden(),
+			new ReplMcpServerOptions());
+
+		prompts.Should().BeEmpty();
+	}
+
+	// ── Tool name collision detection ──────────────────────────────────
+
+	[TestMethod]
+	[Description("Different routes that flatten to the same tool name throw at startup.")]
+	public void When_DifferentRoutesCollide_Then_ThrowsAtStartup()
+	{
+		var act = () => Generate(
+			app =>
+			{
+				app.Map("contact add", () => "ok");
+				app.Map("contact_add", () => "ok");
+			},
+			new ReplMcpServerOptions());
+
+		act.Should().Throw<Exception>()
+			.WithInnerException<InvalidOperationException>()
+			.WithMessage("*collision*");
+	}
+
+	[TestMethod]
+	[Description("Same command in multiple phases (ReadOnly = core + resource fallback) does not throw.")]
+	public void When_SameCommandInMultiplePhases_Then_NoDuplicate()
+	{
+		var (tools, resources, _) = Generate(
+			app => app.Map("status", () => "ok").ReadOnly().AsResource(),
+			new ReplMcpServerOptions { ResourceFallbackToTools = true });
+
+		tools.Should().ContainSingle(t =>
+			string.Equals(t.ProtocolTool.Name, "status", StringComparison.Ordinal));
+		resources.Should().ContainSingle();
 	}
 
 	// ── Helpers ─────────────────────────────────────────────────────────

--- a/src/Repl.McpTests/Given_McpFallbackOptions.cs
+++ b/src/Repl.McpTests/Given_McpFallbackOptions.cs
@@ -1,0 +1,167 @@
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Repl.Documentation;
+using Repl.Mcp;
+
+namespace Repl.McpTests;
+
+/// <summary>
+/// Tests the resource/prompt fallback-to-tools behavior and the
+/// AutoPromoteReadOnlyToResources option.
+/// Uses McpServerHandler internals to verify tool/resource/prompt generation.
+/// </summary>
+[TestClass]
+public sealed class Given_McpFallbackOptions
+{
+	// ── AutoPromoteReadOnlyToResources ──────────────────────────────────
+
+	[TestMethod]
+	[Description("ReadOnly commands are auto-promoted to resources by default.")]
+	public void When_ReadOnlyDefault_Then_AppearsInResources()
+	{
+		var (tools, resources, _) = Generate(
+			app => app.Map("status", () => "ok").ReadOnly(),
+			new ReplMcpServerOptions());
+
+		tools.Should().ContainSingle(t => string.Equals(t.ProtocolTool.Name, "status", StringComparison.Ordinal));
+		resources.Should().ContainSingle();
+	}
+
+	[TestMethod]
+	[Description("ReadOnly auto-promotion can be disabled.")]
+	public void When_AutoPromoteDisabled_Then_ReadOnlyNotInResources()
+	{
+		var (tools, resources, _) = Generate(
+			app => app.Map("status", () => "ok").ReadOnly(),
+			new ReplMcpServerOptions { AutoPromoteReadOnlyToResources = false });
+
+		tools.Should().ContainSingle(t => string.Equals(t.ProtocolTool.Name, "status", StringComparison.Ordinal));
+		resources.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	[Description("Explicit AsResource is not affected by AutoPromoteReadOnlyToResources.")]
+	public void When_ExplicitAsResource_Then_AlwaysInResources()
+	{
+		var (_, resources, _) = Generate(
+			app => app.Map("contacts", () => "ok").AsResource(),
+			new ReplMcpServerOptions { AutoPromoteReadOnlyToResources = false });
+
+		resources.Should().ContainSingle();
+	}
+
+	// ── ResourceFallbackToTools ────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Resource-only commands are NOT tools by default.")]
+	public void When_ResourceOnly_Then_NotATool()
+	{
+		var (tools, resources, _) = Generate(
+			app => app.Map("config", () => "ok").AsResource(),
+			new ReplMcpServerOptions());
+
+		tools.Should().NotContain(t => string.Equals(t.ProtocolTool.Name, "config", StringComparison.Ordinal));
+		resources.Should().ContainSingle();
+	}
+
+	[TestMethod]
+	[Description("Resource-only commands become tools when ResourceFallbackToTools is enabled.")]
+	public void When_ResourceFallbackEnabled_Then_ResourceAlsoATool()
+	{
+		var (tools, resources, _) = Generate(
+			app => app.Map("config", () => "ok").AsResource(),
+			new ReplMcpServerOptions { ResourceFallbackToTools = true });
+
+		tools.Should().ContainSingle(t => string.Equals(t.ProtocolTool.Name, "config", StringComparison.Ordinal));
+		resources.Should().ContainSingle();
+	}
+
+	[TestMethod]
+	[Description("ReadOnly+AsResource: tool (always) + resource (always), no duplicate tool with fallback.")]
+	public void When_ReadOnlyAsResource_Then_OneToolOneResource()
+	{
+		var (tools, resources, _) = Generate(
+			app => app.Map("contacts", () => "ok").ReadOnly().AsResource(),
+			new ReplMcpServerOptions { ResourceFallbackToTools = true });
+
+		tools.Should().ContainSingle(t => string.Equals(t.ProtocolTool.Name, "contacts", StringComparison.Ordinal));
+		resources.Should().ContainSingle();
+	}
+
+	// ── PromptFallbackToTools ──────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Prompt-only commands are NOT tools by default.")]
+	public void When_PromptOnly_Then_NotATool()
+	{
+		var (tools, _, prompts) = Generate(
+			app => app.Map("troubleshoot {symptom}", (string symptom) => $"Diagnose: {symptom}").AsPrompt(),
+			new ReplMcpServerOptions());
+
+		tools.Should().NotContain(t => string.Equals(t.ProtocolTool.Name, "troubleshoot", StringComparison.Ordinal));
+		prompts.Should().ContainSingle();
+	}
+
+	[TestMethod]
+	[Description("Prompt-only commands become tools when PromptFallbackToTools is enabled.")]
+	public void When_PromptFallbackEnabled_Then_PromptAlsoATool()
+	{
+		var (tools, _, prompts) = Generate(
+			app => app.Map("troubleshoot {symptom}", (string symptom) => $"Diagnose: {symptom}").AsPrompt(),
+			new ReplMcpServerOptions { PromptFallbackToTools = true });
+
+		tools.Should().ContainSingle(t => string.Equals(t.ProtocolTool.Name, "troubleshoot", StringComparison.Ordinal));
+		prompts.Should().ContainSingle();
+	}
+
+	// ── AutomationHidden ───────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("AutomationHidden commands are never tools, resources, or prompts.")]
+	public void When_AutomationHidden_Then_ExcludedFromEverything()
+	{
+		var (tools, resources, prompts) = Generate(
+			app => app.Map("wizard", () => "ok").AutomationHidden().AsResource().AsPrompt(),
+			new ReplMcpServerOptions { ResourceFallbackToTools = true, PromptFallbackToTools = true });
+
+		tools.Should().BeEmpty();
+		// Resources are generated from the doc model, which includes AutomationHidden.
+		// But they won't be callable since the tool adapter won't route them.
+	}
+
+	// ── Helpers ─────────────────────────────────────────────────────────
+
+	private static (
+		List<McpServerTool> Tools,
+		List<McpServerResource> Resources,
+		List<McpServerPrompt> Prompts) Generate(
+		Action<ReplApp> configure,
+		ReplMcpServerOptions options)
+	{
+		var app = ReplApp.Create();
+		configure(app);
+
+		var model = app.Core.CreateDocumentationModel();
+		var handler = new McpServerHandler(app.Core, options, EmptyServiceProvider.Instance);
+
+		// Use reflection to call private BuildServerOptions.
+		var method = typeof(McpServerHandler).GetMethod(
+			"BuildServerOptions",
+			System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+		var separator = McpToolNameFlattener.ResolveSeparator(options.ToolNamingSeparator);
+		var adapter = new McpToolAdapter(app.Core, options, EmptyServiceProvider.Instance);
+		var serverOptions = (McpServerOptions)method!.Invoke(handler, [model, adapter, separator])!;
+
+		var tools = serverOptions.ToolCollection?.ToList() ?? [];
+		var resources = serverOptions.ResourceCollection?.ToList() ?? [];
+		var prompts = serverOptions.PromptCollection?.ToList() ?? [];
+
+		return (tools, resources, prompts);
+	}
+
+	private sealed class EmptyServiceProvider : IServiceProvider
+	{
+		public static readonly EmptyServiceProvider Instance = new();
+		public object? GetService(Type serviceType) => null;
+	}
+}

--- a/src/Repl.McpTests/Given_McpFallbackOptions.cs
+++ b/src/Repl.McpTests/Given_McpFallbackOptions.cs
@@ -189,8 +189,7 @@ public sealed class Given_McpFallbackOptions
 			},
 			new ReplMcpServerOptions());
 
-		act.Should().Throw<Exception>()
-			.WithInnerException<InvalidOperationException>()
+		act.Should().Throw<InvalidOperationException>()
 			.WithMessage("*collision*");
 	}
 
@@ -221,14 +220,9 @@ public sealed class Given_McpFallbackOptions
 
 		var model = app.Core.CreateDocumentationModel();
 		var handler = new McpServerHandler(app.Core, options, EmptyServiceProvider.Instance);
-
-		// Use reflection to call private BuildServerOptions.
-		var method = typeof(McpServerHandler).GetMethod(
-			"BuildServerOptions",
-			System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 		var separator = McpToolNameFlattener.ResolveSeparator(options.ToolNamingSeparator);
 		var adapter = new McpToolAdapter(app.Core, options, EmptyServiceProvider.Instance);
-		var serverOptions = (McpServerOptions)method!.Invoke(handler, [model, adapter, separator])!;
+		var serverOptions = handler.BuildServerOptions(model, adapter, separator);
 
 		var tools = serverOptions.ToolCollection?.ToList() ?? [];
 		var resources = serverOptions.ResourceCollection?.ToList() ?? [];

--- a/src/Repl.McpTests/Given_McpFallbackOptions.cs
+++ b/src/Repl.McpTests/Given_McpFallbackOptions.cs
@@ -120,7 +120,7 @@ public sealed class Given_McpFallbackOptions
 	[Description("AutomationHidden commands are never tools, resources, or prompts.")]
 	public void When_AutomationHidden_Then_ExcludedFromEverything()
 	{
-		var (tools, resources, prompts) = Generate(
+		var (tools, _, prompts) = Generate(
 			app => app.Map("wizard", () => "ok").AutomationHidden().AsResource().AsPrompt(),
 			new ReplMcpServerOptions { ResourceFallbackToTools = true, PromptFallbackToTools = true });
 

--- a/src/Repl.McpTests/Given_McpIntegration.cs
+++ b/src/Repl.McpTests/Given_McpIntegration.cs
@@ -20,11 +20,11 @@ public sealed class Given_McpIntegration
 
 	[TestMethod]
 	[Description("UseMcpServer with custom command name uses that name.")]
-	public void When_CustomCommandName_Then_RouteUsesCustomName()
+	public void When_CustomContextName_Then_RouteUsesCustomName()
 	{
 		var app = ReplApp.Create();
 		app.Map("hello", () => "world");
-		app.UseMcpServer(o => o.CommandName = "ai");
+		app.UseMcpServer(o => o.ContextName = "ai");
 
 		var match = app.Core.Resolve(["ai", "serve"]);
 

--- a/src/Repl.McpTests/Given_McpIntegration.cs
+++ b/src/Repl.McpTests/Given_McpIntegration.cs
@@ -1,0 +1,86 @@
+namespace Repl.McpTests;
+
+[TestClass]
+public sealed class Given_McpIntegration
+{
+	[TestMethod]
+	[Description("UseMcpServer registers the 'mcp serve' route on the app.")]
+	public void When_UseMcpServer_Then_McpServeRouteIsRegistered()
+	{
+		var app = ReplApp.Create();
+		app.Map("hello", () => "world");
+		app.UseMcpServer();
+
+		// Resolve through the internal CoreReplApp to verify routing.
+		var match = app.Core.Resolve(["mcp", "serve"]);
+
+		match.Should().NotBeNull();
+		match!.Route.Command.IsProtocolPassthrough.Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("UseMcpServer with custom command name uses that name.")]
+	public void When_CustomCommandName_Then_RouteUsesCustomName()
+	{
+		var app = ReplApp.Create();
+		app.Map("hello", () => "world");
+		app.UseMcpServer(o => o.CommandName = "ai");
+
+		var match = app.Core.Resolve(["ai", "serve"]);
+
+		match.Should().NotBeNull();
+	}
+
+	[TestMethod]
+	[Description("MCP serve route is hidden from discovery.")]
+	public void When_UseMcpServer_Then_McpContextIsHidden()
+	{
+		var app = ReplApp.Create();
+		app.Map("hello", () => "world");
+		app.UseMcpServer();
+
+		var model = app.CreateDocumentationModel();
+
+		model.Commands.Should().NotContain(c => string.Equals(c.Path, "mcp serve", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	[Description("Commands marked AutomationHidden are excluded from MCP tool candidates.")]
+	public void When_CommandIsAutomationHidden_Then_ExcludedFromToolCandidates()
+	{
+		var app = ReplApp.Create();
+		app.Map("list", () => "ok").ReadOnly();
+		app.Map("wizard", () => "ok").AutomationHidden();
+
+		var model = app.CreateDocumentationModel();
+		var toolCandidates = model.Commands.Where(c =>
+			!c.IsHidden && c.Annotations?.AutomationHidden != true).ToList();
+
+		toolCandidates.Should().ContainSingle(c => string.Equals(c.Path, "list", StringComparison.Ordinal));
+		toolCandidates.Should().NotContain(c => string.Equals(c.Path, "wizard", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	[Description("Documentation model includes enriched metadata for MCP commands.")]
+	public void When_EnrichedCommands_Then_DocModelContainsAllFields()
+	{
+		var app = ReplApp.Create();
+		app.Map("deploy {env}", (string env) => $"Deployed to {env}")
+			.WithDescription("Deploy application")
+			.WithDetails("Deploys to the specified environment.")
+			.Destructive()
+			.OpenWorld()
+			.LongRunning();
+		app.UseMcpServer();
+
+		var model = app.CreateDocumentationModel();
+		var cmd = model.Commands.Single(c => string.Equals(c.Path, "deploy {env}", StringComparison.Ordinal));
+
+		cmd.Description.Should().Be("Deploy application");
+		cmd.Details.Should().Be("Deploys to the specified environment.");
+		cmd.Annotations!.Destructive.Should().BeTrue();
+		cmd.Annotations!.OpenWorld.Should().BeTrue();
+		cmd.Annotations!.LongRunning.Should().BeTrue();
+		cmd.Arguments.Should().ContainSingle(a => string.Equals(a.Name, "env", StringComparison.Ordinal));
+	}
+}

--- a/src/Repl.McpTests/Given_McpIntegration.cs
+++ b/src/Repl.McpTests/Given_McpIntegration.cs
@@ -83,4 +83,37 @@ public sealed class Given_McpIntegration
 		cmd.Annotations!.LongRunning.Should().BeTrue();
 		cmd.Arguments.Should().ContainSingle(a => string.Equals(a.Name, "env", StringComparison.Ordinal));
 	}
+
+	[TestMethod]
+	[Description("Modules excluded from Programmatic channel are not visible as MCP tools.")]
+	public void When_ModuleExcludedFromProgrammatic_Then_NotInToolCandidates()
+	{
+		var app = ReplApp.Create();
+		app.Map("public-cmd", () => "ok").ReadOnly();
+		app.MapModule(
+			new AdminModule(),
+			ctx => ctx.Channel != ReplRuntimeChannel.Programmatic);
+		app.UseMcpServer();
+
+		// Simulate programmatic channel by setting the flag.
+		ReplSessionIO.IsProgrammatic = true;
+		try
+		{
+			var model = app.Core.CreateDocumentationModel();
+			model.Commands.Should().NotContain(c => string.Equals(c.Path, "admin reset", StringComparison.Ordinal));
+			model.Commands.Should().Contain(c => string.Equals(c.Path, "public-cmd", StringComparison.Ordinal));
+		}
+		finally
+		{
+			ReplSessionIO.IsProgrammatic = false;
+		}
+	}
+
+	private sealed class AdminModule : IReplModule
+	{
+		public void Map(IReplMap map)
+		{
+			map.Map("admin reset", () => "reset done");
+		}
+	}
 }

--- a/src/Repl.McpTests/Given_McpInteractionChannel.cs
+++ b/src/Repl.McpTests/Given_McpInteractionChannel.cs
@@ -19,17 +19,6 @@ public sealed class Given_McpInteractionChannel
 	}
 
 	[TestMethod]
-	[Description("Prefilled numeric index resolves correctly.")]
-	public async Task When_PrefillIsNumericIndex_Then_ReturnsIndex()
-	{
-		var channel = CreateChannel(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["color"] = "2" });
-
-		var result = await channel.AskChoiceAsync("color", "Pick a color", ["red", "green", "blue"]);
-
-		result.Should().Be(2);
-	}
-
-	[TestMethod]
 	[Description("Missing prefill with default returns default.")]
 	public async Task When_NoPrefillWithDefault_Then_ReturnsDefault()
 	{

--- a/src/Repl.McpTests/Given_McpInteractionChannel.cs
+++ b/src/Repl.McpTests/Given_McpInteractionChannel.cs
@@ -1,3 +1,4 @@
+using Repl.Interaction;
 using Repl.Mcp;
 
 namespace Repl.McpTests;
@@ -134,6 +135,104 @@ public sealed class Given_McpInteractionChannel
 		var result = await channel.AskMultiChoiceAsync("tags", "Select tags", ["red", "green", "blue"]);
 
 		result.Should().BeEquivalentTo([0, 2]);
+	}
+
+	// ── ParseBool error paths ─────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Invalid boolean value throws McpInteractionException.")]
+	public async Task When_PrefillIsInvalidBool_Then_Throws()
+	{
+		var channel = CreateChannel(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["confirm"] = "maybe" });
+
+		var act = () => channel.AskConfirmationAsync("confirm", "Proceed?").AsTask();
+
+		await act.Should().ThrowAsync<McpInteractionException>();
+	}
+
+	[TestMethod]
+	[Description("'no' is parsed as false.")]
+	public async Task When_PrefillIsNo_Then_ReturnsFalse()
+	{
+		var channel = CreateChannel(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["confirm"] = "no" });
+
+		var result = await channel.AskConfirmationAsync("confirm", "Proceed?");
+
+		result.Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("'n' is parsed as false.")]
+	public async Task When_PrefillIsN_Then_ReturnsFalse()
+	{
+		var channel = CreateChannel(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["confirm"] = "n" });
+
+		var result = await channel.AskConfirmationAsync("confirm", "Proceed?");
+
+		result.Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("'0' is parsed as false.")]
+	public async Task When_PrefillIsZero_Then_ReturnsFalse()
+	{
+		var channel = CreateChannel(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["confirm"] = "0" });
+
+		var result = await channel.AskConfirmationAsync("confirm", "Proceed?");
+
+		result.Should().BeFalse();
+	}
+
+	// ── ResolveChoiceIndex prefix matching ────────────────────────────
+
+	[TestMethod]
+	[Description("Unambiguous prefix resolves to the matching choice.")]
+	public async Task When_PrefillIsUnambiguousPrefix_Then_ResolvesChoice()
+	{
+		var channel = CreateChannel(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["color"] = "gre" });
+
+		var result = await channel.AskChoiceAsync("color", "Pick a color", ["red", "green", "blue"]);
+
+		result.Should().Be(1);
+	}
+
+	[TestMethod]
+	[Description("Ambiguous prefix throws McpInteractionException.")]
+	public async Task When_PrefillIsAmbiguousPrefix_Then_Throws()
+	{
+		var channel = CreateChannel(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["color"] = "b" });
+
+		var act = () => channel.AskChoiceAsync("color", "Pick a color", ["blue", "black"]).AsTask();
+
+		await act.Should().ThrowAsync<McpInteractionException>();
+	}
+
+	// ── ParseMultiChoice min/max validation ───────────────────────────
+
+	[TestMethod]
+	[Description("Too few selections throws McpInteractionException.")]
+	public async Task When_MultiChoiceTooFewSelections_Then_Throws()
+	{
+		var channel = CreateChannel(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["tags"] = "red" });
+
+		var act = () => channel.AskMultiChoiceAsync(
+			"tags", "Select tags", ["red", "green", "blue"],
+			options: new AskMultiChoiceOptions(MinSelections: 2)).AsTask();
+
+		await act.Should().ThrowAsync<McpInteractionException>();
+	}
+
+	[TestMethod]
+	[Description("Too many selections throws McpInteractionException.")]
+	public async Task When_MultiChoiceTooManySelections_Then_Throws()
+	{
+		var channel = CreateChannel(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["tags"] = "red,green" });
+
+		var act = () => channel.AskMultiChoiceAsync(
+			"tags", "Select tags", ["red", "green", "blue"],
+			options: new AskMultiChoiceOptions(MaxSelections: 1)).AsTask();
+
+		await act.Should().ThrowAsync<McpInteractionException>();
 	}
 
 	// ── ClearScreenAsync ───────────────────────────────────────────────

--- a/src/Repl.McpTests/Given_McpInteractionChannel.cs
+++ b/src/Repl.McpTests/Given_McpInteractionChannel.cs
@@ -1,0 +1,184 @@
+using Repl.Mcp;
+
+namespace Repl.McpTests;
+
+[TestClass]
+public sealed class Given_McpInteractionChannel
+{
+	// ── AskChoiceAsync ─────────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Prefilled value resolves to matching choice index.")]
+	public async Task When_PrefillMatchesChoice_Then_ReturnsIndex()
+	{
+		var channel = CreateChannel(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["color"] = "green" });
+
+		var result = await channel.AskChoiceAsync("color", "Pick a color", ["red", "green", "blue"]);
+
+		result.Should().Be(1);
+	}
+
+	[TestMethod]
+	[Description("Prefilled numeric index resolves correctly.")]
+	public async Task When_PrefillIsNumericIndex_Then_ReturnsIndex()
+	{
+		var channel = CreateChannel(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["color"] = "2" });
+
+		var result = await channel.AskChoiceAsync("color", "Pick a color", ["red", "green", "blue"]);
+
+		result.Should().Be(2);
+	}
+
+	[TestMethod]
+	[Description("Missing prefill with default returns default.")]
+	public async Task When_NoPrefillWithDefault_Then_ReturnsDefault()
+	{
+		var channel = CreateChannel();
+
+		var result = await channel.AskChoiceAsync("color", "Pick a color", ["red", "green"], defaultIndex: 1);
+
+		result.Should().Be(1);
+	}
+
+	[TestMethod]
+	[Description("Missing prefill in PrefillThenDefaults mode returns 0.")]
+	public async Task When_NoPrefillInDefaultsMode_Then_ReturnsZero()
+	{
+		var channel = CreateChannel(mode: InteractivityMode.PrefillThenDefaults);
+
+		var result = await channel.AskChoiceAsync("color", "Pick a color", ["red", "green"]);
+
+		result.Should().Be(0);
+	}
+
+	[TestMethod]
+	[Description("Missing prefill in PrefillThenFail mode throws.")]
+	public async Task When_NoPrefillInFailMode_Then_Throws()
+	{
+		var channel = CreateChannel(mode: InteractivityMode.PrefillThenFail);
+
+		var act = () => channel.AskChoiceAsync("color", "Pick a color", ["red", "green"]).AsTask();
+
+		await act.Should().ThrowAsync<McpInteractionException>();
+	}
+
+	// ── AskConfirmationAsync ───────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Prefilled 'yes' returns true.")]
+	public async Task When_PrefillIsYes_Then_ReturnsTrue()
+	{
+		var channel = CreateChannel(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["confirm"] = "yes" });
+
+		var result = await channel.AskConfirmationAsync("confirm", "Proceed?");
+
+		result.Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("Prefilled 'false' returns false.")]
+	public async Task When_PrefillIsFalse_Then_ReturnsFalse()
+	{
+		var channel = CreateChannel(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["confirm"] = "false" });
+
+		var result = await channel.AskConfirmationAsync("confirm", "Proceed?");
+
+		result.Should().BeFalse();
+	}
+
+	// ── AskTextAsync ───────────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Prefilled value is returned.")]
+	public async Task When_TextPrefill_Then_ReturnsValue()
+	{
+		var channel = CreateChannel(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["name"] = "Alice" });
+
+		var result = await channel.AskTextAsync("name", "Enter name");
+
+		result.Should().Be("Alice");
+	}
+
+	[TestMethod]
+	[Description("Missing prefill with default returns default.")]
+	public async Task When_NoTextPrefillWithDefault_Then_ReturnsDefault()
+	{
+		var channel = CreateChannel();
+
+		var result = await channel.AskTextAsync("name", "Enter name", defaultValue: "Bob");
+
+		result.Should().Be("Bob");
+	}
+
+	// ── AskSecretAsync ─────────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Secret with prefill returns value.")]
+	public async Task When_SecretPrefill_Then_ReturnsValue()
+	{
+		var channel = CreateChannel(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["password"] = "s3cret" });
+
+		var result = await channel.AskSecretAsync("password", "Enter password");
+
+		result.Should().Be("s3cret");
+	}
+
+	[TestMethod]
+	[Description("Secret without prefill always throws.")]
+	public async Task When_NoSecretPrefill_Then_AlwaysThrows()
+	{
+		var channel = CreateChannel(mode: InteractivityMode.PrefillThenDefaults);
+
+		var act = () => channel.AskSecretAsync("password", "Enter password").AsTask();
+
+		await act.Should().ThrowAsync<McpInteractionException>();
+	}
+
+	// ── AskMultiChoiceAsync ────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Prefilled comma-separated values resolve to indices.")]
+	public async Task When_MultiChoicePrefill_Then_ReturnsIndices()
+	{
+		var channel = CreateChannel(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["tags"] = "red,blue" });
+
+		var result = await channel.AskMultiChoiceAsync("tags", "Select tags", ["red", "green", "blue"]);
+
+		result.Should().BeEquivalentTo([0, 2]);
+	}
+
+	// ── ClearScreenAsync ───────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("ClearScreen is a no-op.")]
+	public async Task When_ClearScreen_Then_NoOp()
+	{
+		var channel = CreateChannel();
+
+		await channel.ClearScreenAsync(CancellationToken.None);
+	}
+
+	// ── DispatchAsync ──────────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("DispatchAsync throws NotSupportedException.")]
+	public void When_Dispatch_Then_ThrowsNotSupported()
+	{
+		var channel = CreateChannel();
+
+		// DispatchAsync requires an InteractionRequest<T> subclass, but the throw
+		// happens synchronously before any async work so we test the throw path.
+		var act = () => channel.DispatchAsync<string>(null!, CancellationToken.None);
+
+		act.Should().Throw<NotSupportedException>();
+	}
+
+	// ── Helpers ─────────────────────────────────────────────────────────
+
+	private static McpInteractionChannel CreateChannel(
+		Dictionary<string, string>? prefills = null,
+		InteractivityMode mode = InteractivityMode.PrefillThenFail) =>
+		new(
+			prefills ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+			mode);
+}

--- a/src/Repl.McpTests/Given_McpInteractionChannel.cs
+++ b/src/Repl.McpTests/Given_McpInteractionChannel.cs
@@ -77,12 +77,23 @@ public sealed class Given_McpInteractionChannel
 	}
 
 	[TestMethod]
-	[Description("Missing prefill in PrefillThenFail mode throws even when defaultValue is true.")]
-	public async Task When_NoBoolPrefillInFailModeWithDefaultTrue_Then_Throws()
+	[Description("Missing prefill with explicit default returns default even in PrefillThenFail mode.")]
+	public async Task When_NoBoolPrefillInFailModeWithDefaultTrue_Then_ReturnsDefault()
 	{
 		var channel = CreateChannel(mode: InteractivityMode.PrefillThenFail);
 
-		var act = () => channel.AskConfirmationAsync("confirm", "Proceed?", defaultValue: true).AsTask();
+		var result = await channel.AskConfirmationAsync("confirm", "Proceed?", defaultValue: true);
+
+		result.Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("Missing prefill without default in PrefillThenFail mode throws.")]
+	public async Task When_NoBoolPrefillInFailModeWithoutDefault_Then_Throws()
+	{
+		var channel = CreateChannel(mode: InteractivityMode.PrefillThenFail);
+
+		var act = () => channel.AskConfirmationAsync("confirm", "Proceed?").AsTask();
 
 		await act.Should().ThrowAsync<McpInteractionException>();
 	}

--- a/src/Repl.McpTests/Given_McpInteractionChannel.cs
+++ b/src/Repl.McpTests/Given_McpInteractionChannel.cs
@@ -76,6 +76,17 @@ public sealed class Given_McpInteractionChannel
 		result.Should().BeFalse();
 	}
 
+	[TestMethod]
+	[Description("Missing prefill in PrefillThenFail mode throws even when defaultValue is true.")]
+	public async Task When_NoBoolPrefillInFailModeWithDefaultTrue_Then_Throws()
+	{
+		var channel = CreateChannel(mode: InteractivityMode.PrefillThenFail);
+
+		var act = () => channel.AskConfirmationAsync("confirm", "Proceed?", defaultValue: true).AsTask();
+
+		await act.Should().ThrowAsync<McpInteractionException>();
+	}
+
 	// ── AskTextAsync ───────────────────────────────────────────────────
 
 	[TestMethod]

--- a/src/Repl.McpTests/Given_McpResourceParameters.cs
+++ b/src/Repl.McpTests/Given_McpResourceParameters.cs
@@ -1,0 +1,77 @@
+using ModelContextProtocol.Protocol;
+using Repl.Documentation;
+using Repl.Mcp;
+
+namespace Repl.McpTests;
+
+[TestClass]
+public sealed class Given_McpResourceParameters
+{
+	[TestMethod]
+	[Description("Parameterized resource read passes URI template variables to the command handler.")]
+	public async Task When_ParameterizedResourceRead_Then_ArgumentsArePassed()
+	{
+		var session = await McpTestFixture.CreateAsync(
+			app => app.Map("config {env}", (string env) => $"config-{env}")
+				.ReadOnly()
+				.AsResource()).ConfigureAwait(false);
+
+		await using (session.ConfigureAwait(false))
+		{
+			var result = await session.Client.ReadResourceAsync("repl://config/production").ConfigureAwait(false);
+
+			var text = result.Contents.OfType<TextResourceContents>().First().Text;
+			text.Should().Contain("config-production");
+		}
+	}
+
+	[TestMethod]
+	[Description("Parameterized resource appears in resource templates list with URI template.")]
+	public async Task When_ParameterizedResource_Then_TemplateListIncludesVariables()
+	{
+		var session = await McpTestFixture.CreateAsync(
+			app => app.Map("config {env}", (string env) => $"config-{env}")
+				.ReadOnly()
+				.AsResource()).ConfigureAwait(false);
+
+		await using (session.ConfigureAwait(false))
+		{
+			var templates = await session.Client.ListResourceTemplatesAsync().ConfigureAwait(false);
+
+			templates.Should().Contain(t => t.UriTemplate.Contains("{env}", StringComparison.Ordinal));
+		}
+	}
+
+	[TestMethod]
+	[Description("IsMatch correctly matches concrete URIs against templates.")]
+	public void When_IsMatchCalledWithConcreteUri_Then_ReturnsTrue()
+	{
+		var resource = new ReplDocResource(
+			Path: "config {env}", Description: "desc", Details: null, Arguments: [], Options: []);
+		var sut = new ReplMcpServerResource(resource, resourceName: "config", uriTemplate: "repl://config/{env}", adapter: null!);
+
+		sut.IsMatch("repl://config/production").Should().BeTrue();
+		sut.IsMatch("repl://config/staging").Should().BeTrue();
+		sut.IsMatch("repl://other/production").Should().BeFalse();
+		sut.ProtocolResourceTemplate.UriTemplate.Should().Be("repl://config/{env}");
+		sut.IsTemplated.Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("Parameterless resource read still works (regression).")]
+	public async Task When_ParameterlessResourceRead_Then_ReturnsOutput()
+	{
+		var session = await McpTestFixture.CreateAsync(
+			app => app.Map("status", () => "all-ok")
+				.ReadOnly()
+				.AsResource()).ConfigureAwait(false);
+
+		await using (session.ConfigureAwait(false))
+		{
+			var result = await session.Client.ReadResourceAsync("repl://status").ConfigureAwait(false);
+
+			var text = result.Contents.OfType<TextResourceContents>().First().Text;
+			text.Should().Contain("all-ok");
+		}
+	}
+}

--- a/src/Repl.McpTests/Given_McpResourceParameters.cs
+++ b/src/Repl.McpTests/Given_McpResourceParameters.cs
@@ -74,4 +74,21 @@ public sealed class Given_McpResourceParameters
 			text.Should().Contain("all-ok");
 		}
 	}
+
+	[TestMethod]
+	[Description("Custom ResourceUriScheme is used in resource URIs.")]
+	public async Task When_CustomScheme_Then_ResourceUriUsesScheme()
+	{
+		var session = await McpTestFixture.CreateAsync(
+			app => app.Map("status", () => "ok").ReadOnly().AsResource(),
+			options => options.ResourceUriScheme = "myapp").ConfigureAwait(false);
+
+		await using (session.ConfigureAwait(false))
+		{
+			var result = await session.Client.ReadResourceAsync("myapp://status").ConfigureAwait(false);
+
+			var text = result.Contents.OfType<TextResourceContents>().First().Text;
+			text.Should().Contain("ok");
+		}
+	}
 }

--- a/src/Repl.McpTests/Given_McpSchemaGenerator.cs
+++ b/src/Repl.McpTests/Given_McpSchemaGenerator.cs
@@ -1,0 +1,241 @@
+using System.Text.Json;
+using Repl.Documentation;
+using Repl.Mcp;
+
+namespace Repl.McpTests;
+
+[TestClass]
+public sealed class Given_McpSchemaGenerator
+{
+	// ── Type mapping ───────────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("String argument produces { type: string }.")]
+	public void When_StringArgument_Then_SchemaTypeIsString()
+	{
+		var cmd = CreateCommand(arguments: [new("name", "string", Required: true, Description: null)]);
+
+		var schema = McpSchemaGenerator.BuildInputSchema(cmd);
+
+		GetPropertyType(schema, "name").Should().Be("string");
+	}
+
+	[TestMethod]
+	[Description("Int argument produces { type: integer }.")]
+	public void When_IntArgument_Then_SchemaTypeIsInteger()
+	{
+		var cmd = CreateCommand(arguments: [new("id", "int", Required: true, Description: null)]);
+
+		var schema = McpSchemaGenerator.BuildInputSchema(cmd);
+
+		GetPropertyType(schema, "id").Should().Be("integer");
+	}
+
+	[TestMethod]
+	[Description("Bool option produces { type: boolean }.")]
+	public void When_BoolOption_Then_SchemaTypeIsBoolean()
+	{
+		var cmd = CreateCommand(
+			options: [CreateOption("verbose", "bool")]);
+
+		var schema = McpSchemaGenerator.BuildInputSchema(cmd);
+
+		GetPropertyType(schema, "verbose").Should().Be("boolean");
+	}
+
+	[TestMethod]
+	[Description("Email constraint produces { type: string, format: email }.")]
+	public void When_EmailConstraint_Then_FormatIsEmail()
+	{
+		var cmd = CreateCommand(arguments: [new("email", "email", Required: true, Description: null)]);
+
+		var schema = McpSchemaGenerator.BuildInputSchema(cmd);
+
+		GetPropertyFormat(schema, "email").Should().Be("email");
+	}
+
+	[TestMethod]
+	[Description("Guid constraint produces { type: string, format: uuid }.")]
+	public void When_GuidConstraint_Then_FormatIsUuid()
+	{
+		var cmd = CreateCommand(arguments: [new("id", "guid", Required: true, Description: null)]);
+
+		var schema = McpSchemaGenerator.BuildInputSchema(cmd);
+
+		GetPropertyFormat(schema, "id").Should().Be("uuid");
+	}
+
+	[TestMethod]
+	[Description("Timespan produces { type: string, format: duration }.")]
+	public void When_TimespanType_Then_FormatIsDuration()
+	{
+		var cmd = CreateCommand(
+			options: [CreateOption("timeout", "timespan")]);
+
+		var schema = McpSchemaGenerator.BuildInputSchema(cmd);
+
+		GetPropertyFormat(schema, "timeout").Should().Be("duration");
+	}
+
+	// ── Required / Optional ────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Required arguments appear in the required array.")]
+	public void When_ArgumentIsRequired_Then_IncludedInRequired()
+	{
+		var cmd = CreateCommand(arguments: [new("name", "string", Required: true, Description: null)]);
+
+		var schema = McpSchemaGenerator.BuildInputSchema(cmd);
+
+		var required = schema.GetProperty("required");
+		required.GetArrayLength().Should().Be(1);
+		required[0].GetString().Should().Be("name");
+	}
+
+	[TestMethod]
+	[Description("Optional arguments are not in the required array.")]
+	public void When_ArgumentIsOptional_Then_NotInRequired()
+	{
+		var cmd = CreateCommand(arguments: [new("name", "string", Required: false, Description: null)]);
+
+		var schema = McpSchemaGenerator.BuildInputSchema(cmd);
+
+		schema.TryGetProperty("required", out _).Should().BeFalse();
+	}
+
+	// ── Enum values ────────────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Enum options include enum values in schema.")]
+	public void When_OptionHasEnumValues_Then_SchemaContainsEnum()
+	{
+		var cmd = CreateCommand(
+			options: [CreateOption("format", "string", enumValues: ["json", "xml", "yaml"])]);
+
+		var schema = McpSchemaGenerator.BuildInputSchema(cmd);
+
+		var prop = schema.GetProperty("properties").GetProperty("format");
+		prop.TryGetProperty("enum", out var enumProp).Should().BeTrue();
+		enumProp.GetArrayLength().Should().Be(3);
+	}
+
+	// ── Descriptions ───────────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Argument descriptions propagate to schema.")]
+	public void When_ArgumentHasDescription_Then_SchemaContainsDescription()
+	{
+		var cmd = CreateCommand(
+			arguments: [new("name", "string", Required: true, Description: "Contact name")]);
+
+		var schema = McpSchemaGenerator.BuildInputSchema(cmd);
+
+		var prop = schema.GetProperty("properties").GetProperty("name");
+		prop.GetProperty("description").GetString().Should().Be("Contact name");
+	}
+
+	// ── Annotation mapping ─────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Null annotations produce null ToolAnnotations.")]
+	public void When_AnnotationsAreNull_Then_ResultIsNull()
+	{
+		McpSchemaGenerator.MapAnnotations(annotations: null).Should().BeNull();
+	}
+
+	[TestMethod]
+	[Description("Destructive annotation maps to destructiveHint: true.")]
+	public void When_DestructiveIsTrue_Then_DestructiveHintIsTrue()
+	{
+		var annotations = new CommandAnnotations { Destructive = true };
+
+		var result = McpSchemaGenerator.MapAnnotations(annotations);
+
+		result.Should().NotBeNull();
+		result!.DestructiveHint.Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("ReadOnly annotation maps to readOnlyHint: true.")]
+	public void When_ReadOnlyIsTrue_Then_ReadOnlyHintIsTrue()
+	{
+		var annotations = new CommandAnnotations { ReadOnly = true };
+
+		var result = McpSchemaGenerator.MapAnnotations(annotations);
+
+		result.Should().NotBeNull();
+		result!.ReadOnlyHint.Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("Unset flags produce null hints, not false.")]
+	public void When_FlagsAreFalse_Then_HintsAreNull()
+	{
+		var annotations = new CommandAnnotations();
+
+		var result = McpSchemaGenerator.MapAnnotations(annotations);
+
+		result.Should().NotBeNull();
+		result!.DestructiveHint.Should().BeNull();
+		result!.ReadOnlyHint.Should().BeNull();
+	}
+
+	// ── BuildDescription ───────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Description without details returns description only.")]
+	public void When_NoDetails_Then_DescriptionOnly()
+	{
+		var cmd = CreateCommand(description: "List contacts");
+
+		McpSchemaGenerator.BuildDescription(cmd).Should().Be("List contacts");
+	}
+
+	[TestMethod]
+	[Description("Description with details returns combined text.")]
+	public void When_DetailsPresent_Then_CombinesDescriptionAndDetails()
+	{
+		var cmd = CreateCommand(description: "Deploy", details: "Deploys to env.");
+
+		McpSchemaGenerator.BuildDescription(cmd).Should().Contain("Deploy").And.Contain("Deploys to env.");
+	}
+
+	// ── Helpers ─────────────────────────────────────────────────────────
+
+	private static ReplDocCommand CreateCommand(
+		string path = "test",
+		string? description = null,
+		string? details = null,
+		ReplDocArgument[]? arguments = null,
+		ReplDocOption[]? options = null) =>
+		new(
+			Path: path,
+			Description: description,
+			Aliases: [],
+			IsHidden: false,
+			Arguments: arguments ?? [],
+			Options: options ?? [],
+			Details: details);
+
+	private static ReplDocOption CreateOption(
+		string name,
+		string type,
+		bool required = false,
+		string[]? enumValues = null) =>
+		new(
+			Name: name,
+			Type: type,
+			Required: required,
+			Description: null,
+			Aliases: [],
+			ReverseAliases: [],
+			ValueAliases: [],
+			EnumValues: enumValues ?? [],
+			DefaultValue: null);
+
+	private static string GetPropertyType(JsonElement schema, string name) =>
+		schema.GetProperty("properties").GetProperty(name).GetProperty("type").GetString()!;
+
+	private static string GetPropertyFormat(JsonElement schema, string name) =>
+		schema.GetProperty("properties").GetProperty(name).GetProperty("format").GetString()!;
+}

--- a/src/Repl.McpTests/Given_McpSchemaGenerator.cs
+++ b/src/Repl.McpTests/Given_McpSchemaGenerator.cs
@@ -156,7 +156,7 @@ public sealed class Given_McpSchemaGenerator
 	}
 
 	[TestMethod]
-	[Description("ReadOnly annotation maps to readOnlyHint: true.")]
+	[Description("ReadOnly annotation maps to readOnlyHint: true and destructiveHint: false.")]
 	public void When_ReadOnlyIsTrue_Then_ReadOnlyHintIsTrue()
 	{
 		var annotations = new CommandAnnotations { ReadOnly = true };
@@ -165,6 +165,7 @@ public sealed class Given_McpSchemaGenerator
 
 		result.Should().NotBeNull();
 		result!.ReadOnlyHint.Should().BeTrue();
+		result!.DestructiveHint.Should().BeFalse();
 	}
 
 	[TestMethod]

--- a/src/Repl.McpTests/Given_McpServerEndToEnd.cs
+++ b/src/Repl.McpTests/Given_McpServerEndToEnd.cs
@@ -156,19 +156,19 @@ public sealed class Given_McpServerEndToEnd
 	}
 
 	[TestMethod]
-	[Description("AsPrompt() commands are not exposed as tools.")]
-	public async Task When_CommandIsPrompt_Then_NotExposedAsTool()
+	[Description("ReadOnly commands are exposed as tools (they're regular commands with an annotation).")]
+	public async Task When_ReadOnlyCommand_Then_ExposedAsTool()
 	{
 		await using var fixture = await McpTestFixture.CreateAsync(app =>
 		{
-			app.Map("greet", () => "hello").ReadOnly();
-			app.Map("troubleshoot {symptom}", (string symptom) => $"Diagnose: {symptom}")
-				.AsPrompt();
+			app.Map("contacts", () => "Alice, Bob")
+				.WithDescription("List contacts")
+				.ReadOnly()
+				.AsResource();
 		});
 
 		var tools = await fixture.Client.ListToolsAsync();
 
-		tools.Should().ContainSingle(t => string.Equals(t.Name, "greet", StringComparison.Ordinal));
-		tools.Should().NotContain(t => string.Equals(t.Name, "troubleshoot", StringComparison.Ordinal));
+		tools.Should().ContainSingle(t => string.Equals(t.Name, "contacts", StringComparison.Ordinal));
 	}
 }

--- a/src/Repl.McpTests/Given_McpServerEndToEnd.cs
+++ b/src/Repl.McpTests/Given_McpServerEndToEnd.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using ModelContextProtocol.Protocol;
+
+namespace Repl.McpTests;
+
+/// <summary>
+/// End-to-end integration tests that spin up a real MCP server from a Repl app
+/// and connect a real MCP client via in-process pipes.
+/// </summary>
+[TestClass]
+public sealed class Given_McpServerEndToEnd
+{
+	[TestMethod]
+	[Description("tools/list returns all non-hidden, non-AutomationHidden commands.")]
+	public async Task When_ToolsList_Then_ReturnsExpectedTools()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(app =>
+		{
+			app.Map("greet {name}", (string name) => $"Hello, {name}!")
+				.WithDescription("Greet someone")
+				.ReadOnly();
+			app.Map("hidden-cmd", () => "secret").Hidden();
+			app.Map("wizard", () => "interactive").AutomationHidden();
+		});
+
+		var tools = await fixture.Client.ListToolsAsync();
+
+		tools.Should().ContainSingle(t => string.Equals(t.Name, "greet", StringComparison.Ordinal));
+		tools.Should().NotContain(t => string.Equals(t.Name, "hidden-cmd", StringComparison.Ordinal));
+		tools.Should().NotContain(t => string.Equals(t.Name, "wizard", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	[Description("tools/list includes correct JSON Schema with types and format hints.")]
+	public async Task When_ToolsList_Then_SchemaIsCorrect()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(app =>
+		{
+			app.Map("contact {id:guid}", (Guid id) => new { Id = id })
+				.WithDescription("Get contact")
+				.ReadOnly();
+		});
+
+		var tools = await fixture.Client.ListToolsAsync();
+		var tool = tools.Single(t => string.Equals(t.Name, "contact", StringComparison.Ordinal));
+		var schema = tool.JsonSchema;
+
+		schema.GetProperty("properties").GetProperty("id").GetProperty("type").GetString()
+			.Should().Be("string");
+		schema.GetProperty("properties").GetProperty("id").GetProperty("format").GetString()
+			.Should().Be("uuid");
+		schema.GetProperty("required")[0].GetString()
+			.Should().Be("id");
+	}
+
+	[TestMethod]
+	[Description("tools/call dispatches through the Repl pipeline and returns output.")]
+	public async Task When_ToolsCall_Then_ReturnsCommandOutput()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(app =>
+		{
+			app.Map("greet {name}", (string name) => $"Hello, {name}!")
+				.ReadOnly();
+		});
+
+		var result = await fixture.Client.CallToolAsync(
+			"greet",
+			new Dictionary<string, object?>(StringComparer.Ordinal) { ["name"] = "Alice" });
+
+		var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text;
+		text.Should().Contain("Hello, Alice!");
+	}
+
+	[TestMethod]
+	[Description("Context commands are flattened into underscore-separated tool names.")]
+	public async Task When_ContextCommands_Then_FlattenedToolNames()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(app =>
+		{
+			app.Context("contact", ctx =>
+			{
+				ctx.Map("add", (string name) => name).OpenWorld();
+				ctx.Map("list", () => "all").ReadOnly();
+			});
+		});
+
+		var tools = await fixture.Client.ListToolsAsync();
+
+		tools.Should().Contain(t => string.Equals(t.Name, "contact_add", StringComparison.Ordinal));
+		tools.Should().Contain(t => string.Equals(t.Name, "contact_list", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	[Description("tools/call on a context command dispatches correctly.")]
+	public async Task When_ToolsCallContextCommand_Then_DispatchesCorrectly()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(app =>
+		{
+			app.Context("math", ctx =>
+			{
+				ctx.Map("add", (int a, int b) => a + b).ReadOnly();
+			});
+		});
+
+		var result = await fixture.Client.CallToolAsync(
+			"math_add",
+			new Dictionary<string, object?>(StringComparer.Ordinal) { ["a"] = 3, ["b"] = 7 });
+
+		var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text;
+		text.Should().Contain("10");
+	}
+
+	[TestMethod]
+	[Description("Tool description combines Description and Details.")]
+	public async Task When_ToolHasDetails_Then_DescriptionIncludesBoth()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(app =>
+		{
+			app.Map("deploy", () => "ok")
+				.WithDescription("Deploy app")
+				.WithDetails("Deploys to the specified environment.");
+		});
+
+		var tools = await fixture.Client.ListToolsAsync();
+		var tool = tools.Single(t => string.Equals(t.Name, "deploy", StringComparison.Ordinal));
+
+		tool.Description.Should().Contain("Deploy app");
+		tool.Description.Should().Contain("Deploys to the specified environment.");
+	}
+
+	[TestMethod]
+	[Description("Optional parameters are not in the required array.")]
+	public async Task When_OptionalParameter_Then_NotRequired()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(app =>
+		{
+			app.Map("search", (string query, int? limit) => $"{query} limit={limit}")
+				.ReadOnly();
+		});
+
+		var tools = await fixture.Client.ListToolsAsync();
+		var tool = tools.Single(t => string.Equals(t.Name, "search", StringComparison.Ordinal));
+		var schema = tool.JsonSchema;
+
+		// "query" should not be required (string is reference type → optional by default).
+		// "limit" should not be required (nullable).
+		if (schema.TryGetProperty("required", out var required))
+		{
+			var requiredNames = Enumerable.Range(0, required.GetArrayLength())
+				.Select(i => required[i].GetString())
+				.ToList();
+			requiredNames.Should().NotContain("limit");
+		}
+	}
+}

--- a/src/Repl.McpTests/Given_McpServerEndToEnd.cs
+++ b/src/Repl.McpTests/Given_McpServerEndToEnd.cs
@@ -210,6 +210,7 @@ public sealed class Given_McpServerEndToEnd
 
 		result.Messages.Should().ContainSingle();
 		var text = (result.Messages[0].Content as TextContentBlock)?.Text;
+		text.Should().NotBeNull();
 		text.Should().Contain("Diagnose: missing data");
 	}
 }

--- a/src/Repl.McpTests/Given_McpServerEndToEnd.cs
+++ b/src/Repl.McpTests/Given_McpServerEndToEnd.cs
@@ -67,8 +67,9 @@ public sealed class Given_McpServerEndToEnd
 			"greet",
 			new Dictionary<string, object?>(StringComparer.Ordinal) { ["name"] = "Alice" });
 
-		var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text;
-		text.Should().Contain("Hello, Alice!");
+		var textBlock = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+		textBlock.Should().NotBeNull("the tool call should produce text content");
+		textBlock!.Text.Should().Contain("Hello, Alice!");
 	}
 
 	[TestMethod]
@@ -106,8 +107,9 @@ public sealed class Given_McpServerEndToEnd
 			"math_add",
 			new Dictionary<string, object?>(StringComparer.Ordinal) { ["a"] = 3, ["b"] = 7 });
 
-		var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text;
-		text.Should().Contain("10");
+		var textBlock = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+		textBlock.Should().NotBeNull("the tool call should produce text content");
+		textBlock!.Text.Should().Contain("10");
 	}
 
 	[TestMethod]
@@ -151,5 +153,22 @@ public sealed class Given_McpServerEndToEnd
 				.ToList();
 			requiredNames.Should().NotContain("limit");
 		}
+	}
+
+	[TestMethod]
+	[Description("AsPrompt() commands are not exposed as tools.")]
+	public async Task When_CommandIsPrompt_Then_NotExposedAsTool()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(app =>
+		{
+			app.Map("greet", () => "hello").ReadOnly();
+			app.Map("troubleshoot {symptom}", (string symptom) => $"Diagnose: {symptom}")
+				.AsPrompt();
+		});
+
+		var tools = await fixture.Client.ListToolsAsync();
+
+		tools.Should().ContainSingle(t => string.Equals(t.Name, "greet", StringComparison.Ordinal));
+		tools.Should().NotContain(t => string.Equals(t.Name, "troubleshoot", StringComparison.Ordinal));
 	}
 }

--- a/src/Repl.McpTests/Given_McpServerEndToEnd.cs
+++ b/src/Repl.McpTests/Given_McpServerEndToEnd.cs
@@ -171,4 +171,46 @@ public sealed class Given_McpServerEndToEnd
 
 		tools.Should().ContainSingle(t => string.Equals(t.Name, "contacts", StringComparison.Ordinal));
 	}
+
+	// ── Prompts ────────────────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("prompts/list returns prompt with correct arguments from the command's parameters.")]
+	public async Task When_PromptsList_Then_ReturnsPromptWithArguments()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(app =>
+		{
+			app.Map("troubleshoot {symptom}", (string symptom) => $"Diagnose: {symptom}")
+				.WithDescription("Diagnose an issue")
+				.AsPrompt();
+		});
+
+		var prompts = await fixture.Client.ListPromptsAsync();
+
+		var prompt = prompts.Should().ContainSingle(p =>
+			string.Equals(p.Name, "troubleshoot", StringComparison.Ordinal)).Which;
+		prompt.ProtocolPrompt.Description.Should().Be("Diagnose an issue");
+		prompt.ProtocolPrompt.Arguments.Should().ContainSingle(a =>
+			string.Equals(a.Name, "symptom", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	[Description("prompts/get dispatches through the pipeline and returns the handler output.")]
+	[Ignore("Prompt pipeline dispatch requires full CoreReplApp execution context — deferred to hosted integration tests.")]
+	public async Task When_PromptsGet_Then_ReturnsHandlerOutput()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(app =>
+		{
+			app.Map("troubleshoot {symptom}", (string symptom) => $"Diagnose: {symptom}")
+				.AsPrompt();
+		});
+
+		var result = await fixture.Client.GetPromptAsync(
+			"troubleshoot",
+			new Dictionary<string, object?>(StringComparer.Ordinal) { ["symptom"] = "missing data" });
+
+		result.Messages.Should().ContainSingle();
+		var text = (result.Messages[0].Content as TextContentBlock)?.Text;
+		text.Should().Contain("Diagnose: missing data");
+	}
 }

--- a/src/Repl.McpTests/Given_McpServerEndToEnd.cs
+++ b/src/Repl.McpTests/Given_McpServerEndToEnd.cs
@@ -196,7 +196,6 @@ public sealed class Given_McpServerEndToEnd
 
 	[TestMethod]
 	[Description("prompts/get dispatches through the pipeline and returns the handler output.")]
-	[Ignore("Prompt pipeline dispatch requires full CoreReplApp execution context — deferred to hosted integration tests.")]
 	public async Task When_PromptsGet_Then_ReturnsHandlerOutput()
 	{
 		await using var fixture = await McpTestFixture.CreateAsync(app =>

--- a/src/Repl.McpTests/Given_McpServerOptionsBuilder.cs
+++ b/src/Repl.McpTests/Given_McpServerOptionsBuilder.cs
@@ -1,0 +1,79 @@
+using System.IO.Pipelines;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Repl.McpTests;
+
+[TestClass]
+public sealed class Given_McpServerOptionsBuilder
+{
+	[TestMethod]
+	[Description("BuildMcpServerOptions returns options with tools from the app's command graph.")]
+	public void When_AppHasCommands_Then_OptionsContainTools()
+	{
+		var app = ReplApp.Create();
+		app.Map("greet {name}", (string name) => $"Hello, {name}!").ReadOnly();
+		app.Map("ping", () => "pong");
+
+		var options = app.Core.BuildMcpServerOptions();
+
+		options.ToolCollection.Should().NotBeNull();
+		options.ToolCollection!.Should().Contain(t => string.Equals(t.ProtocolTool.Name, "greet", StringComparison.Ordinal));
+		options.ToolCollection!.Should().Contain(t => string.Equals(t.ProtocolTool.Name, "ping", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	[Description("BuildMcpServerOptions returns options with resources from ReadOnly commands.")]
+	public void When_AppHasReadOnlyCommands_Then_OptionsContainResources()
+	{
+		var app = ReplApp.Create();
+		app.Map("status", () => "ok").ReadOnly();
+
+		var options = app.Core.BuildMcpServerOptions();
+
+		options.ResourceCollection.Should().NotBeNull();
+		options.ResourceCollection!.Should().NotBeEmpty();
+	}
+
+	[TestMethod]
+	[Description("BuildMcpServerOptions produces options usable with McpServer.Create via pipes.")]
+	public async Task When_OptionsUsedWithMcpServer_Then_ServerResponds()
+	{
+		var app = ReplApp.Create();
+		app.Map("echo {msg}", (string msg) => $"echo:{msg}");
+
+		var mcpOptions = app.Core.BuildMcpServerOptions();
+
+		var clientToServer = new Pipe();
+		var serverToClient = new Pipe();
+		using var cts = new CancellationTokenSource();
+
+		var transport = new StreamServerTransport(
+			clientToServer.Reader.AsStream(),
+			serverToClient.Writer.AsStream(),
+			"test-server");
+		var server = McpServer.Create(transport, mcpOptions);
+		var serverTask = server.RunAsync(cts.Token);
+
+		var clientTransport = new StreamClientTransport(
+			clientToServer.Writer.AsStream(),
+			serverToClient.Reader.AsStream());
+		var client = await McpClient.CreateAsync(clientTransport).ConfigureAwait(false);
+
+		await using (client.ConfigureAwait(false))
+		{
+			var tools = await client.ListToolsAsync().ConfigureAwait(false);
+			tools.Should().ContainSingle(t => string.Equals(t.Name, "echo", StringComparison.Ordinal));
+		}
+
+		await cts.CancelAsync().ConfigureAwait(false);
+		await clientToServer.Writer.CompleteAsync().ConfigureAwait(false);
+		await serverToClient.Writer.CompleteAsync().ConfigureAwait(false);
+
+		try { await serverTask.ConfigureAwait(false); }
+		catch (OperationCanceledException) { /* Expected: server shutdown. */ }
+
+		await server.DisposeAsync().ConfigureAwait(false);
+	}
+}

--- a/src/Repl.McpTests/Given_McpToolAdapter.cs
+++ b/src/Repl.McpTests/Given_McpToolAdapter.cs
@@ -1,0 +1,90 @@
+using Repl.Mcp;
+
+namespace Repl.McpTests;
+
+[TestClass]
+public sealed class Given_McpToolAdapter
+{
+	[TestMethod]
+	[Description("Literal segments pass through unchanged.")]
+	public void When_LiteralSegments_Then_PassedThrough()
+	{
+		var tokens = McpToolAdapter.ReconstructTokens(
+			"contact add",
+			new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase));
+
+		tokens.Should().BeEquivalentTo(["contact", "add"]);
+	}
+
+	[TestMethod]
+	[Description("Dynamic segments are substituted from arguments.")]
+	public void When_DynamicSegment_Then_SubstitutedFromArguments()
+	{
+		var args = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+		{
+			["id"] = "abc123",
+		};
+
+		var tokens = McpToolAdapter.ReconstructTokens("client {id} show", args);
+
+		tokens.Should().BeEquivalentTo(["client", "abc123", "show"]);
+	}
+
+	[TestMethod]
+	[Description("Constrained dynamic segments are substituted.")]
+	public void When_ConstrainedDynamicSegment_Then_Substituted()
+	{
+		var args = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+		{
+			["id"] = "550e8400-e29b-41d4-a716-446655440000",
+		};
+
+		var tokens = McpToolAdapter.ReconstructTokens("contact {id:guid} show", args);
+
+		tokens.Should().BeEquivalentTo(["contact", "550e8400-e29b-41d4-a716-446655440000", "show"]);
+	}
+
+	[TestMethod]
+	[Description("Non-route arguments become named options.")]
+	public void When_ExtraArguments_Then_BecomeNamedOptions()
+	{
+		var args = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+		{
+			["format"] = "json",
+		};
+
+		var tokens = McpToolAdapter.ReconstructTokens("status", args);
+
+		tokens.Should().BeEquivalentTo(["status", "--format", "json"]);
+	}
+
+	[TestMethod]
+	[Description("Interaction prefills become --answer:name=value tokens.")]
+	public void When_AnswerPrefixes_Then_BecomeAnswerTokens()
+	{
+		var args = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+		{
+			["answer:confirm"] = "yes",
+		};
+
+		var tokens = McpToolAdapter.ReconstructTokens("deploy", args);
+
+		tokens.Should().BeEquivalentTo(["deploy", "--answer:confirm=yes"]);
+	}
+
+	[TestMethod]
+	[Description("Mixed route args, options, and prefills reconstruct correctly.")]
+	public void When_MixedArguments_Then_ReconstructedCorrectly()
+	{
+		var args = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+		{
+			["id"] = "42",
+			["verbose"] = "true",
+			["answer:confirm"] = "yes",
+		};
+
+		var tokens = McpToolAdapter.ReconstructTokens("contact {id:int} delete", args);
+
+		tokens.Should().BeEquivalentTo(["contact", "42", "delete", "--verbose", "true", "--answer:confirm=yes"]);
+	}
+}

--- a/src/Repl.McpTests/Given_McpToolAdapter.cs
+++ b/src/Repl.McpTests/Given_McpToolAdapter.cs
@@ -59,32 +59,32 @@ public sealed class Given_McpToolAdapter
 	}
 
 	[TestMethod]
-	[Description("Interaction prefills become --answer:name=value tokens.")]
-	public void When_AnswerPrefixes_Then_BecomeAnswerTokens()
+	[Description("ReconstructTokens treats all non-route args as named options (answer: separation happens upstream in PrepareExecution).")]
+	public void When_RemainingArgs_Then_AllBecomeNamedOptions()
 	{
 		var args = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
 		{
-			["answer:confirm"] = "yes",
+			["format"] = "json",
+			["verbose"] = "true",
 		};
 
 		var tokens = McpToolAdapter.ReconstructTokens("deploy", args);
 
-		tokens.Should().BeEquivalentTo(["deploy", "--answer:confirm=yes"]);
+		tokens.Should().BeEquivalentTo(["deploy", "--format", "json", "--verbose", "true"]);
 	}
 
 	[TestMethod]
-	[Description("Mixed route args, options, and prefills reconstruct correctly.")]
+	[Description("Mixed route args and options reconstruct correctly.")]
 	public void When_MixedArguments_Then_ReconstructedCorrectly()
 	{
 		var args = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
 		{
 			["id"] = "42",
 			["verbose"] = "true",
-			["answer:confirm"] = "yes",
 		};
 
 		var tokens = McpToolAdapter.ReconstructTokens("contact {id:int} delete", args);
 
-		tokens.Should().BeEquivalentTo(["contact", "42", "delete", "--verbose", "true", "--answer:confirm=yes"]);
+		tokens.Should().BeEquivalentTo(["contact", "42", "delete", "--verbose", "true"]);
 	}
 }

--- a/src/Repl.McpTests/Given_McpToolNameFlattener.cs
+++ b/src/Repl.McpTests/Given_McpToolNameFlattener.cs
@@ -1,0 +1,65 @@
+using Repl.Mcp;
+
+namespace Repl.McpTests;
+
+[TestClass]
+public sealed class Given_McpToolNameFlattener
+{
+	[TestMethod]
+	[Description("Simple command without contexts produces the command name.")]
+	public void When_SimpleRoute_Then_ReturnsSameWord()
+	{
+		McpToolNameFlattener.Flatten("greet", '_').Should().Be("greet");
+	}
+
+	[TestMethod]
+	[Description("Context + command produces flattened name with separator.")]
+	public void When_ContextAndCommand_Then_Flattened()
+	{
+		McpToolNameFlattener.Flatten("contact add", '_').Should().Be("contact_add");
+	}
+
+	[TestMethod]
+	[Description("Dynamic segments are removed from the tool name.")]
+	public void When_DynamicSegment_Then_Removed()
+	{
+		McpToolNameFlattener.Flatten("contact {id} notes", '_').Should().Be("contact_notes");
+	}
+
+	[TestMethod]
+	[Description("Multiple dynamic segments are all removed.")]
+	public void When_MultipleDynamicSegments_Then_AllRemoved()
+	{
+		McpToolNameFlattener.Flatten("project {pid} task {tid}", '_').Should().Be("project_task");
+	}
+
+	[TestMethod]
+	[Description("Constrained dynamic segments are removed.")]
+	public void When_ConstrainedDynamicSegment_Then_Removed()
+	{
+		McpToolNameFlattener.Flatten("contact {id:guid} show", '_').Should().Be("contact_show");
+	}
+
+	[TestMethod]
+	[Description("Slash separator works.")]
+	public void When_SlashSeparator_Then_UsesSlash()
+	{
+		McpToolNameFlattener.Flatten("contact add", '/').Should().Be("contact/add");
+	}
+
+	[TestMethod]
+	[Description("Dot separator works.")]
+	public void When_DotSeparator_Then_UsesDot()
+	{
+		McpToolNameFlattener.Flatten("contact add", '.').Should().Be("contact.add");
+	}
+
+	[TestMethod]
+	[Description("Separator resolution from enum.")]
+	public void When_ResolveSeparator_Then_ReturnsCorrectChar()
+	{
+		McpToolNameFlattener.ResolveSeparator(ToolNamingSeparator.Underscore).Should().Be('_');
+		McpToolNameFlattener.ResolveSeparator(ToolNamingSeparator.Slash).Should().Be('/');
+		McpToolNameFlattener.ResolveSeparator(ToolNamingSeparator.Dot).Should().Be('.');
+	}
+}

--- a/src/Repl.McpTests/Given_McpTransportFactory.cs
+++ b/src/Repl.McpTests/Given_McpTransportFactory.cs
@@ -1,0 +1,41 @@
+using ModelContextProtocol.Server;
+using static Repl.McpTests.McpTestFixture;
+
+namespace Repl.McpTests;
+
+[TestClass]
+public sealed class Given_McpTransportFactory
+{
+	[TestMethod]
+	[Description("Custom transport factory is called and server operates through it.")]
+	public async Task When_TransportFactoryProvided_Then_ServerUsesCustomTransport()
+	{
+		var factoryCalled = false;
+
+		await using var fixture = await McpTestFixture.CreateAsync(
+			app => app.Map("ping", () => "pong"),
+			options =>
+			{
+				options.TransportFactory = (serverName, io) =>
+				{
+					factoryCalled = true;
+					var ctx = (PipeIoContext)io;
+					return new StreamServerTransport(ctx.InputStream, ctx.OutputStream, serverName);
+				};
+			}).ConfigureAwait(false);
+
+		factoryCalled.Should().BeTrue();
+
+		var tools = await fixture.Client.ListToolsAsync().ConfigureAwait(false);
+		tools.Should().ContainSingle(t => string.Equals(t.Name, "ping", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	[Description("When no factory is configured, default stdio transport is used (null factory).")]
+	public void When_NoTransportFactory_Then_PropertyIsNull()
+	{
+		var options = new ReplMcpServerOptions();
+
+		options.TransportFactory.Should().BeNull();
+	}
+}

--- a/src/Repl.McpTests/GlobalUsings.cs
+++ b/src/Repl.McpTests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using AwesomeAssertions;
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/Repl.McpTests/McpTestFixture.cs
+++ b/src/Repl.McpTests/McpTestFixture.cs
@@ -1,0 +1,126 @@
+using System.IO.Pipelines;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Repl.Mcp;
+
+namespace Repl.McpTests;
+
+/// <summary>
+/// Connects a Repl app's MCP server to an MCP client via in-process pipes.
+/// Disposes cleanly on teardown — no stdio involved.
+/// </summary>
+internal sealed class McpTestFixture : IAsyncDisposable
+{
+	private readonly CancellationTokenSource _cts = new();
+	private readonly Pipe _clientToServer = new();
+	private readonly Pipe _serverToClient = new();
+	private readonly Task _serverTask;
+
+	private McpTestFixture(McpClient client, Task serverTask)
+	{
+		Client = client;
+		_serverTask = serverTask;
+	}
+
+	public McpClient Client { get; }
+
+	public static async Task<McpTestFixture> CreateAsync(Action<ReplApp> configure)
+	{
+		var app = ReplApp.Create();
+		app.UseMcpServer();
+		configure(app);
+
+		var model = app.Core.CreateDocumentationModel();
+		var adapter = CreateToolAdapter(app, model);
+		var serverOptions = BuildServerOptions(model, adapter);
+
+		var fixture = new McpTestFixture(null!, Task.CompletedTask);
+		var serverTransport = new StreamServerTransport(
+			fixture._clientToServer.Reader.AsStream(),
+			fixture._serverToClient.Writer.AsStream(),
+			"test-server");
+
+		var server = McpServer.Create(serverTransport, serverOptions);
+		var serverTask = server.RunAsync(fixture._cts.Token);
+
+		var clientTransport = new StreamClientTransport(
+			fixture._clientToServer.Writer.AsStream(),
+			fixture._serverToClient.Reader.AsStream());
+		var client = await McpClient.CreateAsync(clientTransport).ConfigureAwait(false);
+
+		return new McpTestFixture(client, serverTask);
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		await Client.DisposeAsync().ConfigureAwait(false);
+		await _cts.CancelAsync().ConfigureAwait(false);
+
+		await _clientToServer.Writer.CompleteAsync().ConfigureAwait(false);
+		await _serverToClient.Writer.CompleteAsync().ConfigureAwait(false);
+
+		try
+		{
+			await _serverTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+		}
+		catch (OperationCanceledException)
+		{
+		}
+		catch (TimeoutException)
+		{
+		}
+
+		_cts.Dispose();
+	}
+
+	private static McpToolAdapter CreateToolAdapter(ReplApp app, Documentation.ReplDocumentationModel model)
+	{
+		var adapter = new McpToolAdapter(app.Core, new ReplMcpServerOptions(), EmptyServiceProvider.Instance);
+		foreach (var command in model.Commands)
+		{
+			if (command.IsHidden || command.Annotations?.AutomationHidden == true)
+			{
+				continue;
+			}
+
+			var toolName = McpToolNameFlattener.Flatten(command.Path, '_');
+			adapter.RegisterRoute(toolName, command);
+		}
+
+		return adapter;
+	}
+
+	private static McpServerOptions BuildServerOptions(
+		Documentation.ReplDocumentationModel model,
+		McpToolAdapter adapter)
+	{
+		var tools = new McpServerPrimitiveCollection<McpServerTool>();
+		foreach (var command in model.Commands)
+		{
+			if (command.IsHidden || command.Annotations?.AutomationHidden == true)
+			{
+				continue;
+			}
+
+			var toolName = McpToolNameFlattener.Flatten(command.Path, '_');
+			tools.Add(new ReplMcpServerTool(command, toolName, adapter));
+		}
+
+		return new McpServerOptions
+		{
+			ServerInfo = new Implementation { Name = "test-server", Version = "1.0.0" },
+			Capabilities = new ServerCapabilities
+			{
+				Tools = new ToolsCapability { ListChanged = true },
+			},
+			ToolCollection = tools,
+		};
+	}
+
+	private sealed class EmptyServiceProvider : IServiceProvider
+	{
+		public static readonly EmptyServiceProvider Instance = new();
+		public object? GetService(Type serviceType) => null;
+	}
+}

--- a/src/Repl.McpTests/McpTestFixture.cs
+++ b/src/Repl.McpTests/McpTestFixture.cs
@@ -92,7 +92,7 @@ internal sealed class McpTestFixture : IAsyncDisposable
 		var adapter = new McpToolAdapter(app.Core, new ReplMcpServerOptions(), EmptyServiceProvider.Instance);
 		foreach (var command in model.Commands)
 		{
-			if (command.IsHidden || command.IsPrompt || command.Annotations?.AutomationHidden == true)
+			if (command.IsHidden || command.Annotations?.AutomationHidden == true)
 			{
 				continue;
 			}
@@ -111,7 +111,7 @@ internal sealed class McpTestFixture : IAsyncDisposable
 		var tools = new McpServerPrimitiveCollection<McpServerTool>();
 		foreach (var command in model.Commands)
 		{
-			if (command.IsHidden || command.IsPrompt || command.Annotations?.AutomationHidden == true)
+			if (command.IsHidden || command.Annotations?.AutomationHidden == true)
 			{
 				continue;
 			}

--- a/src/Repl.McpTests/McpTestFixture.cs
+++ b/src/Repl.McpTests/McpTestFixture.cs
@@ -8,7 +8,8 @@ namespace Repl.McpTests;
 
 /// <summary>
 /// Connects a Repl app's MCP server to an MCP client via in-process pipes.
-/// Disposes cleanly on teardown — no stdio involved.
+/// Uses the real <see cref="McpServerHandler"/> pipeline so fallback options,
+/// filtering, and collision detection are exercised end-to-end.
 /// </summary>
 internal sealed class McpTestFixture : IAsyncDisposable
 {
@@ -33,15 +34,27 @@ internal sealed class McpTestFixture : IAsyncDisposable
 
 	public McpClient Client { get; }
 
-	public static async Task<McpTestFixture> CreateAsync(Action<ReplApp> configure)
+	public static Task<McpTestFixture> CreateAsync(Action<ReplApp> configure) =>
+		CreateAsync(configure, configureOptions: null);
+
+	public static async Task<McpTestFixture> CreateAsync(
+		Action<ReplApp> configure,
+		Action<ReplMcpServerOptions>? configureOptions)
 	{
 		var app = ReplApp.Create();
-		app.UseMcpServer();
+		app.UseMcpServer(configureOptions);
 		configure(app);
 
+		var options = new ReplMcpServerOptions();
+		configureOptions?.Invoke(options);
+
+		// Use the real McpServerHandler to build server options — exercises
+		// the full tool/resource/prompt generation pipeline with fallbacks.
 		var model = app.Core.CreateDocumentationModel();
-		var adapter = CreateToolAdapter(app, model);
-		var serverOptions = BuildServerOptions(model, adapter);
+		var adapter = new McpToolAdapter(app.Core, options, EmptyServiceProvider.Instance);
+		var separator = McpToolNameFlattener.ResolveSeparator(options.ToolNamingSeparator);
+		var handler = new McpServerHandler(app.Core, options, EmptyServiceProvider.Instance);
+		var serverOptions = handler.BuildServerOptions(model, adapter, separator);
 
 		var clientToServer = new Pipe();
 		var serverToClient = new Pipe();
@@ -85,63 +98,6 @@ internal sealed class McpTestFixture : IAsyncDisposable
 		}
 
 		_cts.Dispose();
-	}
-
-	private static McpToolAdapter CreateToolAdapter(ReplApp app, Documentation.ReplDocumentationModel model)
-	{
-		var adapter = new McpToolAdapter(app.Core, new ReplMcpServerOptions(), EmptyServiceProvider.Instance);
-		foreach (var command in model.Commands)
-		{
-			if (command.IsHidden || command.Annotations?.AutomationHidden == true)
-			{
-				continue;
-			}
-
-			var toolName = McpToolNameFlattener.Flatten(command.Path, '_');
-			adapter.RegisterRoute(toolName, command);
-		}
-
-		return adapter;
-	}
-
-	private static McpServerOptions BuildServerOptions(
-		Documentation.ReplDocumentationModel model,
-		McpToolAdapter adapter)
-	{
-		var tools = new McpServerPrimitiveCollection<McpServerTool>();
-		var prompts = new McpServerPrimitiveCollection<McpServerPrompt>();
-
-		foreach (var command in model.Commands)
-		{
-			if (command.IsHidden || command.Annotations?.AutomationHidden == true)
-			{
-				continue;
-			}
-
-			var name = McpToolNameFlattener.Flatten(command.Path, '_');
-
-			if (command.IsPrompt)
-			{
-				adapter.RegisterRoute(name, command);
-				prompts.Add(new ReplMcpServerPrompt(command, name, adapter));
-			}
-			else
-			{
-				tools.Add(new ReplMcpServerTool(command, name, adapter));
-			}
-		}
-
-		return new McpServerOptions
-		{
-			ServerInfo = new Implementation { Name = "test-server", Version = "1.0.0" },
-			Capabilities = new ServerCapabilities
-			{
-				Tools = new ToolsCapability { ListChanged = true },
-				Prompts = prompts.Count > 0 ? new PromptsCapability { ListChanged = true } : null,
-			},
-			ToolCollection = tools,
-			PromptCollection = prompts,
-		};
 	}
 
 	private sealed class EmptyServiceProvider : IServiceProvider

--- a/src/Repl.McpTests/McpTestFixture.cs
+++ b/src/Repl.McpTests/McpTestFixture.cs
@@ -60,10 +60,13 @@ internal sealed class McpTestFixture : IAsyncDisposable
 		var serverToClient = new Pipe();
 		var cts = new CancellationTokenSource();
 
-		var serverTransport = new StreamServerTransport(
-			clientToServer.Reader.AsStream(),
-			serverToClient.Writer.AsStream(),
-			"test-server");
+		var serverName = serverOptions.ServerInfo?.Name ?? "test-server";
+		var inputStream = clientToServer.Reader.AsStream();
+		var outputStream = serverToClient.Writer.AsStream();
+		var ioContext = new PipeIoContext(inputStream, outputStream);
+		ITransport serverTransport = options.TransportFactory is { } factory
+			? factory(serverName, ioContext)
+			: new StreamServerTransport(inputStream, outputStream, serverName);
 
 		var server = McpServer.Create(serverTransport, serverOptions);
 		var serverTask = server.RunAsync(cts.Token);
@@ -104,5 +107,16 @@ internal sealed class McpTestFixture : IAsyncDisposable
 	{
 		public static readonly EmptyServiceProvider Instance = new();
 		public object? GetService(Type serviceType) => null;
+	}
+
+	internal sealed class PipeIoContext(Stream inputStream, Stream outputStream) : IReplIoContext
+	{
+		public Stream InputStream => inputStream;
+		public Stream OutputStream => outputStream;
+		public TextReader Input => new StreamReader(inputStream);
+		public TextWriter Output => new StreamWriter(outputStream);
+		public TextWriter Error => TextWriter.Null;
+		public bool IsHostedSession => false;
+		public string? SessionId => null;
 	}
 }

--- a/src/Repl.McpTests/McpTestFixture.cs
+++ b/src/Repl.McpTests/McpTestFixture.cs
@@ -109,6 +109,8 @@ internal sealed class McpTestFixture : IAsyncDisposable
 		McpToolAdapter adapter)
 	{
 		var tools = new McpServerPrimitiveCollection<McpServerTool>();
+		var prompts = new McpServerPrimitiveCollection<McpServerPrompt>();
+
 		foreach (var command in model.Commands)
 		{
 			if (command.IsHidden || command.Annotations?.AutomationHidden == true)
@@ -116,8 +118,17 @@ internal sealed class McpTestFixture : IAsyncDisposable
 				continue;
 			}
 
-			var toolName = McpToolNameFlattener.Flatten(command.Path, '_');
-			tools.Add(new ReplMcpServerTool(command, toolName, adapter));
+			var name = McpToolNameFlattener.Flatten(command.Path, '_');
+
+			if (command.IsPrompt)
+			{
+				adapter.RegisterRoute(name, command);
+				prompts.Add(new ReplMcpServerPrompt(command, name, adapter));
+			}
+			else
+			{
+				tools.Add(new ReplMcpServerTool(command, name, adapter));
+			}
 		}
 
 		return new McpServerOptions
@@ -126,8 +137,10 @@ internal sealed class McpTestFixture : IAsyncDisposable
 			Capabilities = new ServerCapabilities
 			{
 				Tools = new ToolsCapability { ListChanged = true },
+				Prompts = prompts.Count > 0 ? new PromptsCapability { ListChanged = true } : null,
 			},
 			ToolCollection = tools,
+			PromptCollection = prompts,
 		};
 	}
 

--- a/src/Repl.McpTests/McpTestFixture.cs
+++ b/src/Repl.McpTests/McpTestFixture.cs
@@ -12,15 +12,23 @@ namespace Repl.McpTests;
 /// </summary>
 internal sealed class McpTestFixture : IAsyncDisposable
 {
-	private readonly CancellationTokenSource _cts = new();
-	private readonly Pipe _clientToServer = new();
-	private readonly Pipe _serverToClient = new();
+	private readonly CancellationTokenSource _cts;
+	private readonly Pipe _clientToServer;
+	private readonly Pipe _serverToClient;
 	private readonly Task _serverTask;
 
-	private McpTestFixture(McpClient client, Task serverTask)
+	private McpTestFixture(
+		McpClient client,
+		Task serverTask,
+		CancellationTokenSource cts,
+		Pipe clientToServer,
+		Pipe serverToClient)
 	{
 		Client = client;
 		_serverTask = serverTask;
+		_cts = cts;
+		_clientToServer = clientToServer;
+		_serverToClient = serverToClient;
 	}
 
 	public McpClient Client { get; }
@@ -35,21 +43,24 @@ internal sealed class McpTestFixture : IAsyncDisposable
 		var adapter = CreateToolAdapter(app, model);
 		var serverOptions = BuildServerOptions(model, adapter);
 
-		var fixture = new McpTestFixture(null!, Task.CompletedTask);
+		var clientToServer = new Pipe();
+		var serverToClient = new Pipe();
+		var cts = new CancellationTokenSource();
+
 		var serverTransport = new StreamServerTransport(
-			fixture._clientToServer.Reader.AsStream(),
-			fixture._serverToClient.Writer.AsStream(),
+			clientToServer.Reader.AsStream(),
+			serverToClient.Writer.AsStream(),
 			"test-server");
 
 		var server = McpServer.Create(serverTransport, serverOptions);
-		var serverTask = server.RunAsync(fixture._cts.Token);
+		var serverTask = server.RunAsync(cts.Token);
 
 		var clientTransport = new StreamClientTransport(
-			fixture._clientToServer.Writer.AsStream(),
-			fixture._serverToClient.Reader.AsStream());
+			clientToServer.Writer.AsStream(),
+			serverToClient.Reader.AsStream());
 		var client = await McpClient.CreateAsync(clientTransport).ConfigureAwait(false);
 
-		return new McpTestFixture(client, serverTask);
+		return new McpTestFixture(client, serverTask, cts, clientToServer, serverToClient);
 	}
 
 	public async ValueTask DisposeAsync()
@@ -66,9 +77,11 @@ internal sealed class McpTestFixture : IAsyncDisposable
 		}
 		catch (OperationCanceledException)
 		{
+			// Expected: server RunAsync cancelled during shutdown.
 		}
 		catch (TimeoutException)
 		{
+			// Server did not shut down within timeout — transport will be collected.
 		}
 
 		_cts.Dispose();
@@ -79,7 +92,7 @@ internal sealed class McpTestFixture : IAsyncDisposable
 		var adapter = new McpToolAdapter(app.Core, new ReplMcpServerOptions(), EmptyServiceProvider.Instance);
 		foreach (var command in model.Commands)
 		{
-			if (command.IsHidden || command.Annotations?.AutomationHidden == true)
+			if (command.IsHidden || command.IsPrompt || command.Annotations?.AutomationHidden == true)
 			{
 				continue;
 			}
@@ -98,7 +111,7 @@ internal sealed class McpTestFixture : IAsyncDisposable
 		var tools = new McpServerPrimitiveCollection<McpServerTool>();
 		foreach (var command in model.Commands)
 		{
-			if (command.IsHidden || command.Annotations?.AutomationHidden == true)
+			if (command.IsHidden || command.IsPrompt || command.Annotations?.AutomationHidden == true)
 			{
 				continue;
 			}

--- a/src/Repl.McpTests/Repl.McpTests.csproj
+++ b/src/Repl.McpTests/Repl.McpTests.csproj
@@ -8,6 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Repl.McpTests/Repl.McpTests.csproj
+++ b/src/Repl.McpTests/Repl.McpTests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="MSTest.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="AwesomeAssertions" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Repl.Mcp\Repl.Mcp.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Repl.Tests/Given_CommandAnnotations.cs
+++ b/src/Repl.Tests/Given_CommandAnnotations.cs
@@ -1,0 +1,74 @@
+namespace Repl.Tests;
+
+[TestClass]
+public sealed class Given_CommandAnnotations
+{
+	[TestMethod]
+	[Description("Verifies annotation record defaults to all-false.")]
+	public void When_DefaultConstructed_Then_AllFlagsAreFalse()
+	{
+		var annotations = new CommandAnnotations();
+
+		annotations.Destructive.Should().BeFalse();
+		annotations.ReadOnly.Should().BeFalse();
+		annotations.Idempotent.Should().BeFalse();
+		annotations.OpenWorld.Should().BeFalse();
+		annotations.LongRunning.Should().BeFalse();
+		annotations.AutomationHidden.Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("Verifies init setters work for individual flags.")]
+	public void When_CreatedWithInitSetters_Then_FlagsAreSet()
+	{
+		var annotations = new CommandAnnotations
+		{
+			Destructive = true,
+			ReadOnly = true,
+		};
+
+		annotations.Destructive.Should().BeTrue();
+		annotations.ReadOnly.Should().BeTrue();
+		annotations.Idempotent.Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("Verifies with-expression preserves existing flags when setting new ones.")]
+	public void When_UsingWithExpression_Then_ExistingFlagsArePreserved()
+	{
+		var original = new CommandAnnotations { Destructive = true };
+		var modified = original with { OpenWorld = true };
+
+		modified.Destructive.Should().BeTrue();
+		modified.OpenWorld.Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("Verifies builder produces matching annotations.")]
+	public void When_UsingBuilder_Then_AnnotationsMatchFlags()
+	{
+		var builder = new CommandAnnotationsBuilder();
+		builder.Destructive().LongRunning().OpenWorld();
+
+		var annotations = builder.Build();
+
+		annotations.Destructive.Should().BeTrue();
+		annotations.LongRunning.Should().BeTrue();
+		annotations.OpenWorld.Should().BeTrue();
+		annotations.ReadOnly.Should().BeFalse();
+		annotations.Idempotent.Should().BeFalse();
+		annotations.AutomationHidden.Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("Verifies builder supports toggling flags off.")]
+	public void When_BuilderTogglesOff_Then_FlagIsCleared()
+	{
+		var builder = new CommandAnnotationsBuilder();
+		builder.Destructive().Destructive(value: false);
+
+		var annotations = builder.Build();
+
+		annotations.Destructive.Should().BeFalse();
+	}
+}

--- a/src/Repl.Tests/Given_CommandBuilderEnrichment.cs
+++ b/src/Repl.Tests/Given_CommandBuilderEnrichment.cs
@@ -1,0 +1,234 @@
+using Repl.Documentation;
+
+namespace Repl.Tests;
+
+[TestClass]
+public sealed class Given_CommandBuilderEnrichment
+{
+	// ── WithDetails ────────────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Verifies WithDetails stores markdown content.")]
+	public void When_WithDetailsIsCalled_Then_DetailsIsStored()
+	{
+		var sut = CoreReplApp.Create();
+		var command = sut.Map("deploy", () => "ok");
+
+		command.WithDetails("Deploys the application.");
+
+		command.Details.Should().Be("Deploys the application.");
+	}
+
+	[TestMethod]
+	[Description("Verifies WithDetails rejects empty content.")]
+	public void When_WithDetailsIsCalledWithEmpty_Then_Throws()
+	{
+		var sut = CoreReplApp.Create();
+		var command = sut.Map("deploy", () => "ok");
+
+		var act = () => command.WithDetails("   ");
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	// ── Annotation shortcuts ───────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Verifies ReadOnly shortcut creates and sets annotation.")]
+	public void When_ReadOnlyIsCalled_Then_AnnotationIsSet()
+	{
+		var sut = CoreReplApp.Create();
+		var command = sut.Map("list", () => "ok");
+
+		var chained = command.ReadOnly();
+
+		chained.Should().BeSameAs(command);
+		command.Annotations.Should().NotBeNull();
+		command.Annotations!.ReadOnly.Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("Verifies chaining multiple annotation shortcuts preserves all flags.")]
+	public void When_MultipleShortsAreChained_Then_AllFlagsArePreserved()
+	{
+		var sut = CoreReplApp.Create();
+		var command = sut.Map("deploy", () => "ok");
+
+		command.Destructive().LongRunning().OpenWorld();
+
+		command.Annotations!.Destructive.Should().BeTrue();
+		command.Annotations!.LongRunning.Should().BeTrue();
+		command.Annotations!.OpenWorld.Should().BeTrue();
+		command.Annotations!.ReadOnly.Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("Verifies WithAnnotations builder escape hatch works and overwrites shortcuts.")]
+	public void When_WithAnnotationsIsCalled_Then_PreviousShortcutsAreOverwritten()
+	{
+		var sut = CoreReplApp.Create();
+		var command = sut.Map("deploy", () => "ok");
+
+		command.ReadOnly();
+		command.WithAnnotations(a => a.Destructive().OpenWorld());
+
+		command.Annotations!.ReadOnly.Should().BeFalse();
+		command.Annotations!.Destructive.Should().BeTrue();
+		command.Annotations!.OpenWorld.Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("Verifies WithAnnotations rejects null configure.")]
+	public void When_WithAnnotationsIsCalledWithNull_Then_Throws()
+	{
+		var sut = CoreReplApp.Create();
+		var command = sut.Map("deploy", () => "ok");
+
+		var act = () => command.WithAnnotations(null!);
+
+		act.Should().Throw<ArgumentNullException>();
+	}
+
+	// ── AsResource / AsPrompt ──────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Verifies AsResource marks the command as a resource.")]
+	public void When_AsResourceIsCalled_Then_IsResourceIsTrue()
+	{
+		var sut = CoreReplApp.Create();
+		var command = sut.Map("contacts", () => "ok");
+
+		command.AsResource();
+
+		command.IsResource.Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("Verifies AsPrompt marks the command as a prompt source.")]
+	public void When_AsPromptIsCalled_Then_IsPromptIsTrue()
+	{
+		var sut = CoreReplApp.Create();
+		var command = sut.Map("explain", () => "ok");
+
+		command.AsPrompt();
+
+		command.IsPrompt.Should().BeTrue();
+	}
+
+	// ── WithMetadata ───────────────────────────────────────────────────
+
+	[TestMethod]
+	[Description("Verifies WithMetadata stores key-value pairs.")]
+	public void When_WithMetadataIsCalled_Then_EntryIsStored()
+	{
+		var sut = CoreReplApp.Create();
+		var command = sut.Map("deploy", () => "ok");
+
+		command.WithMetadata("category", "operations");
+
+		command.Metadata.Should().ContainKey("category");
+		command.Metadata["category"].Should().Be("operations");
+	}
+
+	[TestMethod]
+	[Description("Verifies WithMetadata rejects empty key.")]
+	public void When_WithMetadataIsCalledWithEmptyKey_Then_Throws()
+	{
+		var sut = CoreReplApp.Create();
+		var command = sut.Map("deploy", () => "ok");
+
+		var act = () => command.WithMetadata("", "value");
+
+		act.Should().Throw<ArgumentException>();
+	}
+
+	// ── Documentation model enrichment ─────────────────────────────────
+
+	[TestMethod]
+	[Description("Verifies enriched fields propagate through the documentation model.")]
+	public void When_DocumentationModelIsCreated_Then_EnrichedFieldsArePresent()
+	{
+		var sut = CoreReplApp.Create();
+		sut.Map("contacts", () => "ok")
+			.WithDescription("List contacts")
+			.WithDetails("Returns all contacts.")
+			.ReadOnly()
+			.AsResource()
+			.WithMetadata("scope", "crm");
+
+		var model = sut.CreateDocumentationModel();
+
+		var cmd = model.Commands.Should().ContainSingle(c => c.Path == "contacts").Which;
+		cmd.Details.Should().Be("Returns all contacts.");
+		cmd.Annotations.Should().NotBeNull();
+		cmd.Annotations!.ReadOnly.Should().BeTrue();
+		cmd.IsResource.Should().BeTrue();
+		cmd.Metadata.Should().NotBeNull();
+		cmd.Metadata!["scope"].Should().Be("crm");
+	}
+
+	[TestMethod]
+	[Description("Verifies resources collection is populated from AsResource commands.")]
+	public void When_CommandIsMarkedAsResource_Then_ResourcesCollectionContainsIt()
+	{
+		var sut = CoreReplApp.Create();
+		sut.Map("contacts", () => "ok")
+			.WithDescription("List contacts")
+			.AsResource();
+
+		var model = sut.CreateDocumentationModel();
+
+		model.Resources.Should().ContainSingle(r => r.Path == "contacts");
+	}
+
+	[TestMethod]
+	[Description("Verifies ReadOnly commands are auto-promoted to resources.")]
+	public void When_CommandIsReadOnly_Then_ResourcesCollectionContainsIt()
+	{
+		var sut = CoreReplApp.Create();
+		sut.Map("status", () => "ok")
+			.WithDescription("Show status")
+			.ReadOnly();
+
+		var model = sut.CreateDocumentationModel();
+
+		model.Resources.Should().ContainSingle(r => r.Path == "status");
+	}
+
+	[TestMethod]
+	[Description("Verifies AsPrompt flag propagates through the documentation model.")]
+	public void When_CommandIsMarkedAsPrompt_Then_IsPromptIsTrue()
+	{
+		var sut = CoreReplApp.Create();
+		sut.Map("explain {code}", (string code) => $"Explain {code}")
+			.AsPrompt();
+
+		var model = sut.CreateDocumentationModel();
+
+		model.Commands.Should().ContainSingle(c => c.Path == "explain {code}").Which
+			.IsPrompt.Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("Verifies route argument descriptions are picked up from [Description] attributes.")]
+	public void When_HandlerHasDescriptionAttribute_Then_ArgumentDescriptionIsPopulated()
+	{
+		var sut = CoreReplApp.Create();
+		sut.Map("contact {id:int}", ([System.ComponentModel.Description("Contact numeric id")] int id) => id);
+
+		var model = sut.CreateDocumentationModel();
+
+		var arg = model.Commands.Should().ContainSingle(c => c.Path == "contact {id:int}").Which
+			.Arguments.Should().ContainSingle().Which;
+		arg.Description.Should().Be("Contact numeric id");
+	}
+
+	// ── ReplRuntimeChannel.Programmatic ────────────────────────────────
+
+	[TestMethod]
+	[Description("Verifies Programmatic channel value exists.")]
+	public void When_ProgrammaticChannel_Then_ValueIs3()
+	{
+		((int)ReplRuntimeChannel.Programmatic).Should().Be(3);
+	}
+}

--- a/src/Repl.slnx
+++ b/src/Repl.slnx
@@ -6,11 +6,13 @@
 	<Project Path="Repl.WebSocket/Repl.WebSocket.csproj" />
 	<Project Path="Repl.Telnet/Repl.Telnet.csproj" />
 	<Project Path="Repl.Testing/Repl.Testing.csproj" />
+	<Project Path="Repl.Mcp/Repl.Mcp.csproj" />
 	<Project Path="Repl.Spectre/Repl.Spectre.csproj" />
 	<Project Path="Repl.ShellCompletionTestHost/Repl.ShellCompletionTestHost.csproj" />
 	<Project Path="Repl.Tests/Repl.Tests.csproj" />
 	<Project Path="Repl.IntegrationTests/Repl.IntegrationTests.csproj" />
 	<Project Path="Repl.ProtocolTests/Repl.ProtocolTests.csproj" />
+	<Project Path="Repl.McpTests/Repl.McpTests.csproj" />
 	<Project Path="Repl.SpectreTests/Repl.SpectreTests.csproj" />
 	<Folder Name="/Samples/">
 		<Project Path="../samples/01-core-basics/CoreBasicsSample.csproj" />

--- a/src/Repl.slnx
+++ b/src/Repl.slnx
@@ -22,5 +22,6 @@
 		<Project Path="../samples/05-hosting-remote/HostingRemoteSample.csproj" />
 		<Project Path="../samples/06-testing/TestingSample.csproj" />
 		<Project Path="../samples/07-spectre/SpectreOpsSample.csproj" />
+		<Project Path="../samples/08-mcp-server/McpServerSample.csproj" />
 	</Folder>
 </Solution>


### PR DESCRIPTION
## Summary

Enables any Repl app to become an MCP (Model Context Protocol) server with a single `app.UseMcpServer()` call. AI agents like Claude Desktop, VS Code Copilot, and Cursor can then discover and invoke commands as typed tools with real JSON Schema, behavioral annotations, and progressive interaction degradation.

```csharp
var app = ReplApp.Create().UseDefaultInteractive();

app.Map("contacts", () => db.GetAll())
    .ReadOnly()
    .AsResource();

app.Map("contact add", (string name, string email) => db.Add(name, email))
    .OpenWorld().Idempotent();

app.Map("contact delete {id:guid}", async (Guid id, IReplInteractionChannel interaction, CancellationToken ct) =>
    {
        if (!await interaction.AskConfirmationAsync("confirm", $"Delete {id}?", options: new(ct)))
            return Results.Cancelled("Aborted.");
        return db.Delete(id);
    })
    .Destructive();

app.UseMcpServer();
return app.Run(args);
```

```bash
myapp mcp serve                    # starts MCP stdio server
myapp                              # still works as a CLI / interactive REPL
```

One command graph. CLI, REPL, remote sessions, and AI agents — all from the same code.

## What agents see

Commands become **MCP tools** with typed JSON Schema derived from route constraints and handler parameters. Annotations map directly to MCP hints that agents use for safety decisions:

| Repl API | MCP effect |
|----------|-----------|
| `.ReadOnly()` | `readOnlyHint: true`, `destructiveHint: false` — agent calls autonomously |
| `.Destructive()` | `destructiveHint: true` — agent asks for confirmation |
| `.Idempotent()` | `idempotentHint: true` — agent retries on failure |
| `.OpenWorld()` | `openWorldHint: true` — agent expects latency |
| `.AutomationHidden()` | excluded from tool list entirely |
| `.AsResource()` | exposed as MCP resource with URI template (e.g. `repl://config/{env}`) |
| `.AsPrompt()` | exposed as MCP prompt template |
| `.WithDetails(md)` | enriches MCP tool description with extended markdown |

Route constraints (`{id:guid}`, `{email:email}`, `{when:date}`) produce proper JSON Schema formats. Parameterized resources (e.g. `config {env}`) are exposed as URI templates — agents read `repl://config/production` and the parameters flow through the command pipeline.

## Runtime interaction in MCP mode

Commands that prompt users at runtime (`AskConfirmationAsync`, `AskChoiceAsync`, etc.) degrade gracefully across four tiers:

1. **Prefill** — values from tool arguments (`answer:confirm=yes`)
2. **Elicitation** — structured form request to the user through the agent client
3. **Sampling** — LLM answers on behalf of the user
4. **Default/Fail** — use explicit default value or fail with descriptive error

`AskConfirmationAsync` accepts `bool? defaultValue = null` — explicit defaults are returned before mode checks (consistent with `AskChoiceAsync` and `AskTextAsync`). `AskSecretAsync` is always prefill-only (security). `WriteProgressAsync` maps to real-time MCP progress notifications. `WriteStatusAsync` maps to MCP log messages.

## Custom transports & HTTP

The server supports three integration patterns:

- **Stdio** (default) — `myapp mcp serve` for standard MCP clients
- **Stdio-over-anything** — `TransportFactory` option for WebSocket, named pipes, SSH, etc.
- **MCP-over-HTTP** — `BuildMcpServerOptions()` builds the MCP collections for use with ASP.NET Core or any HTTP host

Multi-session is supported in all patterns via `AsyncLocal` session isolation (same mechanism as hosted sessions). See [docs/mcp-advanced.md](docs/mcp-advanced.md) for recipes.

```csharp
// Custom transport via mcp serve
app.UseMcpServer(o => o.TransportFactory = (name, io) =>
    new StreamServerTransport(wsInput, wsOutput, name));

// Standalone options for HTTP integration
var mcpOptions = app.Core.BuildMcpServerOptions();
var server = McpServer.Create(httpTransport, mcpOptions);
```

## Architecture

The design splits into two layers:

- **Core enrichment** (`Repl.Core`) — `CommandAnnotations`, `WithDetails`, `AsResource`, `AsPrompt`, `ReplRuntimeChannel.Programmatic`, public `CreateDocumentationModel`. Useful independently of MCP.
- **`Repl.Mcp` package** — opt-in, references `ModelContextProtocol` SDK. Reads the documentation model, generates JSON Schema, registers MCP tools/resources/prompts, dispatches tool calls through the existing Repl pipeline, and captures output.

Tool calls execute through `CoreReplApp.RunWithServicesAsync` — the same pipeline as CLI and interactive mode. No parallel code path.

## Reliability & performance

- **Debounced routing invalidation** — multiple rapid `Map()` calls coalesce into a single rebuild (100ms debounce via injectable `TimeProvider`)
- **Optimistic concurrency** — route rebuilds use a temporary adapter; existing routes stay live until the atomic swap
- **Timer crash resilience** — unhandled exceptions in rebuild callbacks are caught; server continues with stale routes
- **IsProgrammatic AsyncLocal** — properly saved/restored across all execution paths
- **Concurrent sessions** — tested with parallel MCP sessions sharing the same app instance

## Configuration

```csharp
app.UseMcpServer(o =>
{
    o.ServerName = "MyApp";
    o.ServerVersion = "1.0.0";
    o.ResourceUriScheme = "myapp";                              // myapp://status instead of repl://status
    o.TransportFactory = (name, io) => customTransport;         // custom transport
    o.InteractivityMode = InteractivityMode.PrefillThenFail;
    o.ResourceFallbackToTools = true;                           // resources also appear as tools
    o.PromptFallbackToTools = true;                             // prompts also appear as tools
    o.CommandFilter = cmd => true;
});
```

## Test plan

- [x] 736 tests pass (`dotnet test --solution src/Repl.slnx`)
- [x] End-to-end tests via real MCP client/server over in-process pipes
- [x] Concurrent session isolation tested
- [x] Debounce tested with `FakeTimeProvider` (deterministic, sync)
- [x] Parameterized resource read tested
- [x] Interaction error paths tested (ParseBool, prefix matching, min/max multi-choice)
- [x] Timer crash resilience tested
- [x] Custom transport factory tested
