### PR TITLE
Fix [FromServices]/[FromContext] parameters leaking into MCP tool schemas

### DIFF
--- a/src/Repl.Core/CoreReplApp.Documentation.cs
+++ b/src/Repl.Core/CoreReplApp.Documentation.cs
@@ -231,6 +231,8 @@ public sealed partial class CoreReplApp
 				&& parameter.ParameterType != typeof(CancellationToken)
 				&& !routeParameterNames.Contains(parameter.Name!)
 				&& !IsFrameworkInjectedParameter(parameter.ParameterType)
+				&& parameter.GetCustomAttribute<FromServicesAttribute>() is null
+				&& parameter.GetCustomAttribute<FromContextAttribute>() is null
 				&& !Attribute.IsDefined(parameter.ParameterType, typeof(ReplOptionsGroupAttribute), inherit: true))
 			.Select(parameter => BuildDocumentationOption(route.OptionSchema, parameter));
 		var groupOptions = handlerParams

--- a/src/Repl.McpTests/Given_McpServerEndToEnd.cs
+++ b/src/Repl.McpTests/Given_McpServerEndToEnd.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 
 namespace Repl.McpTests;
@@ -171,6 +172,135 @@ public sealed class Given_McpServerEndToEnd
 
 		tools.Should().ContainSingle(t => string.Equals(t.Name, "contacts", StringComparison.Ordinal));
 	}
+
+	// ── Prompts ────────────────────────────────────────────────────────
+
+	// ── Context parameter binding ─────────────────────────────────────
+
+	[TestMethod]
+	[Description("Context tool call with optional params present dispatches correctly.")]
+	public async Task When_ContextToolCallWithOptionalParams_Then_Succeeds()
+	{
+		await using var fixture = await CreateContextFixtureAsync();
+
+		var result = await fixture.Client.CallToolAsync(
+			"session_screenshot",
+			new Dictionary<string, object?>(StringComparer.Ordinal)
+			{
+				["id"] = "s1",
+				["path"] = @"C:\out\file.png",
+				["zone"] = "status",
+			});
+
+		result.IsError.Should().BeFalse("call with optional param should succeed");
+		var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text;
+		text.Should().NotBeNull();
+		text.Should().Contain("s1");
+		text.Should().Contain("file.png");
+	}
+
+	[TestMethod]
+	[Description("Context tool call without optional params dispatches correctly.")]
+	public async Task When_ContextToolCallWithoutOptionalParams_Then_Succeeds()
+	{
+		await using var fixture = await CreateContextFixtureAsync();
+
+		var result = await fixture.Client.CallToolAsync(
+			"session_screenshot",
+			new Dictionary<string, object?>(StringComparer.Ordinal)
+			{
+				["id"] = "s1",
+				["path"] = @"C:\out\file.png",
+			});
+
+		result.IsError.Should().BeFalse("omitting optional params should not cause a binding failure");
+		var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text;
+		text.Should().NotBeNull();
+		text.Should().Contain("s1");
+		text.Should().Contain("file.png");
+	}
+
+	[TestMethod]
+	[Description("[FromServices] parameters must not appear in tool schema properties.")]
+	public async Task When_HandlerHasFromServicesParams_Then_SchemaExcludesThem()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(app =>
+		{
+			app.Context("session", session =>
+			{
+				session.Context("{id}", scoped =>
+				{
+					scoped.Map("screenshot", async (
+						string id,
+						[System.ComponentModel.Description("File path")] string path,
+						[System.ComponentModel.Description("Named zone")] string? zone,
+						[FromServices] MarkerService svc,
+						[FromServices] AnotherService svc2) =>
+					{
+						await Task.CompletedTask.ConfigureAwait(false);
+						return (object)new { id, path, zone };
+					});
+				});
+			});
+		}, configureServices: services =>
+		{
+			services.AddSingleton<MarkerService>();
+			services.AddSingleton<AnotherService>();
+		});
+
+		var tools = await fixture.Client.ListToolsAsync();
+		var tool = tools.Single(t => string.Equals(t.Name, "session_screenshot", StringComparison.Ordinal));
+		var properties = tool.JsonSchema.GetProperty("properties");
+
+		properties.TryGetProperty("id", out _).Should().BeTrue("id is a route argument");
+		properties.TryGetProperty("path", out _).Should().BeTrue("path is a command option");
+		properties.TryGetProperty("zone", out _).Should().BeTrue("zone is a command option");
+		properties.TryGetProperty("svc", out _).Should().BeFalse("[FromServices] params must not leak into schema");
+		properties.TryGetProperty("svc2", out _).Should().BeFalse("[FromServices] params must not leak into schema");
+	}
+
+	private static Task<McpTestFixture> CreateContextFixtureAsync() =>
+		McpTestFixture.CreateAsync(app =>
+		{
+			app.Context("session", session =>
+			{
+				session.Map("list", ([FromServices] MarkerService svc) => "all")
+					.WithDescription("List sessions").ReadOnly();
+
+				session.Context("{id}", scoped =>
+				{
+					scoped.Map("info", (
+						string id,
+						[System.ComponentModel.Description("Process id")] int? pid,
+						[System.ComponentModel.Description("Show details")] bool? detailed,
+						[FromServices] MarkerService svc) =>
+						(object)new { id, pid, detailed }).ReadOnly();
+
+					scoped.Map("screenshot", async (
+						string id,
+						[System.ComponentModel.Description("File path")] string path,
+						[System.ComponentModel.Description("Crop region")] string? region,
+						[System.ComponentModel.Description("Named zone")] string? zone,
+						[FromServices] MarkerService svc,
+						[FromServices] AnotherService svc2) =>
+					{
+						await Task.CompletedTask.ConfigureAwait(false);
+						return (object)new { id, path, zone, region };
+					});
+				});
+			});
+		}, configureServices: services =>
+		{
+			services.AddSingleton<MarkerService>();
+			services.AddSingleton<AnotherService>();
+		});
+
+	private sealed class MarkerService
+	{
+		public static string Marker => "ok";
+	}
+
+	private sealed class AnotherService;
 
 	// ── Prompts ────────────────────────────────────────────────────────
 

--- a/src/Repl.McpTests/Given_McpServerEndToEnd.cs
+++ b/src/Repl.McpTests/Given_McpServerEndToEnd.cs
@@ -195,7 +195,7 @@ public sealed class Given_McpServerEndToEnd
 		result.IsError.Should().BeFalse("call with optional param should succeed");
 		var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text;
 		text.Should().NotBeNull();
-		text.Should().Contain("s1");
+		text!.Should().Contain("s1");
 		text.Should().Contain("file.png");
 	}
 
@@ -216,7 +216,7 @@ public sealed class Given_McpServerEndToEnd
 		result.IsError.Should().BeFalse("omitting optional params should not cause a binding failure");
 		var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text;
 		text.Should().NotBeNull();
-		text.Should().Contain("s1");
+		text!.Should().Contain("s1");
 		text.Should().Contain("file.png");
 	}
 

--- a/src/Repl.McpTests/McpTestFixture.cs
+++ b/src/Repl.McpTests/McpTestFixture.cs
@@ -1,4 +1,5 @@
 using System.IO.Pipelines;
+using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -41,19 +42,28 @@ internal sealed class McpTestFixture : IAsyncDisposable
 	public static Task<McpTestFixture> CreateAsync(Action<ReplApp> configure) =>
 		CreateAsync(configure, configureOptions: null, clientOptions: null);
 
+	public static Task<McpTestFixture> CreateAsync(
+		Action<ReplApp> configure,
+		Action<IServiceCollection>? configureServices) =>
+		CreateAsync(configure, configureOptions: null, clientOptions: null, configureServices: configureServices);
+
 	public static async Task<McpTestFixture> CreateAsync(
 		Action<ReplApp> configure,
 		Action<ReplMcpServerOptions>? configureOptions,
-		McpClientOptions? clientOptions = null)
+		McpClientOptions? clientOptions = null,
+		Action<IServiceCollection>? configureServices = null)
 	{
-		var app = ReplApp.Create();
+		var app = configureServices is not null
+			? ReplApp.Create(configureServices)
+			: ReplApp.Create();
 		app.UseMcpServer(configureOptions);
 		configure(app);
 
 		var options = new ReplMcpServerOptions();
 		configureOptions?.Invoke(options);
 
-		var handler = new McpServerHandler(app.Core, options, EmptyServiceProvider.Instance);
+		var serviceProvider = configureServices is not null ? app.Services : EmptyServiceProvider.Instance;
+		var handler = new McpServerHandler(app.Core, options, serviceProvider);
 
 		var clientToServer = new Pipe();
 		var serverToClient = new Pipe();


### PR DESCRIPTION
## Summary

- The documentation model builder (`CoreReplApp.Documentation.cs`) did not filter `[FromServices]` or `[FromContext]` parameters, causing them to appear as user-facing properties in MCP tool JSON schemas. The `OptionSchemaBuilder` already excluded them correctly, so runtime binding was unaffected — but LLM agents saw spurious parameters (e.g. service type names like `manager`, `viewers`) in tool definitions.
- Add MCP end-to-end tests covering nested context patterns (`session → {id} → screenshot/info`) with service injection, including a schema assertion that `[FromServices]` params are excluded.
- Add `configureServices` support to `McpTestFixture` for DI-enabled test scenarios.

## Test plan

- [x] New test `When_HandlerHasFromServicesParams_Then_SchemaExcludesThem` verifies service params are absent from schema
- [x] New tests `When_ContextToolCallWithOptionalParams_Then_Succeeds` / `WithoutOptionalParams` cover multi-command context dispatch
- [x] Full suite: 743 tests, 0 failures
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yllibed/repl/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
