### PR TITLE
Fix implicit context binding for option-schema parameters

### DIFF
--- a/src/Repl.Core/HandlerArgumentBinder.cs
+++ b/src/Repl.Core/HandlerArgumentBinder.cs
@@ -44,7 +44,7 @@ internal static class HandlerArgumentBinder
 
 		if (HasExplicitBindingDirection(parameter))
 		{
-			if (TryResolveFromContextOrServices(parameter, context, out var explicitValue))
+			if (TryResolveFromContextOrServices(parameter, context, skipContext: false, out var explicitValue))
 			{
 				return explicitValue;
 			}
@@ -87,7 +87,8 @@ internal static class HandlerArgumentBinder
 					enumIgnoreCase);
 			}
 
-		if (TryResolveFromContextOrServices(parameter, context, out var resolved))
+		var isUserOption = context.OptionSchema.TryGetParameter(parameterName, out _);
+		if (TryResolveFromContextOrServices(parameter, context, skipContext: isUserOption, out var resolved))
 		{
 			return resolved;
 		}
@@ -126,6 +127,7 @@ internal static class HandlerArgumentBinder
 	private static bool TryResolveFromContextOrServices(
 		System.Reflection.ParameterInfo parameter,
 		InvocationBindingContext context,
+		bool skipContext,
 		out object? resolved)
 	{
 		var fromContext = parameter.GetCustomAttributes(typeof(FromContextAttribute), inherit: true)
@@ -150,7 +152,7 @@ internal static class HandlerArgumentBinder
 			return ResolveExplicitFromServices(parameter, context.ServiceProvider, fromServices!, out resolved);
 		}
 
-		return ResolveImplicitFromContextOrServices(parameter, context, out resolved);
+		return ResolveImplicitFromContextOrServices(parameter, context, skipContext, out resolved);
 	}
 
 	private static bool ResolveExplicitFromContext(
@@ -201,6 +203,7 @@ internal static class HandlerArgumentBinder
 	private static bool ResolveImplicitFromContextOrServices(
 		System.Reflection.ParameterInfo parameter,
 		InvocationBindingContext context,
+		bool skipContext,
 		out object? resolved)
 	{
 		if (InteractionProgressFactory.TryCreate(parameter.ParameterType, context, out resolved))
@@ -208,7 +211,9 @@ internal static class HandlerArgumentBinder
 			return true;
 		}
 
-		var foundContext = TryResolveFromContext(parameter.ParameterType, context.ContextValues, out var contextValue);
+		object? contextValue = null;
+		var foundContext = !skipContext
+			&& TryResolveFromContext(parameter.ParameterType, context.ContextValues, out contextValue);
 		var serviceValue = context.ServiceProvider.GetService(parameter.ParameterType);
 		if (foundContext && serviceValue is not null)
 		{

--- a/src/Repl.IntegrationTests/Given_ContextHierarchyBinding.cs
+++ b/src/Repl.IntegrationTests/Given_ContextHierarchyBinding.cs
@@ -126,8 +126,8 @@ public sealed class Given_ContextHierarchyBinding
 	}
 
 	[TestMethod]
-	[Description("Regression guard: verifies ambiguous default binding between context and services so that command fails with structured validation output.")]
-	public void When_BindingIsAmbiguousBetweenContextAndServices_Then_ValidationErrorIsReturned()
+	[Description("Option-schema parameters skip implicit context resolution, so services win without ambiguity.")]
+	public void When_OptionParamMatchesContextAndService_Then_ServiceWinsWithoutAmbiguity()
 	{
 		var sut = ReplApp.Create(services => services.AddSingleton<string>("service-name"));
 		sut.Context("contact {name}", map =>
@@ -137,8 +137,8 @@ public sealed class Given_ContextHierarchyBinding
 
 		var output = ConsoleCaptureHelper.Capture(() => sut.Run(["contact", "alice", "show", "--no-logo"]));
 
-		output.ExitCode.Should().Be(1);
-		output.Text.Should().Contain("Validation: Ambiguous binding for parameter 'value'.");
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("service-name");
 	}
 
 	[TestMethod]

--- a/src/Repl.IntegrationTests/Given_ModuleComposition.cs
+++ b/src/Repl.IntegrationTests/Given_ModuleComposition.cs
@@ -83,8 +83,8 @@ public sealed class Given_ModuleComposition
 	}
 
 	[TestMethod]
-	[Description("Regression guard: verifies module handlers follow ambiguity rules so that context-versus-service collisions fail unless explicit attributes are used.")]
-	public void When_ContextAndServiceCanBindSameType_Then_AmbiguityErrorsAndExplicitBindingWorks()
+	[Description("Option-schema parameters skip implicit context resolution; explicit [FromContext]/[FromServices] still works.")]
+	public void When_ContextAndServiceCanBindSameType_Then_OptionParamUsesServiceAndExplicitBindingWorks()
 	{
 		var sut = ReplApp.Create(services =>
 		{
@@ -92,6 +92,7 @@ public sealed class Given_ModuleComposition
 		});
 		sut.Context("client {scope}", client => client.MapModule(new AmbiguousScopeModule()));
 
+		// 'ambiguous' handler has bare (string value) — option-schema param skips context, service wins.
 		var ambiguous = ConsoleCaptureHelper.Capture(
 			() => sut.Run(["client", "context-scope", "insights", "ambiguous", "--no-logo"]));
 		var explicitContext = ConsoleCaptureHelper.Capture(
@@ -99,8 +100,8 @@ public sealed class Given_ModuleComposition
 		var explicitService = ConsoleCaptureHelper.Capture(
 			() => sut.Run(["client", "context-scope", "insights", "from-services", "--no-logo"]));
 
-		ambiguous.ExitCode.Should().Be(1);
-		ambiguous.Text.Should().Contain("Ambiguous binding");
+		ambiguous.ExitCode.Should().Be(0);
+		ambiguous.Text.Should().Contain("service-scope");
 		explicitContext.ExitCode.Should().Be(0);
 		explicitContext.Text.Should().Contain("context-scope");
 		explicitService.ExitCode.Should().Be(0);

--- a/src/Repl.McpTests/Given_McpServerEndToEnd.cs
+++ b/src/Repl.McpTests/Given_McpServerEndToEnd.cs
@@ -218,6 +218,7 @@ public sealed class Given_McpServerEndToEnd
 		text.Should().NotBeNull();
 		text!.Should().Contain("s1");
 		text.Should().Contain("file.png");
+		text.Should().Contain("null", "optional string? params should be null when omitted, not resolved from context");
 	}
 
 	[TestMethod]


### PR DESCRIPTION
## Summary

- Option-schema parameters (user-facing handler options) now skip implicit context hierarchy resolution, preventing greedy type matches (e.g. `string?` matching ancestor `string` context values) from silently injecting context values into nullable options.
- Explicit `[FromContext]` and `[FromServices]` bindings remain unaffected — only the implicit fallback path is guarded.
- Updated integration tests to reflect the new behavior: bare option params resolve from services (not context) when both are available.

## Test plan

- [x] `dotnet test src/Repl.McpTests/` — all MCP E2E tests pass, including the new null-assertion for omitted optional params
- [x] `dotnet test src/Repl.IntegrationTests/` — updated ambiguity tests now assert service-wins behavior
- [x] `dotnet test` — full suite (743 tests) passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yllibed/repl/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
