### PR TITLE
Add IGlobalOptionsAccessor for typed access to global options

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -77,6 +77,36 @@ app.Context("project {id:int}", project =>
 });
 ```
 
+## Use global options for cross-cutting configuration
+
+When configuration applies to all commands (tenant, environment, verbosity), register global options and access them via `IGlobalOptionsAccessor`:
+
+```csharp
+app.Options(o =>
+{
+    o.Parsing.AddGlobalOption<string>("tenant");
+    o.Parsing.AddGlobalOption<bool>("verbose");
+});
+```
+
+For many global options, prefer `UseGlobalOptions<T>()` with a typed class:
+
+```csharp
+app.UseGlobalOptions<MyGlobalOptions>();
+```
+
+Use `IGlobalOptionsAccessor` in DI factories for services that depend on global option values:
+
+```csharp
+services.AddSingleton<ITenantClient>(sp =>
+{
+    var globals = sp.GetRequiredService<IGlobalOptionsAccessor>();
+    return new TenantClient(globals.GetValue<string>("tenant", "default")!);
+});
+```
+
+Note: DI singleton factories are resolved lazily, so the values are available after global option parsing completes. See [Commands — Accessing global options](commands.md#accessing-global-options-outside-handlers).
+
 ## Group related options with `[ReplOptionsGroup]`
 
 When a command has many options, group them into a class instead of listing them all as handler parameters. This keeps handlers clean and makes option sets reusable across commands.

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -105,7 +105,7 @@ services.AddSingleton<ITenantClient>(sp =>
 });
 ```
 
-Note: DI singleton factories are resolved lazily, so the values are available after global option parsing completes. See [Commands — Accessing global options](commands.md#accessing-global-options-outside-handlers).
+Note: DI singleton factories are resolved lazily, so the values are available after global option parsing completes. However, singleton factories capture values once — in interactive mode, global options can change between commands. If your service needs to see updated values per command, inject `IGlobalOptionsAccessor` directly and read values at call time instead of capturing them in a factory. See [Commands — Accessing global options](commands.md#accessing-global-options-outside-handlers).
 
 ## Group related options with `[ReplOptionsGroup]`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -106,6 +106,19 @@ app.Options(o => o.Parsing.AddGlobalOption("port", "int"));
 
 Supported type names: `string`, `int`, `long`, `bool`, `guid`, `uri`, `date`, `datetime`, `timespan`.
 
+### Session-sticky behavior in interactive mode
+
+Global options passed at CLI launch persist as session defaults throughout the interactive session. Per-command overrides are temporary — they apply to that single command, then the session defaults take effect again:
+
+```
+$ myapp --env staging         # launches interactive with env=staging
+> deploy                      # env=staging (inherited from session)
+> deploy --env prod           # env=prod (override for this command only)
+> status                      # env=staging (session default restored)
+```
+
+This eliminates the need to re-specify global options on every interactive command.
+
 ## Parse diagnostics model
 
 Command option parsing returns structured diagnostics through the internal `OptionParsingResult` model:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -98,13 +98,13 @@ app.Map("show", (MyGlobalOptions opts) => $"{opts.Tenant}:{opts.Port}");
 
 Property names are converted to kebab-case option names (`Port` → `--port`). Use `[ReplOption]` on properties for custom names or aliases.
 
-You can also register global options using a type name string instead of a generic parameter:
+You can also register global options using a type or constraint name instead of a generic parameter:
 
 ```csharp
 app.Options(o => o.Parsing.AddGlobalOption("port", "int"));
 ```
 
-Supported type names: `string`, `int`, `long`, `bool`, `guid`, `uri`, `date`, `datetime`, `timespan`.
+Built-in type names: `string`, `alpha`, `int`, `long`, `bool`, `guid`, `uri`/`url`/`urn`, `date`/`dateonly`/`date-only`, `datetime`/`date-time`, `datetimeoffset`/`date-time-offset`, `time`/`timeonly`/`time-only`, `timespan`/`time-span`. Custom route constraint names are also accepted and resolve to `string`.
 
 ### Session-sticky behavior in interactive mode
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -53,6 +53,59 @@ app.Map(
 
 Root help now includes a dedicated `Global Options:` section with built-ins plus custom options registered through `options.Parsing.AddGlobalOption<T>(...)`.
 
+### Accessing global options outside handlers
+
+Parsed global option values are available via `IGlobalOptionsAccessor`, registered in DI automatically. This enables access from middleware, DI service factories, and handlers:
+
+```csharp
+// Register a global option
+app.Options(o => o.Parsing.AddGlobalOption<string>("tenant"));
+
+// Access in middleware
+app.Use(async (ctx, next) =>
+{
+    var globals = ctx.Services.GetRequiredService<IGlobalOptionsAccessor>();
+    var tenant = globals.GetValue<string>("tenant");
+    await next();
+});
+
+// Access in a DI factory (lazy — resolved after parsing)
+services.AddSingleton<ITenantClient>(sp =>
+{
+    var globals = sp.GetRequiredService<IGlobalOptionsAccessor>();
+    return new TenantClient(globals.GetValue<string>("tenant", "default")!);
+});
+
+// Access in a handler
+app.Map("show", (IGlobalOptionsAccessor globals) =>
+    globals.GetValue<string>("tenant") ?? "none");
+```
+
+For applications with many global options, use `UseGlobalOptions<T>()` to register a typed class:
+
+```csharp
+public class MyGlobalOptions
+{
+    public string? Tenant { get; set; }
+    public int Port { get; set; } = 8080;
+}
+
+app.UseGlobalOptions<MyGlobalOptions>();
+
+// Access via DI
+app.Map("show", (MyGlobalOptions opts) => $"{opts.Tenant}:{opts.Port}");
+```
+
+Property names are converted to kebab-case option names (`Port` → `--port`). Use `[ReplOption]` on properties for custom names or aliases.
+
+You can also register global options using a type name string instead of a generic parameter:
+
+```csharp
+app.Options(o => o.Parsing.AddGlobalOption("port", "int"));
+```
+
+Supported type names: `string`, `int`, `long`, `bool`, `guid`, `uri`, `date`, `datetime`, `timespan`.
+
 ## Parse diagnostics model
 
 Command option parsing returns structured diagnostics through the internal `OptionParsingResult` model:

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -40,6 +40,22 @@ Accessed via `ReplOptions.Parsing`.
 
 - `AddRouteConstraint(name, predicate)` — Register a named route constraint.
 - `AddGlobalOption<T>(name, aliases, defaultValue)` — Register a global option available to all commands.
+- `AddGlobalOption(name, typeName, aliases, defaultValue)` — Register a global option using a type name string (`"int"`, `"bool"`, `"guid"`, etc.).
+
+### IGlobalOptionsAccessor
+
+Registered automatically in DI. Provides typed access to parsed global option values from middleware, DI factories, and handlers.
+
+- `GetValue<T>(name, defaultValue)` — Get typed value, falling back to registration default then caller default.
+- `GetRawValues(name)` — Get all raw string values (supports repeated options).
+- `HasValue(name)` — Check if the option was explicitly provided.
+- `GetOptionNames()` — Enumerate all option names with values.
+
+Values are updated after each global option parsing pass (per-invocation in interactive mode).
+
+### UseGlobalOptions&lt;T&gt;()
+
+Extension method on `ReplApp`. Registers a typed class whose public settable properties become global options. The class is available via DI, populated from parsed values. Property names are converted to kebab-case (`MaxRetries` → `--max-retries`). See [Commands — Accessing global options](commands.md#accessing-global-options-outside-handlers).
 
 ## InteractiveOptions
 

--- a/docs/execution-pipeline.md
+++ b/docs/execution-pipeline.md
@@ -86,6 +86,10 @@ These tokens are consumed and removed from the argument list before the next sta
 Parsed custom global option values are stored in `IGlobalOptionsAccessor` (registered in DI),
 making them available to middleware, DI service factories, and handlers in subsequent stages.
 
+In interactive mode, CLI-level global options become session defaults — they persist across
+all commands unless explicitly overridden per-command. Overrides are temporary and revert
+to the session baseline on the next command.
+
 ### 2. Prefix Resolution
 
 `ResolveUniquePrefixes()` expands abbreviated command names to their full registered

--- a/docs/execution-pipeline.md
+++ b/docs/execution-pipeline.md
@@ -83,6 +83,8 @@ any routing takes place. Recognized options:
 - Custom global options registered through configuration
 
 These tokens are consumed and removed from the argument list before the next stage.
+Parsed custom global option values are stored in `IGlobalOptionsAccessor` (registered in DI),
+making them available to middleware, DI service factories, and handlers in subsequent stages.
 
 ### 2. Prefix Resolution
 

--- a/docs/parameter-system.md
+++ b/docs/parameter-system.md
@@ -14,7 +14,7 @@ This document describes Repl Toolkit's parameter/option model and key design dec
 - option value syntaxes: `--name value`, `--name=value`, `--name:value`
 - option parsing is case-sensitive by default, configurable via `ParsingOptions.OptionCaseSensitivity`
 - response files are supported with `@file.rsp` (non-recursive)
-- custom global options can be registered via `ParsingOptions.AddGlobalOption<T>(...)`
+- custom global options can be registered via `ParsingOptions.AddGlobalOption<T>(...)` or `AddGlobalOption(name, typeName)`, and accessed outside handlers via `IGlobalOptionsAccessor` (see [Commands — Accessing global options](commands.md#accessing-global-options-outside-handlers))
 - signed numeric literals (`-1`, `-0.5`, `-1e3`) are treated as positional values, not options
 
 ## Public declaration API

--- a/src/Repl.Core/CoreReplApp.Interactive.cs
+++ b/src/Repl.Core/CoreReplApp.Interactive.cs
@@ -150,6 +150,7 @@ public sealed partial class CoreReplApp
 
 		var invocationTokens = scopeTokens.Concat(inputTokens).ToArray();
 		var globalOptions = GlobalOptionParser.Parse(invocationTokens, _options.Output, _options.Parsing);
+		_globalOptionsSnapshot.Update(globalOptions.CustomGlobalNamedOptions);
 		var prefixResolution = ResolveUniquePrefixes(globalOptions.RemainingTokens);
 		if (prefixResolution.IsAmbiguous)
 		{

--- a/src/Repl.Core/CoreReplApp.cs
+++ b/src/Repl.Core/CoreReplApp.cs
@@ -33,13 +33,16 @@ public sealed partial class CoreReplApp : ICoreReplApp
 	private Delegate? _banner;
 	private readonly AsyncLocal<bool> _bannerRendered = new();
 	private readonly AsyncLocal<bool> _allBannersSuppressed = new();
+	private readonly GlobalOptionsSnapshot _globalOptionsSnapshot;
 
 	internal ReplOptions OptionsSnapshot => _options;
+	internal IGlobalOptionsAccessor GlobalOptionsAccessor => _globalOptionsSnapshot;
 	internal IReplExecutionObserver? ExecutionObserver { get; set; }
 
 	private CoreReplApp()
 	{
 		_options.Output.SetHostAnsiSupportResolver(() => _options.Capabilities.SupportsAnsi);
+		_globalOptionsSnapshot = new GlobalOptionsSnapshot(_options.Parsing);
 		_services = CreateDefaultServiceProvider();
 		_shellCompletionRuntime = new ShellCompletionRuntime(
 			_options,
@@ -416,6 +419,7 @@ public sealed partial class CoreReplApp : ICoreReplApp
 		try
 		{
 			var globalOptions = GlobalOptionParser.Parse(args, _options.Output, _options.Parsing);
+			_globalOptionsSnapshot.Update(globalOptions.CustomGlobalNamedOptions);
 			using var runtimeStateScope = PushRuntimeState(serviceProvider, isInteractiveSession: false);
 			var prefixResolution = ResolveUniquePrefixes(globalOptions.RemainingTokens);
 			var resolvedGlobalOptions = globalOptions with { RemainingTokens = prefixResolution.Tokens };
@@ -1399,6 +1403,7 @@ public sealed partial class CoreReplApp : ICoreReplApp
 		{
 			[typeof(CoreReplApp)] = this,
 			[typeof(ICoreReplApp)] = this,
+			[typeof(IGlobalOptionsAccessor)] = _globalOptionsSnapshot,
 			[typeof(IReplSessionState)] = new InMemoryReplSessionState(),
 			[typeof(IReplInteractionChannel)] = new ConsoleInteractionChannel(
 				_options.Interaction, _options.Output,

--- a/src/Repl.Core/CoreReplApp.cs
+++ b/src/Repl.Core/CoreReplApp.cs
@@ -420,6 +420,7 @@ public sealed partial class CoreReplApp : ICoreReplApp
 		{
 			var globalOptions = GlobalOptionParser.Parse(args, _options.Output, _options.Parsing);
 			_globalOptionsSnapshot.Update(globalOptions.CustomGlobalNamedOptions);
+			_globalOptionsSnapshot.SetSessionBaseline();
 			using var runtimeStateScope = PushRuntimeState(serviceProvider, isInteractiveSession: false);
 			var prefixResolution = ResolveUniquePrefixes(globalOptions.RemainingTokens);
 			var resolvedGlobalOptions = globalOptions with { RemainingTokens = prefixResolution.Tokens };

--- a/src/Repl.Core/GlobalOptionDefinition.cs
+++ b/src/Repl.Core/GlobalOptionDefinition.cs
@@ -4,4 +4,5 @@ internal sealed record GlobalOptionDefinition(
 	string Name,
 	string CanonicalToken,
 	IReadOnlyList<string> Aliases,
-	string? DefaultValue);
+	string? DefaultValue,
+	Type ValueType);

--- a/src/Repl.Core/GlobalOptionParser.cs
+++ b/src/Repl.Core/GlobalOptionParser.cs
@@ -78,6 +78,7 @@ internal static class GlobalOptionParser
 				ref index,
 				argument,
 				customTokenMap,
+				parsingOptions.GlobalOptions,
 				customGlobalValues))
 			{
 				continue;
@@ -164,6 +165,7 @@ internal static class GlobalOptionParser
 		ref int index,
 		string argument,
 		IReadOnlyDictionary<string, string> tokenMap,
+		IReadOnlyDictionary<string, GlobalOptionDefinition> definitions,
 		Dictionary<string, List<string>> customGlobalValues)
 	{
 		if (!TryResolveCustomGlobalName(argument, tokenMap, out var optionName, out var inlineValue))
@@ -171,8 +173,10 @@ internal static class GlobalOptionParser
 			return false;
 		}
 
+		var isBool = definitions.TryGetValue(optionName, out var def) && def.ValueType == typeof(bool);
+
 		var value = inlineValue;
-		if (value is null
+		if (value is null && !isBool
 			&& index + 1 < args.Count
 			&& (!args[index + 1].StartsWith('-') || IsSignedNumericLiteral(args[index + 1])))
 		{

--- a/src/Repl.Core/GlobalOptionsSnapshot.cs
+++ b/src/Repl.Core/GlobalOptionsSnapshot.cs
@@ -1,0 +1,54 @@
+namespace Repl;
+
+internal sealed class GlobalOptionsSnapshot(ParsingOptions parsingOptions) : IGlobalOptionsAccessor
+{
+	private IReadOnlyDictionary<string, IReadOnlyList<string>> _currentValues =
+		new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+
+	internal void Update(IReadOnlyDictionary<string, IReadOnlyList<string>> parsedValues)
+	{
+		_currentValues = parsedValues;
+	}
+
+	public T? GetValue<T>(string name, T? defaultValue = default)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+		if (_currentValues.TryGetValue(name, out var values) && values.Count > 0)
+		{
+			return (T?)ParameterValueConverter.ConvertSingle(
+				values[0],
+				typeof(T),
+				parsingOptions.NumericFormatProvider);
+		}
+
+		if (parsingOptions.GlobalOptions.TryGetValue(name, out var definition)
+			&& definition.DefaultValue is not null)
+		{
+			return (T?)ParameterValueConverter.ConvertSingle(
+				definition.DefaultValue,
+				typeof(T),
+				parsingOptions.NumericFormatProvider);
+		}
+
+		return defaultValue;
+	}
+
+	public IReadOnlyList<string> GetRawValues(string name)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+		return _currentValues.TryGetValue(name, out var values)
+			? values
+			: [];
+	}
+
+	public bool HasValue(string name)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+		return _currentValues.ContainsKey(name);
+	}
+
+	public IEnumerable<string> GetOptionNames() => _currentValues.Keys;
+}

--- a/src/Repl.Core/GlobalOptionsSnapshot.cs
+++ b/src/Repl.Core/GlobalOptionsSnapshot.cs
@@ -12,7 +12,19 @@ internal sealed class GlobalOptionsSnapshot(ParsingOptions parsingOptions) : IGl
 
 	internal void SetSessionBaseline()
 	{
-		_sessionBaseline = _currentValues;
+		// Capture only the explicitly parsed values as the new baseline.
+		// This prevents stale baselines from leaking across separate Run() calls.
+		var baseline = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+		foreach (var key in _explicitKeys)
+		{
+			if (_currentValues.TryGetValue(key, out var values))
+			{
+				baseline[key] = values;
+			}
+		}
+
+		_sessionBaseline = baseline;
+		_currentValues = baseline;
 	}
 
 	internal void Update(IReadOnlyDictionary<string, IReadOnlyList<string>> parsedValues)

--- a/src/Repl.Core/GlobalOptionsSnapshot.cs
+++ b/src/Repl.Core/GlobalOptionsSnapshot.cs
@@ -2,11 +2,13 @@ namespace Repl;
 
 internal sealed class GlobalOptionsSnapshot(ParsingOptions parsingOptions) : IGlobalOptionsAccessor
 {
-	private IReadOnlyDictionary<string, IReadOnlyList<string>> _sessionBaseline =
+	private volatile IReadOnlyDictionary<string, IReadOnlyList<string>> _sessionBaseline =
 		new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
 
-	private IReadOnlyDictionary<string, IReadOnlyList<string>> _currentValues =
+	private volatile IReadOnlyDictionary<string, IReadOnlyList<string>> _currentValues =
 		new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+
+	private volatile HashSet<string> _explicitKeys = new(StringComparer.OrdinalIgnoreCase);
 
 	internal void SetSessionBaseline()
 	{
@@ -15,6 +17,7 @@ internal sealed class GlobalOptionsSnapshot(ParsingOptions parsingOptions) : IGl
 
 	internal void Update(IReadOnlyDictionary<string, IReadOnlyList<string>> parsedValues)
 	{
+		_explicitKeys = new HashSet<string>(parsedValues.Keys, StringComparer.OrdinalIgnoreCase);
 		var merged = new Dictionary<string, IReadOnlyList<string>>(_sessionBaseline, StringComparer.OrdinalIgnoreCase);
 		foreach (var (key, value) in parsedValues)
 		{
@@ -61,7 +64,7 @@ internal sealed class GlobalOptionsSnapshot(ParsingOptions parsingOptions) : IGl
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
-		return _currentValues.ContainsKey(name);
+		return _explicitKeys.Contains(name);
 	}
 
 	public IEnumerable<string> GetOptionNames() => _currentValues.Keys;

--- a/src/Repl.Core/GlobalOptionsSnapshot.cs
+++ b/src/Repl.Core/GlobalOptionsSnapshot.cs
@@ -2,12 +2,26 @@ namespace Repl;
 
 internal sealed class GlobalOptionsSnapshot(ParsingOptions parsingOptions) : IGlobalOptionsAccessor
 {
+	private IReadOnlyDictionary<string, IReadOnlyList<string>> _sessionBaseline =
+		new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+
 	private IReadOnlyDictionary<string, IReadOnlyList<string>> _currentValues =
 		new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
 
+	internal void SetSessionBaseline()
+	{
+		_sessionBaseline = _currentValues;
+	}
+
 	internal void Update(IReadOnlyDictionary<string, IReadOnlyList<string>> parsedValues)
 	{
-		_currentValues = parsedValues;
+		var merged = new Dictionary<string, IReadOnlyList<string>>(_sessionBaseline, StringComparer.OrdinalIgnoreCase);
+		foreach (var (key, value) in parsedValues)
+		{
+			merged[key] = value;
+		}
+
+		_currentValues = merged;
 	}
 
 	public T? GetValue<T>(string name, T? defaultValue = default)

--- a/src/Repl.Core/IGlobalOptionsAccessor.cs
+++ b/src/Repl.Core/IGlobalOptionsAccessor.cs
@@ -1,0 +1,36 @@
+namespace Repl;
+
+/// <summary>
+/// Provides typed access to parsed global option values.
+/// Values are updated after each global option parsing pass.
+/// </summary>
+public interface IGlobalOptionsAccessor
+{
+	/// <summary>
+	/// Gets the typed value of a global option by its registered name.
+	/// Returns <paramref name="defaultValue"/> if the option was not provided.
+	/// </summary>
+	/// <typeparam name="T">Target value type.</typeparam>
+	/// <param name="name">The registered option name (without <c>--</c> prefix).</param>
+	/// <param name="defaultValue">Value to return if the option was not provided.</param>
+	T? GetValue<T>(string name, T? defaultValue = default);
+
+	/// <summary>
+	/// Gets all raw string values for a global option (supports repeated options).
+	/// Returns an empty list if the option was not provided.
+	/// </summary>
+	/// <param name="name">The registered option name (without <c>--</c> prefix).</param>
+	IReadOnlyList<string> GetRawValues(string name);
+
+	/// <summary>
+	/// Returns <see langword="true"/> if the named global option was explicitly provided
+	/// in the current invocation.
+	/// </summary>
+	/// <param name="name">The registered option name (without <c>--</c> prefix).</param>
+	bool HasValue(string name);
+
+	/// <summary>
+	/// Gets all parsed global option names that have values in the current invocation.
+	/// </summary>
+	IEnumerable<string> GetOptionNames();
+}

--- a/src/Repl.Core/ParsingOptions.cs
+++ b/src/Repl.Core/ParsingOptions.cs
@@ -112,7 +112,7 @@ public sealed class ParsingOptions
 	/// <param name="aliases">Optional aliases. Values without prefix are normalized to <c>--alias</c>.</param>
 	/// <param name="defaultValue">Optional default value as string.</param>
 	public void AddGlobalOption(string name, string typeName, string[]? aliases = null, string? defaultValue = null) =>
-		AddGlobalOptionCore(name, ResolveTypeName(typeName), aliases, defaultValue);
+		AddGlobalOptionCore(name, ResolveTypeName(typeName, _customRouteConstraints), aliases, defaultValue);
 
 	internal void AddGlobalOptionCore(string name, Type valueType, string[]? aliases, string? defaultValue)
 	{
@@ -141,8 +141,13 @@ public sealed class ParsingOptions
 			ValueType: valueType);
 	}
 
-	private static Type ResolveTypeName(string typeName) =>
-		(typeName ?? throw new ArgumentNullException(nameof(typeName))).ToLowerInvariant() switch
+	private static Type ResolveTypeName(
+		string typeName,
+		Dictionary<string, Func<string, bool>> customConstraints)
+	{
+		ArgumentNullException.ThrowIfNull(typeName);
+
+		return typeName.ToLowerInvariant() switch
 		{
 			"string" or "alpha" => typeof(string),
 			"int" => typeof(int),
@@ -155,8 +160,12 @@ public sealed class ParsingOptions
 			"datetimeoffset" or "date-time-offset" => typeof(DateTimeOffset),
 			"time" or "timeonly" or "time-only" => typeof(TimeOnly),
 			"timespan" or "time-span" => typeof(TimeSpan),
-			_ => throw new ArgumentException($"Unknown type name '{typeName}'. Use a known name (string, int, long, bool, guid, uri, date, datetime, timespan) or the generic AddGlobalOption<T> overload.", nameof(typeName)),
+			_ when customConstraints.ContainsKey(typeName) => typeof(string),
+			_ => throw new ArgumentException(
+				$"Unknown type name '{typeName}'. Use a known name (string, int, long, bool, guid, uri, date, datetime, timespan), a registered custom route constraint, or the generic AddGlobalOption<T> overload.",
+				nameof(typeName)),
 		};
+	}
 
 	private static string NormalizeLongToken(string name) =>
 		name.StartsWith("--", StringComparison.Ordinal)

--- a/src/Repl.Core/ParsingOptions.cs
+++ b/src/Repl.Core/ParsingOptions.cs
@@ -152,7 +152,7 @@ public sealed class ParsingOptions
 
 		return constraintOrTypeName.ToLowerInvariant() switch
 		{
-			"string" or "alpha" => typeof(string),
+			"string" or "alpha" or "email" => typeof(string),
 			"int" => typeof(int),
 			"long" => typeof(long),
 			"bool" => typeof(bool),

--- a/src/Repl.Core/ParsingOptions.cs
+++ b/src/Repl.Core/ParsingOptions.cs
@@ -96,11 +96,25 @@ public sealed class ParsingOptions
 	/// <summary>
 	/// Registers a custom global option consumed before command routing.
 	/// </summary>
-	/// <typeparam name="T">Declared value type (metadata only for now).</typeparam>
+	/// <typeparam name="T">Declared value type.</typeparam>
 	/// <param name="name">Canonical name without prefix (for example: "tenant").</param>
 	/// <param name="aliases">Optional aliases. Values without prefix are normalized to <c>--alias</c>.</param>
 	/// <param name="defaultValue">Optional default value metadata.</param>
-	public void AddGlobalOption<T>(string name, string[]? aliases = null, T? defaultValue = default)
+	public void AddGlobalOption<T>(string name, string[]? aliases = null, T? defaultValue = default) =>
+		AddGlobalOptionCore(name, typeof(T), aliases, defaultValue?.ToString());
+
+	/// <summary>
+	/// Registers a custom global option using a type name (for example: "int", "guid", "bool")
+	/// similar to route constraint names.
+	/// </summary>
+	/// <param name="name">Canonical name without prefix (for example: "tenant").</param>
+	/// <param name="typeName">Type name: "string", "int", "long", "bool", "guid", "uri", "date", "datetime", "timespan".</param>
+	/// <param name="aliases">Optional aliases. Values without prefix are normalized to <c>--alias</c>.</param>
+	/// <param name="defaultValue">Optional default value as string.</param>
+	public void AddGlobalOption(string name, string typeName, string[]? aliases = null, string? defaultValue = null) =>
+		AddGlobalOptionCore(name, ResolveTypeName(typeName), aliases, defaultValue);
+
+	internal void AddGlobalOptionCore(string name, Type valueType, string[]? aliases, string? defaultValue)
 	{
 		name = string.IsNullOrWhiteSpace(name)
 			? throw new ArgumentException("Global option name cannot be empty.", nameof(name))
@@ -123,8 +137,26 @@ public sealed class ParsingOptions
 			Name: name,
 			CanonicalToken: normalizedCanonical,
 			Aliases: normalizedAliases,
-			DefaultValue: defaultValue?.ToString());
+			DefaultValue: defaultValue,
+			ValueType: valueType);
 	}
+
+	private static Type ResolveTypeName(string typeName) =>
+		(typeName ?? throw new ArgumentNullException(nameof(typeName))).ToLowerInvariant() switch
+		{
+			"string" or "alpha" => typeof(string),
+			"int" => typeof(int),
+			"long" => typeof(long),
+			"bool" => typeof(bool),
+			"guid" => typeof(Guid),
+			"uri" or "url" or "urn" => typeof(Uri),
+			"date" or "dateonly" or "date-only" => typeof(DateOnly),
+			"datetime" or "date-time" => typeof(DateTime),
+			"datetimeoffset" or "date-time-offset" => typeof(DateTimeOffset),
+			"time" or "timeonly" or "time-only" => typeof(TimeOnly),
+			"timespan" or "time-span" => typeof(TimeSpan),
+			_ => throw new ArgumentException($"Unknown type name '{typeName}'. Use a known name (string, int, long, bool, guid, uri, date, datetime, timespan) or the generic AddGlobalOption<T> overload.", nameof(typeName)),
+		};
 
 	private static string NormalizeLongToken(string name) =>
 		name.StartsWith("--", StringComparison.Ordinal)

--- a/src/Repl.Core/ParsingOptions.cs
+++ b/src/Repl.Core/ParsingOptions.cs
@@ -104,15 +104,18 @@ public sealed class ParsingOptions
 		AddGlobalOptionCore(name, typeof(T), aliases, defaultValue?.ToString());
 
 	/// <summary>
-	/// Registers a custom global option using a type name (for example: "int", "guid", "bool")
-	/// similar to route constraint names.
+	/// Registers a custom global option using a type or constraint name
+	/// (for example: "int", "guid", "bool", or a registered custom route constraint name).
 	/// </summary>
 	/// <param name="name">Canonical name without prefix (for example: "tenant").</param>
-	/// <param name="typeName">Type name: "string", "int", "long", "bool", "guid", "uri", "date", "datetime", "timespan".</param>
+	/// <param name="constraintOrTypeName">
+	/// Built-in type name ("string", "int", "long", "bool", "guid", "uri", "date", "datetime", "timespan")
+	/// or a registered custom route constraint name. Custom constraints resolve to <c>string</c>.
+	/// </param>
 	/// <param name="aliases">Optional aliases. Values without prefix are normalized to <c>--alias</c>.</param>
 	/// <param name="defaultValue">Optional default value as string.</param>
-	public void AddGlobalOption(string name, string typeName, string[]? aliases = null, string? defaultValue = null) =>
-		AddGlobalOptionCore(name, ResolveTypeName(typeName, _customRouteConstraints), aliases, defaultValue);
+	public void AddGlobalOption(string name, string constraintOrTypeName, string[]? aliases = null, string? defaultValue = null) =>
+		AddGlobalOptionCore(name, ResolveConstraintOrTypeName(constraintOrTypeName, _customRouteConstraints), aliases, defaultValue);
 
 	internal void AddGlobalOptionCore(string name, Type valueType, string[]? aliases, string? defaultValue)
 	{
@@ -141,13 +144,13 @@ public sealed class ParsingOptions
 			ValueType: valueType);
 	}
 
-	private static Type ResolveTypeName(
-		string typeName,
+	private static Type ResolveConstraintOrTypeName(
+		string constraintOrTypeName,
 		Dictionary<string, Func<string, bool>> customConstraints)
 	{
-		ArgumentNullException.ThrowIfNull(typeName);
+		ArgumentNullException.ThrowIfNull(constraintOrTypeName);
 
-		return typeName.ToLowerInvariant() switch
+		return constraintOrTypeName.ToLowerInvariant() switch
 		{
 			"string" or "alpha" => typeof(string),
 			"int" => typeof(int),
@@ -160,10 +163,10 @@ public sealed class ParsingOptions
 			"datetimeoffset" or "date-time-offset" => typeof(DateTimeOffset),
 			"time" or "timeonly" or "time-only" => typeof(TimeOnly),
 			"timespan" or "time-span" => typeof(TimeSpan),
-			_ when customConstraints.ContainsKey(typeName) => typeof(string),
+			_ when customConstraints.ContainsKey(constraintOrTypeName) => typeof(string),
 			_ => throw new ArgumentException(
-				$"Unknown type name '{typeName}'. Use a known name (string, int, long, bool, guid, uri, date, datetime, timespan), a registered custom route constraint, or the generic AddGlobalOption<T> overload.",
-				nameof(typeName)),
+				$"Unknown type or constraint name '{constraintOrTypeName}'. Use a known name (string, int, long, bool, guid, uri, date, datetime, timespan), a registered custom route constraint, or the generic AddGlobalOption<T> overload.",
+				nameof(constraintOrTypeName)),
 		};
 	}
 

--- a/src/Repl.Defaults/GlobalOptionsExtensions.cs
+++ b/src/Repl.Defaults/GlobalOptionsExtensions.cs
@@ -1,0 +1,104 @@
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Repl.Parameters;
+
+namespace Repl;
+
+/// <summary>
+/// Extension methods for registering typed global options on <see cref="ReplApp"/>.
+/// </summary>
+public static class GlobalOptionsExtensions
+{
+	/// <summary>
+	/// Registers a typed global options class. Public settable properties are registered as
+	/// global options and the class itself is available via DI, populated from parsed values.
+	/// </summary>
+	/// <typeparam name="T">Options class with a parameterless constructor.</typeparam>
+	/// <param name="app">The REPL application.</param>
+	/// <returns>The application for fluent chaining.</returns>
+	public static ReplApp UseGlobalOptions<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(this ReplApp app)
+		where T : class, new()
+	{
+		ArgumentNullException.ThrowIfNull(app);
+
+		app.Options(options =>
+		{
+			foreach (var property in GetOptionProperties<T>())
+			{
+				var optionAttr = property.GetCustomAttribute<ReplOptionAttribute>();
+				var name = optionAttr?.Name ?? ToKebabCase(property.Name);
+				var aliases = optionAttr?.Aliases;
+
+				options.Parsing.AddGlobalOptionCore(name, property.PropertyType, aliases, defaultValue: null);
+			}
+		});
+
+		app.ServiceDescriptors.TryAddSingleton(sp =>
+		{
+			var accessor = sp.GetRequiredService<IGlobalOptionsAccessor>();
+			return PopulateInstance<T>(accessor);
+		});
+
+		return app;
+	}
+
+	internal static T PopulateInstance<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(IGlobalOptionsAccessor accessor)
+		where T : class, new()
+	{
+		var instance = new T();
+		foreach (var property in GetOptionProperties<T>())
+		{
+			var optionAttr = property.GetCustomAttribute<ReplOptionAttribute>();
+			var name = optionAttr?.Name ?? ToKebabCase(property.Name);
+
+			if (!accessor.HasValue(name))
+			{
+				continue;
+			}
+
+			var rawValues = accessor.GetRawValues(name);
+			if (rawValues.Count == 0)
+			{
+				continue;
+			}
+
+			var value = ParameterValueConverter.ConvertSingle(
+				rawValues[0],
+				property.PropertyType,
+				System.Globalization.CultureInfo.InvariantCulture);
+			property.SetValue(instance, value);
+		}
+
+		return instance;
+	}
+
+	private static PropertyInfo[] GetOptionProperties<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>() =>
+		typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+			.Where(p => p.CanWrite)
+			.ToArray();
+
+	private static string ToKebabCase(string pascalCase)
+	{
+		if (string.IsNullOrEmpty(pascalCase))
+		{
+			return pascalCase;
+		}
+
+		var builder = new System.Text.StringBuilder(pascalCase.Length + 4);
+		for (var i = 0; i < pascalCase.Length; i++)
+		{
+			var c = pascalCase[i];
+			if (char.IsUpper(c) && i > 0)
+			{
+				builder.Append('-');
+			}
+
+			builder.Append(char.ToLowerInvariant(c));
+		}
+
+		return builder.ToString();
+	}
+}

--- a/src/Repl.Defaults/GlobalOptionsExtensions.cs
+++ b/src/Repl.Defaults/GlobalOptionsExtensions.cs
@@ -24,8 +24,10 @@ public static class GlobalOptionsExtensions
 	{
 		ArgumentNullException.ThrowIfNull(app);
 
+		ParsingOptions? capturedParsing = null;
 		app.Options(options =>
 		{
+			capturedParsing = options.Parsing;
 			var prototype = new T();
 			foreach (var property in GetOptionProperties<T>())
 			{
@@ -41,13 +43,13 @@ public static class GlobalOptionsExtensions
 		app.ServiceDescriptors.TryAddTransient(sp =>
 		{
 			var accessor = sp.GetRequiredService<IGlobalOptionsAccessor>();
-			return PopulateInstance<T>(accessor);
+			return PopulateInstance<T>(accessor, capturedParsing!.NumericFormatProvider);
 		});
 
 		return app;
 	}
 
-	internal static T PopulateInstance<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(IGlobalOptionsAccessor accessor)
+	internal static T PopulateInstance<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(IGlobalOptionsAccessor accessor, IFormatProvider numericFormatProvider)
 		where T : class, new()
 	{
 		var instance = new T();
@@ -70,7 +72,7 @@ public static class GlobalOptionsExtensions
 			var value = ParameterValueConverter.ConvertSingle(
 				rawValues[0],
 				property.PropertyType,
-				System.Globalization.CultureInfo.InvariantCulture);
+				numericFormatProvider);
 			property.SetValue(instance, value);
 		}
 

--- a/src/Repl.Defaults/GlobalOptionsExtensions.cs
+++ b/src/Repl.Defaults/GlobalOptionsExtensions.cs
@@ -58,11 +58,6 @@ public static class GlobalOptionsExtensions
 			var optionAttr = property.GetCustomAttribute<ReplOptionAttribute>();
 			var name = optionAttr?.Name ?? ToKebabCase(property.Name);
 
-			if (!accessor.HasValue(name))
-			{
-				continue;
-			}
-
 			var rawValues = accessor.GetRawValues(name);
 			if (rawValues.Count == 0)
 			{

--- a/src/Repl.Defaults/GlobalOptionsExtensions.cs
+++ b/src/Repl.Defaults/GlobalOptionsExtensions.cs
@@ -97,7 +97,15 @@ public static class GlobalOptionsExtensions
 			var c = pascalCase[i];
 			if (char.IsUpper(c) && i > 0)
 			{
-				builder.Append('-');
+				// Only insert hyphen at the start of an uppercase run or
+				// at the transition from an uppercase run to a lowercase char.
+				// "XMLPort" → "xml-port", "MaxRetries" → "max-retries"
+				var prevIsUpper = char.IsUpper(pascalCase[i - 1]);
+				var nextIsLower = i + 1 < pascalCase.Length && char.IsLower(pascalCase[i + 1]);
+				if (!prevIsUpper || nextIsLower)
+				{
+					builder.Append('-');
+				}
 			}
 
 			builder.Append(char.ToLowerInvariant(c));

--- a/src/Repl.Defaults/GlobalOptionsExtensions.cs
+++ b/src/Repl.Defaults/GlobalOptionsExtensions.cs
@@ -26,13 +26,15 @@ public static class GlobalOptionsExtensions
 
 		app.Options(options =>
 		{
+			var prototype = new T();
 			foreach (var property in GetOptionProperties<T>())
 			{
 				var optionAttr = property.GetCustomAttribute<ReplOptionAttribute>();
 				var name = optionAttr?.Name ?? ToKebabCase(property.Name);
 				var aliases = optionAttr?.Aliases;
+				var defaultValue = property.GetValue(prototype)?.ToString();
 
-				options.Parsing.AddGlobalOptionCore(name, property.PropertyType, aliases, defaultValue: null);
+				options.Parsing.AddGlobalOptionCore(name, property.PropertyType, aliases, defaultValue);
 			}
 		});
 

--- a/src/Repl.Defaults/GlobalOptionsExtensions.cs
+++ b/src/Repl.Defaults/GlobalOptionsExtensions.cs
@@ -36,7 +36,7 @@ public static class GlobalOptionsExtensions
 			}
 		});
 
-		app.ServiceDescriptors.TryAddSingleton(sp =>
+		app.ServiceDescriptors.TryAddTransient(sp =>
 		{
 			var accessor = sp.GetRequiredService<IGlobalOptionsAccessor>();
 			return PopulateInstance<T>(accessor);

--- a/src/Repl.Defaults/ReplApp.cs
+++ b/src/Repl.Defaults/ReplApp.cs
@@ -20,6 +20,8 @@ public sealed class ReplApp : IReplApp
 	// as handler parameters resolved at runtime.
 	private ServiceProvider? _sharedProvider;
 
+	internal IServiceCollection ServiceDescriptors => _services;
+
 	private ReplApp(IServiceCollection services)
 	{
 		_services = services;
@@ -684,6 +686,7 @@ public sealed class ReplApp : IReplApp
 		services.TryAddSingleton<IReplIoContext, LiveReplIoContext>();
 		services.TryAddSingleton<ITerminalInfo>(
 			_ => new ConsoleTerminalInfo(core.OptionsSnapshot.Output));
+		services.TryAddSingleton(_ => core.GlobalOptionsAccessor);
 	}
 
 	private sealed class ScopedReplApp(ICoreReplApp map, ReplApp root) : IReplApp

--- a/src/Repl.IntegrationTests/Given_GlobalOptionsAccessor.cs
+++ b/src/Repl.IntegrationTests/Given_GlobalOptionsAccessor.cs
@@ -140,6 +140,32 @@ public sealed class Given_GlobalOptionsAccessor
 		output.Text.Should().Contain("acme");
 	}
 
+	[TestMethod]
+	[Description("UseGlobalOptions<T> returns fresh values on each resolution (not stale singleton).")]
+	public async Task When_TypedOptionsResolvedMultipleTimes_Then_ReflectsLatestValues()
+	{
+		var sut = ReplApp.Create();
+		sut.UseGlobalOptions<TestGlobalOptions>();
+		var results = new List<string>();
+		sut.Map("show", (TestGlobalOptions opts) =>
+		{
+			results.Add($"{opts.Tenant}:{opts.Port}");
+			return "ok";
+		});
+
+		// First invocation
+		ConsoleCaptureHelper.Capture(
+			() => sut.Run(["show", "--tenant", "first", "--port", "1111", "--no-logo"]));
+
+		// Second invocation with different values
+		ConsoleCaptureHelper.Capture(
+			() => sut.Run(["show", "--tenant", "second", "--port", "2222", "--no-logo"]));
+
+		results.Should().HaveCount(2);
+		results[0].Should().Be("first:1111");
+		results[1].Should().Be("second:2222");
+	}
+
 	private sealed record TenantConfig(string Name);
 
 	private sealed class TestGlobalOptions

--- a/src/Repl.IntegrationTests/Given_GlobalOptionsAccessor.cs
+++ b/src/Repl.IntegrationTests/Given_GlobalOptionsAccessor.cs
@@ -219,8 +219,28 @@ public sealed class Given_GlobalOptionsAccessor
 		public int Port { get; set; } = 8080;
 	}
 
+	[TestMethod]
+	[Description("UseGlobalOptions<T> converts consecutive uppercase property names to kebab-case correctly.")]
+	public void When_PropertyHasConsecutiveUppercase_Then_KebabCaseIsCorrect()
+	{
+		var sut = ReplApp.Create();
+		sut.UseGlobalOptions<AcronymGlobalOptions>();
+		sut.Map("show", (AcronymGlobalOptions opts) => $"{opts.XMLPort}");
+
+		var output = ConsoleCaptureHelper.Capture(
+			() => sut.Run(["show", "--xml-port", "9090", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("9090");
+	}
+
 	private sealed class DecimalGlobalOptions
 	{
 		public double Rate { get; set; }
+	}
+
+	private sealed class AcronymGlobalOptions
+	{
+		public int XMLPort { get; set; }
 	}
 }

--- a/src/Repl.IntegrationTests/Given_GlobalOptionsAccessor.cs
+++ b/src/Repl.IntegrationTests/Given_GlobalOptionsAccessor.cs
@@ -111,6 +111,21 @@ public sealed class Given_GlobalOptionsAccessor
 	}
 
 	[TestMethod]
+	[Description("UseGlobalOptions<T> property defaults are visible via IGlobalOptionsAccessor.")]
+	public void When_UsingTypedGlobalOptionsWithoutValues_Then_AccessorReturnsPropertyDefaults()
+	{
+		var sut = ReplApp.Create();
+		sut.UseGlobalOptions<TestGlobalOptions>();
+		sut.Map("show", (IGlobalOptionsAccessor globals) => globals.GetValue<int>("port"));
+
+		var output = ConsoleCaptureHelper.Capture(
+			() => sut.Run(["show", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("8080");
+	}
+
+	[TestMethod]
 	[Description("Global option registered with string type name works end to end.")]
 	public void When_GlobalOptionRegisteredWithStringTypeName_Then_TypedAccessWorks()
 	{

--- a/src/Repl.IntegrationTests/Given_GlobalOptionsAccessor.cs
+++ b/src/Repl.IntegrationTests/Given_GlobalOptionsAccessor.cs
@@ -1,0 +1,151 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Repl.IntegrationTests;
+
+[TestClass]
+[DoNotParallelize]
+public sealed class Given_GlobalOptionsAccessor
+{
+	[TestMethod]
+	[Description("Global option is accessible in handler via IGlobalOptionsAccessor parameter.")]
+	public void When_GlobalOptionProvided_Then_HandlerCanReadItViaAccessor()
+	{
+		var sut = ReplApp.Create();
+		sut.Options(o => o.Parsing.AddGlobalOption<string>("tenant"));
+		sut.Map("show", (IGlobalOptionsAccessor globals) => globals.GetValue<string>("tenant") ?? "none");
+
+		var output = ConsoleCaptureHelper.Capture(
+			() => sut.Run(["show", "--tenant", "acme", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("acme");
+	}
+
+	[TestMethod]
+	[Description("Global option is accessible in middleware via DI.")]
+	public void When_GlobalOptionProvided_Then_MiddlewareCanReadIt()
+	{
+		string? captured = null;
+		var sut = ReplApp.Create();
+		sut.Options(o => o.Parsing.AddGlobalOption<string>("tenant"));
+		sut.Use(async (ctx, next) =>
+		{
+			var globals = ctx.Services.GetRequiredService<IGlobalOptionsAccessor>();
+			captured = globals.GetValue<string>("tenant");
+			await next().ConfigureAwait(false);
+		});
+		sut.Map("ping", () => "pong");
+
+		var output = ConsoleCaptureHelper.Capture(
+			() => sut.Run(["ping", "--tenant", "acme", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		captured.Should().Be("acme");
+	}
+
+	[TestMethod]
+	[Description("Global option is accessible in DI factory via lazy resolution.")]
+	public void When_GlobalOptionProvided_Then_DiFactoryCanReadIt()
+	{
+		var sut = ReplApp.Create(services =>
+		{
+			services.AddSingleton(sp =>
+			{
+				var globals = sp.GetRequiredService<IGlobalOptionsAccessor>();
+				return new TenantConfig(globals.GetValue<string>("tenant") ?? "default");
+			});
+		});
+		sut.Options(o => o.Parsing.AddGlobalOption<string>("tenant"));
+		sut.Map("show", (TenantConfig cfg) => cfg.Name);
+
+		var output = ConsoleCaptureHelper.Capture(
+			() => sut.Run(["show", "--tenant", "acme", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("acme");
+	}
+
+	[TestMethod]
+	[Description("Global option defaults are returned when option not provided.")]
+	public void When_GlobalOptionNotProvided_Then_DefaultIsReturned()
+	{
+		var sut = ReplApp.Create();
+		sut.Options(o => o.Parsing.AddGlobalOption<int>("port", defaultValue: 3000));
+		sut.Map("show", (IGlobalOptionsAccessor globals) => globals.GetValue<int>("port"));
+
+		var output = ConsoleCaptureHelper.Capture(
+			() => sut.Run(["show", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("3000");
+	}
+
+	[TestMethod]
+	[Description("UseGlobalOptions<T> registers typed class accessible via DI.")]
+	public void When_UsingTypedGlobalOptions_Then_ClassIsPopulatedFromParsedValues()
+	{
+		var sut = ReplApp.Create();
+		sut.UseGlobalOptions<TestGlobalOptions>();
+		sut.Map("show", (TestGlobalOptions opts) => $"{opts.Tenant}:{opts.Port}");
+
+		var output = ConsoleCaptureHelper.Capture(
+			() => sut.Run(["show", "--tenant", "acme", "--port", "9090", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("acme:9090");
+	}
+
+	[TestMethod]
+	[Description("UseGlobalOptions<T> properties without values keep defaults.")]
+	public void When_UsingTypedGlobalOptionsWithoutValues_Then_DefaultsAreKept()
+	{
+		var sut = ReplApp.Create();
+		sut.UseGlobalOptions<TestGlobalOptions>();
+		sut.Map("show", (TestGlobalOptions opts) => $"{opts.Tenant ?? "none"}:{opts.Port}");
+
+		var output = ConsoleCaptureHelper.Capture(
+			() => sut.Run(["show", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("none:8080");
+	}
+
+	[TestMethod]
+	[Description("Global option registered with string type name works end to end.")]
+	public void When_GlobalOptionRegisteredWithStringTypeName_Then_TypedAccessWorks()
+	{
+		var sut = ReplApp.Create();
+		sut.Options(o => o.Parsing.AddGlobalOption("port", "int"));
+		sut.Map("show", (IGlobalOptionsAccessor globals) => globals.GetValue<int>("port"));
+
+		var output = ConsoleCaptureHelper.Capture(
+			() => sut.Run(["show", "--port", "4000", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("4000");
+	}
+
+	[TestMethod]
+	[Description("CoreReplApp (no MS DI) also provides IGlobalOptionsAccessor.")]
+	public void When_UsingCoreReplApp_Then_AccessorIsAvailableInHandler()
+	{
+		var sut = CoreReplApp.Create();
+		sut.Options(o => o.Parsing.AddGlobalOption<string>("tenant"));
+		sut.Map("show", (IGlobalOptionsAccessor globals) => globals.GetValue<string>("tenant") ?? "none");
+
+		var output = ConsoleCaptureHelper.Capture(
+			() => sut.Run(["show", "--tenant", "acme", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("acme");
+	}
+
+	private sealed record TenantConfig(string Name);
+
+	private sealed class TestGlobalOptions
+	{
+		public string? Tenant { get; set; }
+
+		public int Port { get; set; } = 8080;
+	}
+}

--- a/src/Repl.IntegrationTests/Given_GlobalOptionsAccessor.cs
+++ b/src/Repl.IntegrationTests/Given_GlobalOptionsAccessor.cs
@@ -181,6 +181,35 @@ public sealed class Given_GlobalOptionsAccessor
 		results[1].Should().Be("second:2222");
 	}
 
+	[TestMethod]
+	[Description("UseGlobalOptions<T> uses configured NumericFormatProvider, not invariant culture.")]
+	public void When_NumericCultureIsCurrent_Then_TypedOptionsUsesConfiguredCulture()
+	{
+		var previousCulture = System.Globalization.CultureInfo.CurrentCulture;
+		try
+		{
+			// Set a culture that uses comma as decimal separator
+			System.Globalization.CultureInfo.CurrentCulture =
+				new System.Globalization.CultureInfo("fr-FR");
+
+			var sut = ReplApp.Create();
+			sut.Options(o => o.Parsing.NumericCulture = NumericParsingCulture.Current);
+			sut.UseGlobalOptions<DecimalGlobalOptions>();
+			sut.Map("show", (DecimalGlobalOptions opts) => opts.Rate.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+			// fr-FR uses comma, but we pass "1,5" which should parse with current culture
+			var output = ConsoleCaptureHelper.Capture(
+				() => sut.Run(["show", "--rate", "1,5", "--no-logo"]));
+
+			output.ExitCode.Should().Be(0);
+			output.Text.Should().Contain("1.5");
+		}
+		finally
+		{
+			System.Globalization.CultureInfo.CurrentCulture = previousCulture;
+		}
+	}
+
 	private sealed record TenantConfig(string Name);
 
 	private sealed class TestGlobalOptions
@@ -188,5 +217,10 @@ public sealed class Given_GlobalOptionsAccessor
 		public string? Tenant { get; set; }
 
 		public int Port { get; set; } = 8080;
+	}
+
+	private sealed class DecimalGlobalOptions
+	{
+		public double Rate { get; set; }
 	}
 }

--- a/src/Repl.Tests/Given_GlobalOptionParser.cs
+++ b/src/Repl.Tests/Given_GlobalOptionParser.cs
@@ -73,4 +73,36 @@ public sealed class Given_GlobalOptionParser
 		parsed.CustomGlobalNamedOptions.Should().ContainKey("tenant");
 		parsed.CustomGlobalNamedOptions["tenant"].Should().ContainSingle().Which.Should().Be("-1");
 	}
+
+	[TestMethod]
+	[Description("Bool-typed global option does not consume next positional token.")]
+	public void When_BoolGlobalOptionFollowedByCommand_Then_CommandNotConsumed()
+	{
+		var parsingOptions = new ParsingOptions();
+		parsingOptions.AddGlobalOption<bool>("verbose");
+
+		var parsed = GlobalOptionParser.Parse(
+			["--verbose", "deploy"],
+			new OutputOptions(),
+			parsingOptions);
+
+		parsed.RemainingTokens.Should().Equal("deploy");
+		parsed.CustomGlobalNamedOptions["verbose"].Should().ContainSingle().Which.Should().Be("true");
+	}
+
+	[TestMethod]
+	[Description("Bool-typed global option with inline value still works.")]
+	public void When_BoolGlobalOptionWithInlineValue_Then_ValueIsUsed()
+	{
+		var parsingOptions = new ParsingOptions();
+		parsingOptions.AddGlobalOption<bool>("verbose");
+
+		var parsed = GlobalOptionParser.Parse(
+			["--verbose=false", "deploy"],
+			new OutputOptions(),
+			parsingOptions);
+
+		parsed.RemainingTokens.Should().Equal("deploy");
+		parsed.CustomGlobalNamedOptions["verbose"].Should().ContainSingle().Which.Should().Be("false");
+	}
 }

--- a/src/Repl.Tests/Given_GlobalOptionsAccessor.cs
+++ b/src/Repl.Tests/Given_GlobalOptionsAccessor.cs
@@ -424,6 +424,50 @@ public sealed class Given_GlobalOptionsAccessor
 		sut.GetValue<LogLevel>("level").Should().Be(LogLevel.Warning);
 	}
 
+	[TestMethod]
+	[Description("PopulateInstance picks up session-baseline values not explicitly provided.")]
+	public void When_BaselineSetAndNoExplicitValue_Then_PopulateInstanceUsesBaseline()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption<string>("tenant");
+		parsing.AddGlobalOption<int>("port");
+		var snapshot = new GlobalOptionsSnapshot(parsing);
+
+		// Simulate CLI launch with --tenant acme --port 3000
+		snapshot.Update(Values(("tenant", "acme"), ("port", "3000")));
+		snapshot.SetSessionBaseline();
+
+		// Simulate interactive command with no global options
+		snapshot.Update(new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase));
+
+		// PopulateInstance should still see baseline values
+		var result = GlobalOptionsExtensions.PopulateInstance<TestTypedOptions>(
+			snapshot, System.Globalization.CultureInfo.InvariantCulture);
+
+		result.Tenant.Should().Be("acme");
+		result.Port.Should().Be(3000);
+	}
+
+	[TestMethod]
+	[Description("AddGlobalOption with string type name 'email' resolves as string.")]
+	public void When_RegisteredWithStringTypeName_Email_Then_ResolvesAsString()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption("contact", "email");
+		var sut = new GlobalOptionsSnapshot(parsing);
+		sut.Update(Values(("contact", "test@example.com")));
+
+		sut.GetValue<string>("contact").Should().Be("test@example.com");
+		parsing.GlobalOptions["contact"].ValueType.Should().Be(typeof(string));
+	}
+
+	private sealed class TestTypedOptions
+	{
+		public string? Tenant { get; set; }
+
+		public int Port { get; set; }
+	}
+
 	private enum LogLevel
 	{
 		Info,

--- a/src/Repl.Tests/Given_GlobalOptionsAccessor.cs
+++ b/src/Repl.Tests/Given_GlobalOptionsAccessor.cs
@@ -134,8 +134,8 @@ public sealed class Given_GlobalOptionsAccessor
 	}
 
 	[TestMethod]
-	[Description("AddGlobalOption with string type name works.")]
-	public void When_RegisteredWithStringTypeName_Then_GetValueConvertsCorrectly()
+	[Description("AddGlobalOption with string type name 'int' works.")]
+	public void When_RegisteredWithStringTypeName_Int_Then_GetValueConvertsCorrectly()
 	{
 		var parsing = new ParsingOptions();
 		parsing.AddGlobalOption("port", "int");
@@ -143,6 +143,203 @@ public sealed class Given_GlobalOptionsAccessor
 		sut.Update(Values(("port", "9090")));
 
 		sut.GetValue<int>("port").Should().Be(9090);
+	}
+
+	[TestMethod]
+	[Description("AddGlobalOption with string type name 'bool' works.")]
+	public void When_RegisteredWithStringTypeName_Bool_Then_GetValueConvertsCorrectly()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption("verbose", "bool");
+		var sut = new GlobalOptionsSnapshot(parsing);
+		sut.Update(Values(("verbose", "true")));
+
+		sut.GetValue<bool>("verbose").Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("AddGlobalOption with string type name 'long' works.")]
+	public void When_RegisteredWithStringTypeName_Long_Then_GetValueConvertsCorrectly()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption("size", "long");
+		var sut = new GlobalOptionsSnapshot(parsing);
+		sut.Update(Values(("size", "9999999999")));
+
+		sut.GetValue<long>("size").Should().Be(9_999_999_999L);
+	}
+
+	[TestMethod]
+	[Description("AddGlobalOption with string type name 'guid' works.")]
+	public void When_RegisteredWithStringTypeName_Guid_Then_GetValueConvertsCorrectly()
+	{
+		var id = Guid.NewGuid();
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption("id", "guid");
+		var sut = new GlobalOptionsSnapshot(parsing);
+		sut.Update(Values(("id", id.ToString())));
+
+		sut.GetValue<Guid>("id").Should().Be(id);
+	}
+
+	[TestMethod]
+	[Description("AddGlobalOption with string type name 'uri' works.")]
+	public void When_RegisteredWithStringTypeName_Uri_Then_GetValueConvertsCorrectly()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption("endpoint", "uri");
+		var sut = new GlobalOptionsSnapshot(parsing);
+		sut.Update(Values(("endpoint", "https://example.com")));
+
+		sut.GetValue<Uri>("endpoint").Should().Be(new Uri("https://example.com"));
+	}
+
+	[TestMethod]
+	[Description("AddGlobalOption with string type name 'date' works.")]
+	public void When_RegisteredWithStringTypeName_Date_Then_GetValueConvertsCorrectly()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption("since", "date");
+		var sut = new GlobalOptionsSnapshot(parsing);
+		sut.Update(Values(("since", "2026-03-30")));
+
+		sut.GetValue<DateOnly>("since").Should().Be(new DateOnly(2026, 3, 30));
+	}
+
+	[TestMethod]
+	[Description("AddGlobalOption with string type name 'timespan' works.")]
+	public void When_RegisteredWithStringTypeName_TimeSpan_Then_GetValueConvertsCorrectly()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption("timeout", "timespan");
+		var sut = new GlobalOptionsSnapshot(parsing);
+		sut.Update(Values(("timeout", "00:05:00")));
+
+		sut.GetValue<TimeSpan>("timeout").Should().Be(TimeSpan.FromMinutes(5));
+	}
+
+	[TestMethod]
+	[Description("AddGlobalOption with string type name 'datetime' works.")]
+	public void When_RegisteredWithStringTypeName_DateTime_Then_GetValueConvertsCorrectly()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption("at", "datetime");
+		var sut = new GlobalOptionsSnapshot(parsing);
+		sut.Update(Values(("at", "2026-03-30T14:00:00")));
+
+		sut.GetValue<DateTime>("at").Day.Should().Be(30);
+	}
+
+	[TestMethod]
+	[Description("AddGlobalOption with string type name 'string' works.")]
+	public void When_RegisteredWithStringTypeName_String_Then_GetValueReturnsIt()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption("name", "string");
+		var sut = new GlobalOptionsSnapshot(parsing);
+		sut.Update(Values(("name", "hello")));
+
+		sut.GetValue<string>("name").Should().Be("hello");
+	}
+
+	[TestMethod]
+	[Description("AddGlobalOption with unknown type name throws ArgumentException.")]
+	public void When_RegisteredWithUnknownTypeName_Then_Throws()
+	{
+		var parsing = new ParsingOptions();
+
+		var act = () => parsing.AddGlobalOption("x", "foobar");
+
+		act.Should().Throw<ArgumentException>()
+			.Which.Message.Should().Contain("foobar");
+	}
+
+	[TestMethod]
+	[Description("AddGlobalOption with case-variant type name works.")]
+	public void When_RegisteredWithUpperCaseTypeName_Then_ResolvesCorrectly()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption("port", "INT");
+		var sut = new GlobalOptionsSnapshot(parsing);
+		sut.Update(Values(("port", "443")));
+
+		sut.GetValue<int>("port").Should().Be(443);
+	}
+
+	[TestMethod]
+	[Description("AddGlobalOption preserves ValueType from generic overload.")]
+	public void When_RegisteredWithGenericOverload_Then_ValueTypeIsPreserved()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption<Guid>("id");
+
+		parsing.GlobalOptions["id"].ValueType.Should().Be(typeof(Guid));
+	}
+
+	[TestMethod]
+	[Description("AddGlobalOption preserves ValueType from string type name overload.")]
+	public void When_RegisteredWithStringTypeNameOverload_Then_ValueTypeIsPreserved()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption("port", "int");
+
+		parsing.GlobalOptions["port"].ValueType.Should().Be(typeof(int));
+	}
+
+	[TestMethod]
+	[Description("AddGlobalOption with custom route constraint type name resolves as string.")]
+	public void When_RegisteredWithCustomConstraintTypeName_Then_ResolvesAsString()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddRouteConstraint("hex", value => value.All(c => "0123456789abcdefABCDEF".Contains(c, StringComparison.Ordinal)));
+		parsing.AddGlobalOption("color", "hex");
+		var sut = new GlobalOptionsSnapshot(parsing);
+		sut.Update(Values(("color", "ff00aa")));
+
+		sut.GetValue<string>("color").Should().Be("ff00aa");
+		parsing.GlobalOptions["color"].ValueType.Should().Be(typeof(string));
+	}
+
+	[TestMethod]
+	[Description("AddGlobalOption with custom constraint that doesn't exist still throws.")]
+	public void When_RegisteredWithUnregisteredConstraintName_Then_Throws()
+	{
+		var parsing = new ParsingOptions();
+
+		var act = () => parsing.AddGlobalOption("x", "nonexistent");
+
+		act.Should().Throw<ArgumentException>()
+			.Which.Message.Should().Contain("nonexistent");
+	}
+
+	[TestMethod]
+	[Description("Duplicate global option name throws.")]
+	public void When_RegisteringDuplicateName_Then_Throws()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption<string>("tenant");
+
+		var act = () => parsing.AddGlobalOption("tenant", "int");
+
+		act.Should().Throw<InvalidOperationException>()
+			.Which.Message.Should().Contain("tenant");
+	}
+
+	[TestMethod]
+	[Description("GetValue with enum type converts string to enum.")]
+	public void When_EnumOptionParsed_Then_GetValueReturnsTypedEnum()
+	{
+		var sut = CreateAccessor<LogLevel>("level");
+		sut.Update(Values(("level", "Warning")));
+
+		sut.GetValue<LogLevel>("level").Should().Be(LogLevel.Warning);
+	}
+
+	private enum LogLevel
+	{
+		Info,
+		Warning,
+		Error,
 	}
 
 	private static GlobalOptionsSnapshot CreateAccessor(string name)

--- a/src/Repl.Tests/Given_GlobalOptionsAccessor.cs
+++ b/src/Repl.Tests/Given_GlobalOptionsAccessor.cs
@@ -134,6 +134,70 @@ public sealed class Given_GlobalOptionsAccessor
 	}
 
 	[TestMethod]
+	[Description("Session baseline values persist when interactive command provides no override.")]
+	public void When_BaselineSet_Then_UpdateWithEmptyPreservesBaseline()
+	{
+		var sut = CreateAccessor("env");
+		sut.Update(Values(("env", "staging")));
+		sut.SetSessionBaseline();
+		sut.Update(new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase));
+
+		sut.GetValue<string>("env").Should().Be("staging");
+	}
+
+	[TestMethod]
+	[Description("Per-command override takes precedence over session baseline.")]
+	public void When_BaselineSetAndOverridden_Then_OverrideTakesPrecedence()
+	{
+		var sut = CreateAccessor("env");
+		sut.Update(Values(("env", "staging")));
+		sut.SetSessionBaseline();
+		sut.Update(Values(("env", "prod")));
+
+		sut.GetValue<string>("env").Should().Be("prod");
+	}
+
+	[TestMethod]
+	[Description("Session baseline is restored after override is gone.")]
+	public void When_OverrideRemovedOnNextUpdate_Then_BaselineRestored()
+	{
+		var sut = CreateAccessor("env");
+		sut.Update(Values(("env", "staging")));
+		sut.SetSessionBaseline();
+
+		// Command with override
+		sut.Update(Values(("env", "prod")));
+		sut.GetValue<string>("env").Should().Be("prod");
+
+		// Next command without override — baseline restored
+		sut.Update(new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase));
+		sut.GetValue<string>("env").Should().Be("staging");
+	}
+
+	[TestMethod]
+	[Description("Override does not mutate the session baseline.")]
+	public void When_OverrideApplied_Then_BaselineRemainsUnchanged()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption<string>("env");
+		parsing.AddGlobalOption<int>("port");
+		var sut = new GlobalOptionsSnapshot(parsing);
+
+		sut.Update(Values(("env", "staging"), ("port", "3000")));
+		sut.SetSessionBaseline();
+
+		// Override only env
+		sut.Update(Values(("env", "prod")));
+		sut.GetValue<string>("env").Should().Be("prod");
+		sut.GetValue<int>("port").Should().Be(3000); // baseline preserved
+
+		// Next command — both baseline values restored
+		sut.Update(new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase));
+		sut.GetValue<string>("env").Should().Be("staging");
+		sut.GetValue<int>("port").Should().Be(3000);
+	}
+
+	[TestMethod]
 	[Description("AddGlobalOption with string type name 'int' works.")]
 	public void When_RegisteredWithStringTypeName_Int_Then_GetValueConvertsCorrectly()
 	{

--- a/src/Repl.Tests/Given_GlobalOptionsAccessor.cs
+++ b/src/Repl.Tests/Given_GlobalOptionsAccessor.cs
@@ -1,0 +1,169 @@
+using AwesomeAssertions;
+
+namespace Repl.Tests;
+
+[TestClass]
+public sealed class Given_GlobalOptionsAccessor
+{
+	[TestMethod]
+	[Description("GetValue returns parsed string value after Update.")]
+	public void When_StringOptionParsed_Then_GetValueReturnsIt()
+	{
+		var sut = CreateAccessor("tenant");
+		sut.Update(Values(("tenant", "acme")));
+
+		sut.GetValue<string>("tenant").Should().Be("acme");
+	}
+
+	[TestMethod]
+	[Description("GetValue returns typed int value after Update.")]
+	public void When_IntOptionParsed_Then_GetValueReturnsTypedValue()
+	{
+		var sut = CreateAccessor<int>("port");
+		sut.Update(Values(("port", "8080")));
+
+		sut.GetValue<int>("port").Should().Be(8080);
+	}
+
+	[TestMethod]
+	[Description("GetValue returns typed bool value after Update.")]
+	public void When_BoolOptionParsed_Then_GetValueReturnsTypedValue()
+	{
+		var sut = CreateAccessor<bool>("verbose");
+		sut.Update(Values(("verbose", "true")));
+
+		sut.GetValue<bool>("verbose").Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("GetValue returns default when option not provided.")]
+	public void When_OptionNotProvided_Then_GetValueReturnsDefault()
+	{
+		var sut = CreateAccessor("tenant");
+		sut.Update(new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase));
+
+		sut.GetValue<string>("tenant").Should().BeNull();
+	}
+
+	[TestMethod]
+	[Description("GetValue returns caller default when option not provided.")]
+	public void When_OptionNotProvided_Then_GetValueReturnsCallerDefault()
+	{
+		var sut = CreateAccessor("tenant");
+		sut.Update(new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase));
+
+		sut.GetValue<string>("tenant", "fallback").Should().Be("fallback");
+	}
+
+	[TestMethod]
+	[Description("GetValue returns registration default when option not provided.")]
+	public void When_OptionNotProvidedButRegisteredDefault_Then_GetValueReturnsRegisteredDefault()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption<int>("port", defaultValue: 3000);
+		var sut = new GlobalOptionsSnapshot(parsing);
+		sut.Update(new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase));
+
+		sut.GetValue<int>("port").Should().Be(3000);
+	}
+
+	[TestMethod]
+	[Description("HasValue returns false before parsing.")]
+	public void When_NeverUpdated_Then_HasValueReturnsFalse()
+	{
+		var sut = CreateAccessor("tenant");
+
+		sut.HasValue("tenant").Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("HasValue returns true after parsing.")]
+	public void When_OptionParsed_Then_HasValueReturnsTrue()
+	{
+		var sut = CreateAccessor("tenant");
+		sut.Update(Values(("tenant", "acme")));
+
+		sut.HasValue("tenant").Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("GetRawValues returns all values for repeated option.")]
+	public void When_OptionRepeated_Then_GetRawValuesReturnsAll()
+	{
+		var sut = CreateAccessor("tag");
+		sut.Update(new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+		{
+			["tag"] = (IReadOnlyList<string>)["alpha", "beta"],
+		});
+
+		sut.GetRawValues("tag").Should().Equal("alpha", "beta");
+	}
+
+	[TestMethod]
+	[Description("GetRawValues returns empty for unset option.")]
+	public void When_OptionNotSet_Then_GetRawValuesReturnsEmpty()
+	{
+		var sut = CreateAccessor("tag");
+		sut.Update(new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase));
+
+		sut.GetRawValues("tag").Should().BeEmpty();
+	}
+
+	[TestMethod]
+	[Description("GetOptionNames returns all parsed option names.")]
+	public void When_MultipleOptionsParsed_Then_GetOptionNamesReturnsThem()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption<string>("tenant");
+		parsing.AddGlobalOption<int>("port");
+		var sut = new GlobalOptionsSnapshot(parsing);
+		sut.Update(Values(("tenant", "acme"), ("port", "8080")));
+
+		sut.GetOptionNames().Should().Contain("tenant").And.Contain("port");
+	}
+
+	[TestMethod]
+	[Description("Update replaces previous values (per-invocation semantics).")]
+	public void When_UpdatedTwice_Then_SecondValuesReplacePrevious()
+	{
+		var sut = CreateAccessor("tenant");
+		sut.Update(Values(("tenant", "first")));
+		sut.Update(Values(("tenant", "second")));
+
+		sut.GetValue<string>("tenant").Should().Be("second");
+	}
+
+	[TestMethod]
+	[Description("AddGlobalOption with string type name works.")]
+	public void When_RegisteredWithStringTypeName_Then_GetValueConvertsCorrectly()
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption("port", "int");
+		var sut = new GlobalOptionsSnapshot(parsing);
+		sut.Update(Values(("port", "9090")));
+
+		sut.GetValue<int>("port").Should().Be(9090);
+	}
+
+	private static GlobalOptionsSnapshot CreateAccessor(string name)
+		=> CreateAccessor<string>(name);
+
+	private static GlobalOptionsSnapshot CreateAccessor<T>(string name)
+	{
+		var parsing = new ParsingOptions();
+		parsing.AddGlobalOption<T>(name);
+		return new GlobalOptionsSnapshot(parsing);
+	}
+
+	private static Dictionary<string, IReadOnlyList<string>> Values(
+		params (string Key, string Value)[] entries)
+	{
+		var dict = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+		foreach (var (key, value) in entries)
+		{
+			dict[key] = [value];
+		}
+
+		return dict;
+	}
+}

--- a/src/Repl.Tests/Given_GlobalOptionsAccessor.cs
+++ b/src/Repl.Tests/Given_GlobalOptionsAccessor.cs
@@ -171,6 +171,23 @@ public sealed class Given_GlobalOptionsAccessor
 	}
 
 	[TestMethod]
+	[Description("Session baseline does not leak across separate Run() cycles.")]
+	public void When_SecondRunOmitsOption_Then_BaselineFromFirstRunDoesNotLeak()
+	{
+		var sut = CreateAccessor("tenant");
+
+		// First Run() cycle
+		sut.Update(Values(("tenant", "acme")));
+		sut.SetSessionBaseline();
+
+		// Second Run() cycle — no --tenant provided
+		sut.Update(new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase));
+		sut.SetSessionBaseline();
+
+		sut.GetValue<string>("tenant").Should().BeNull();
+	}
+
+	[TestMethod]
 	[Description("Per-command override takes precedence over session baseline.")]
 	public void When_BaselineSetAndOverridden_Then_OverrideTakesPrecedence()
 	{

--- a/src/Repl.Tests/Given_GlobalOptionsAccessor.cs
+++ b/src/Repl.Tests/Given_GlobalOptionsAccessor.cs
@@ -146,6 +146,31 @@ public sealed class Given_GlobalOptionsAccessor
 	}
 
 	[TestMethod]
+	[Description("HasValue returns false for baseline-only keys not explicitly provided.")]
+	public void When_BaselineKeyNotExplicitlyProvided_Then_HasValueReturnsFalse()
+	{
+		var sut = CreateAccessor("env");
+		sut.Update(Values(("env", "staging")));
+		sut.SetSessionBaseline();
+		sut.Update(new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase));
+
+		sut.HasValue("env").Should().BeFalse();
+		sut.GetValue<string>("env").Should().Be("staging"); // still accessible via GetValue
+	}
+
+	[TestMethod]
+	[Description("HasValue returns true when option is explicitly provided even with baseline.")]
+	public void When_BaselineKeyExplicitlyOverridden_Then_HasValueReturnsTrue()
+	{
+		var sut = CreateAccessor("env");
+		sut.Update(Values(("env", "staging")));
+		sut.SetSessionBaseline();
+		sut.Update(Values(("env", "prod")));
+
+		sut.HasValue("env").Should().BeTrue();
+	}
+
+	[TestMethod]
 	[Description("Per-command override takes precedence over session baseline.")]
 	public void When_BaselineSetAndOverridden_Then_OverrideTakesPrecedence()
 	{


### PR DESCRIPTION
## Summary

- `IGlobalOptionsAccessor` is now registered in DI automatically, giving middleware, DI service factories, and handlers typed access to parsed global option values.
- `UseGlobalOptions<T>()` extension on `ReplApp` allows declaring a typed class whose public settable properties become global options — the class is available via DI, populated from parsed values. Property names are converted to kebab-case (`MaxRetries` → `--max-retries`).
- New non-generic `AddGlobalOption(name, typeName)` overload accepts constraint-style type names (`"int"`, `"bool"`, `"guid"`, `"uri"`, `"date"`, `"timespan"`, etc.), matching the route constraint naming convention.
- `GlobalOptionDefinition` now preserves the declared `Type` from `AddGlobalOption<T>()` for help text generation and future validation.
- Values are updated per-invocation: in CLI mode after initial parsing, in interactive mode after each command's re-parse. DI singleton factories see the correct values because they resolve lazily (after parsing completes).

## Examples

**Dictionary-style access (works with both `CoreReplApp` and `ReplApp`):**
```csharp
app.Options(o => o.Parsing.AddGlobalOption<string>("tenant"));

// In middleware
app.Use(async (ctx, next) =>
{
    var globals = ctx.Services.GetRequiredService<IGlobalOptionsAccessor>();
    var tenant = globals.GetValue<string>("tenant");
    await next();
});

// In DI factory
services.AddSingleton<ITenantClient>(sp =>
{
    var globals = sp.GetRequiredService<IGlobalOptionsAccessor>();
    return new TenantClient(globals.GetValue<string>("tenant", "default")!);
});
```

**Typed class (requires `ReplApp` with MS DI):**
```csharp
public class MyGlobalOptions
{
    public string? Tenant { get; set; }
    public int Port { get; set; } = 8080;
}

app.UseGlobalOptions<MyGlobalOptions>();
app.Map("show", (MyGlobalOptions opts) => $"{opts.Tenant}:{opts.Port}");
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yllibed/repl/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
