### PR TITLE
Dev/cdb/global options mcp baseline

### DIFF
--- a/src/Repl.Core/CoreReplApp.cs
+++ b/src/Repl.Core/CoreReplApp.cs
@@ -381,7 +381,7 @@ public sealed partial class CoreReplApp : ICoreReplApp
 		_ = _middleware.Count;
 		_ = _options;
 		cancellationToken.ThrowIfCancellationRequested();
-		return ExecuteCoreAsync(args, _services, cancellationToken);
+		return ExecuteCoreAsync(args, _services, cancellationToken: cancellationToken);
 	}
 
 	internal RouteMatch? Resolve(IReadOnlyList<string> inputTokens)
@@ -408,19 +408,23 @@ public sealed partial class CoreReplApp : ICoreReplApp
 		string[] args,
 		IServiceProvider serviceProvider,
 		CancellationToken cancellationToken = default) =>
-		ExecuteCoreAsync(args, serviceProvider, cancellationToken);
+		ExecuteCoreAsync(args, serviceProvider, isSubInvocation: true, cancellationToken);
 
 	private async ValueTask<int> ExecuteCoreAsync(
 		IReadOnlyList<string> args,
 		IServiceProvider serviceProvider,
-		CancellationToken cancellationToken)
+		bool isSubInvocation = false,
+		CancellationToken cancellationToken = default)
 	{
 		_options.Interaction.SetObserver(observer: ExecutionObserver);
 		try
 		{
 			var globalOptions = GlobalOptionParser.Parse(args, _options.Output, _options.Parsing);
 			_globalOptionsSnapshot.Update(globalOptions.CustomGlobalNamedOptions);
-			_globalOptionsSnapshot.SetSessionBaseline();
+			if (!isSubInvocation)
+			{
+				_globalOptionsSnapshot.SetSessionBaseline();
+			}
 			using var runtimeStateScope = PushRuntimeState(serviceProvider, isInteractiveSession: false);
 			var prefixResolution = ResolveUniquePrefixes(globalOptions.RemainingTokens);
 			var resolvedGlobalOptions = globalOptions with { RemainingTokens = prefixResolution.Tokens };

--- a/src/Repl.Core/CoreReplApp.cs
+++ b/src/Repl.Core/CoreReplApp.cs
@@ -408,6 +408,17 @@ public sealed partial class CoreReplApp : ICoreReplApp
 		string[] args,
 		IServiceProvider serviceProvider,
 		CancellationToken cancellationToken = default) =>
+		ExecuteCoreAsync(args, serviceProvider, cancellationToken: cancellationToken);
+
+	/// <summary>
+	/// Executes a nested command invocation that preserves the session baseline.
+	/// Used by MCP tool calls where the global options from the initial session
+	/// must remain in effect even though the sub-invocation tokens don't contain them.
+	/// </summary>
+	internal ValueTask<int> RunSubInvocationAsync(
+		string[] args,
+		IServiceProvider serviceProvider,
+		CancellationToken cancellationToken = default) =>
 		ExecuteCoreAsync(args, serviceProvider, isSubInvocation: true, cancellationToken);
 
 	private async ValueTask<int> ExecuteCoreAsync(

--- a/src/Repl.Core/CoreReplApp.cs
+++ b/src/Repl.Core/CoreReplApp.cs
@@ -431,7 +431,7 @@ public sealed partial class CoreReplApp : ICoreReplApp
 		try
 		{
 			var globalOptions = GlobalOptionParser.Parse(args, _options.Output, _options.Parsing);
-			_globalOptionsSnapshot.Update(globalOptions.CustomGlobalNamedOptions);
+			_globalOptionsSnapshot.Update(globalOptions.CustomGlobalNamedOptions); // volatile ref swap — safe under concurrent sub-invocations
 			if (!isSubInvocation)
 			{
 				_globalOptionsSnapshot.SetSessionBaseline();

--- a/src/Repl.IntegrationTests/Given_GlobalOptionsAccessor.cs
+++ b/src/Repl.IntegrationTests/Given_GlobalOptionsAccessor.cs
@@ -234,6 +234,58 @@ public sealed class Given_GlobalOptionsAccessor
 		output.Text.Should().Contain("9090");
 	}
 
+	[TestMethod]
+	[Description("Sub-invocation via RunSubInvocationAsync preserves baseline from top-level Run.")]
+	public async Task When_SubInvocationAfterRun_Then_BaselineGlobalOptionsArePreserved()
+	{
+		string? capturedTenant = null;
+		var sut = ReplApp.Create();
+		sut.UseGlobalOptions<TestGlobalOptions>();
+		sut.Map("show", (TestGlobalOptions opts) => $"{opts.Tenant}:{opts.Port}");
+		sut.Map("check", (IGlobalOptionsAccessor globals) =>
+		{
+			capturedTenant = globals.GetValue<string>("tenant");
+			return "ok";
+		});
+
+		// Top-level Run establishes baseline with --tenant acme.
+		ConsoleCaptureHelper.Capture(
+			() => sut.Run(["show", "--tenant", "acme", "--no-logo"]));
+
+		// Sub-invocation without --tenant must still see the baseline value.
+		await sut.Core.RunSubInvocationAsync(
+			["--no-logo", "check"], sut.Services).ConfigureAwait(false);
+
+		capturedTenant.Should().Be("acme");
+	}
+
+	[TestMethod]
+	[Description("Sub-invocation does not reset baseline for subsequent sub-invocations.")]
+	public async Task When_MultipleSubInvocations_Then_BaselineRemainsStable()
+	{
+		var captured = new List<string?>();
+		var sut = ReplApp.Create();
+		sut.UseGlobalOptions<TestGlobalOptions>();
+		sut.Map("show", (TestGlobalOptions opts) => "ok");
+		sut.Map("check", (IGlobalOptionsAccessor globals) =>
+		{
+			captured.Add(globals.GetValue<string>("tenant"));
+			return "ok";
+		});
+
+		// Top-level Run establishes baseline.
+		ConsoleCaptureHelper.Capture(
+			() => sut.Run(["show", "--tenant", "acme", "--no-logo"]));
+
+		// Two consecutive sub-invocations — baseline must survive both.
+		await sut.Core.RunSubInvocationAsync(
+			["--no-logo", "check"], sut.Services).ConfigureAwait(false);
+		await sut.Core.RunSubInvocationAsync(
+			["--no-logo", "check"], sut.Services).ConfigureAwait(false);
+
+		captured.Should().AllBe("acme");
+	}
+
 	private sealed class DecimalGlobalOptions
 	{
 		public double Rate { get; set; }

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -105,7 +105,7 @@ internal sealed partial class McpToolAdapter
 			isHostedSession: true))
 		{
 			ReplSessionIO.IsProgrammatic = true;
-			var exitCode = await coreApp.RunWithServicesAsync(
+			var exitCode = await coreApp.RunSubInvocationAsync(
 				effectiveTokens.ToArray(), mcpServices, ct).ConfigureAwait(false);
 
 			var output = outputWriter.ToString().Trim();


### PR DESCRIPTION
## Summary

- Add `RunSubInvocationAsync` to `CoreReplApp` for nested command execution (MCP tool calls) that preserves the session baseline established by the top-level `Run()`
- Without this, MCP tool calls re-parse an empty argument list, call `SetSessionBaseline()`, and wipe the global options set at startup (e.g. `--lock-app`, `--policy`)
- `McpToolAdapter` now uses `RunSubInvocationAsync` instead of `RunWithServicesAsync`

## Problem

When a Repl app uses `UseGlobalOptions<T>()` and runs as an MCP server (`mcp serve`), global options like `--lock-app cmd.exe` are parsed and baselined on the initial `Run()`. But each MCP tool call went through `RunWithServicesAsync` → `ExecuteCoreAsync`, which re-parsed the sub-invocation tokens (no global options present), then called `SetSessionBaseline()` — overwriting the baseline with an empty set. Any DI-resolved typed options class would see default/null values.

## Fix

- Split `ExecuteCoreAsync` with an `isSubInvocation` flag: when true, `Update()` merges with the existing baseline but `SetSessionBaseline()` is skipped
- `RunWithServicesAsync` (top-level) remains unchanged
- New `RunSubInvocationAsync` (nested) passes `isSubInvocation: true`
- `McpToolAdapter` calls `RunSubInvocationAsync`

## Tests

- `When_SubInvocationAfterRun_Then_BaselineGlobalOptionsArePreserved` — verifies baseline survives a sub-invocation
- `When_MultipleSubInvocations_Then_BaselineRemainsStable` — verifies baseline survives consecutive sub-invocations