### PR TITLE
Update dependencies and adapt to MCP SDK 1.2.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,22 +4,22 @@
 	</PropertyGroup>
 
 	<ItemGroup Label="Build and versioning">
-		<PackageVersion Include="Meziantou.Analyzer" Version="3.0.15"/>
-		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.103"/>
+		<PackageVersion Include="Meziantou.Analyzer" Version="3.0.44"/>
+		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201"/>
 		<PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15"/>
 		<PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50"/>
 	</ItemGroup>
 
 	<ItemGroup Label="Runtime dependencies">
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3"/>
-		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.3"/>
-		<PackageVersion Include="ModelContextProtocol" Version="1.1.0"/>
-		<PackageVersion Include="Spectre.Console" Version="0.54.0"/>
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5"/>
+		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5"/>
+		<PackageVersion Include="ModelContextProtocol" Version="1.2.0"/>
+		<PackageVersion Include="Spectre.Console" Version="0.55.0"/>
 	</ItemGroup>
 
 	<ItemGroup Label="Test dependencies">
 		<PackageVersion Include="AwesomeAssertions" Version="9.4.0"/>
-		<PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.3.0"/>
+		<PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0"/>
 		<PackageVersion Include="XTerm.NET" Version="1.0.12"/>
 	</ItemGroup>
 

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -183,9 +183,9 @@ internal sealed class McpServerHandler
 	{
 		AttachServer(request.Server);
 		var snapshot = await GetSnapshotAsync(request.Server, cancellationToken).ConfigureAwait(false);
-		IDictionary<string, JsonElement> arguments = request.Params?.Arguments ?? EmptyArguments;
-		var toolName = request.Params?.Name ?? string.Empty;
-		var progressToken = request.Params?.ProgressToken;
+		IDictionary<string, JsonElement> arguments = request.Params.Arguments ?? EmptyArguments;
+		var toolName = request.Params.Name ?? string.Empty;
+		var progressToken = request.Params.ProgressToken;
 
 		if (_options.DynamicToolCompatibility == DynamicToolCompatibilityMode.DiscoverAndCallShim)
 		{
@@ -249,7 +249,7 @@ internal sealed class McpServerHandler
 	{
 		AttachServer(request.Server);
 		var snapshot = await GetSnapshotAsync(request.Server, cancellationToken).ConfigureAwait(false);
-		var uri = request.Params?.Uri ?? string.Empty;
+		var uri = request.Params.Uri ?? string.Empty;
 		var resource = snapshot.Resources.FirstOrDefault(candidate => candidate.IsMatch(uri));
 		if (resource is null)
 		{
@@ -277,7 +277,7 @@ internal sealed class McpServerHandler
 	{
 		AttachServer(request.Server);
 		var snapshot = await GetSnapshotAsync(request.Server, cancellationToken).ConfigureAwait(false);
-		var promptName = request.Params?.Name ?? string.Empty;
+		var promptName = request.Params.Name ?? string.Empty;
 		var prompt = snapshot.Prompts.FirstOrDefault(candidate =>
 			string.Equals(candidate.ProtocolPrompt.Name, promptName, StringComparison.OrdinalIgnoreCase));
 		if (prompt is null)

--- a/src/Repl.Mcp/ReplMcpServerPrompt.cs
+++ b/src/Repl.Mcp/ReplMcpServerPrompt.cs
@@ -65,7 +65,7 @@ internal sealed class ReplMcpServerPrompt : McpServerPrompt
 		CancellationToken cancellationToken = default)
 	{
 		// Prompt arguments are already JsonElement — pass through directly.
-		var jsonArgs = request.Params?.Arguments is { } args
+		var jsonArgs = request.Params.Arguments is { } args
 			? new Dictionary<string, System.Text.Json.JsonElement>(args, StringComparer.Ordinal)
 			: new Dictionary<string, System.Text.Json.JsonElement>(StringComparer.Ordinal);
 

--- a/src/Repl.Mcp/ReplMcpServerResource.cs
+++ b/src/Repl.Mcp/ReplMcpServerResource.cs
@@ -64,7 +64,7 @@ internal sealed partial class ReplMcpServerResource : McpServerResource
 		RequestContext<ReadResourceRequestParams> request,
 		CancellationToken cancellationToken = default)
 	{
-		var arguments = ExtractArguments(request.Params!.Uri);
+		var arguments = ExtractArguments(request.Params.Uri);
 
 		var result = await _adapter.InvokeAsync(
 			_resourceName, arguments, request.Server, progressToken: null, cancellationToken)

--- a/src/Repl.Mcp/ReplMcpServerTool.cs
+++ b/src/Repl.Mcp/ReplMcpServerTool.cs
@@ -48,9 +48,9 @@ internal sealed class ReplMcpServerTool : McpServerTool
 		RequestContext<CallToolRequestParams> request,
 		CancellationToken cancellationToken = default)
 	{
-		var arguments = request.Params?.Arguments
+		var arguments = request.Params.Arguments
 			?? new Dictionary<string, JsonElement>(StringComparer.Ordinal);
-		var progressToken = request.Params?.ProgressToken;
+		var progressToken = request.Params.ProgressToken;
 
 		return await _adapter.InvokeAsync(
 			_protocolTool.Name, arguments, request.Server, progressToken, cancellationToken)


### PR DESCRIPTION
## Summary
- **ModelContextProtocol** 1.1.0 → 1.2.0
- **Microsoft.Extensions.DependencyInjection** 10.0.3 → 10.0.5
- **Microsoft.Extensions.Hosting** 10.0.3 → 10.0.5
- **Spectre.Console** 0.54.0 → 0.55.0
- **Meziantou.Analyzer** 3.0.15 → 3.0.44
- **Microsoft.SourceLink.GitHub** 10.0.103 → 10.0.201
- **Microsoft.Extensions.TimeProvider.Testing** 10.3.0 → 10.4.0

Adapts code to the non-nullable `RequestContext<T>.Params` change in MCP SDK 1.2.0 (`request.Params?.` → `request.Params.`).

## Test plan
- [x] `Repl.Mcp` builds with 0 warnings, 0 errors
- [x] 113 MCP tests pass
- [x] Full CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yllibed/repl/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
