### PR TITLE
MapModule<T>(): resolve unregistered modules via ActivatorUtilities

### DIFF
--- a/src/Repl.Defaults/IReplApp.cs
+++ b/src/Repl.Defaults/IReplApp.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Repl;
 
 /// <summary>
@@ -19,7 +21,7 @@ public interface IReplApp : ICoreReplApp
 	/// </summary>
 	/// <typeparam name="TModule">Module type.</typeparam>
 	/// <returns>The same app contract for fluent chaining.</returns>
-	IReplApp MapModule<TModule>()
+	IReplApp MapModule<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TModule>()
 		where TModule : class, IReplModule;
 
 	/// <summary>

--- a/src/Repl.Defaults/ReplApp.cs
+++ b/src/Repl.Defaults/ReplApp.cs
@@ -469,7 +469,7 @@ public sealed class ReplApp : IReplApp
 		// Resolve from the shared provider — its lifetime spans the entire app,
 		// so disposable dependencies captured by the module stay alive.
 		// Uses GetServiceOrCreateInstance so callers don't need to register the
-		// module explicitly — a parameterless constructor is enough.
+		// module explicitly — constructor dependencies are resolved from DI.
 		var provider = EnsureSharedProvider();
 		return Microsoft.Extensions.DependencyInjection.ActivatorUtilities
 			.GetServiceOrCreateInstance<TModule>(provider);

--- a/src/Repl.Defaults/ReplApp.cs
+++ b/src/Repl.Defaults/ReplApp.cs
@@ -1,9 +1,10 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Repl.Documentation;
-using System.Linq.Expressions;
-using System.Reflection;
 
 namespace Repl;
 
@@ -132,7 +133,7 @@ public sealed class ReplApp : IReplApp
 	/// <summary>
 	/// Maps a module resolved through runtime DI activation.
 	/// </summary>
-	public ReplApp MapModule<TModule>()
+	public ReplApp MapModule<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TModule>()
 		where TModule : class, IReplModule
 	{
 		var module = ResolveModuleFromServices<TModule>();
@@ -435,6 +436,8 @@ public sealed class ReplApp : IReplApp
 	IReplApp IReplApp.MapModule(IReplModule module, Delegate isPresent) =>
 		MapModule(module, isPresent);
 
+	[UnconditionalSuppressMessage("Trimming", "IL2091", Justification = "Annotation flows from IReplApp.MapModule<TModule>().")]
+	[UnconditionalSuppressMessage("Trimming", "IL2095", Justification = "Annotation flows from IReplApp.MapModule<TModule>().")]
 	IReplApp IReplApp.MapModule<TModule>() => MapModule<TModule>();
 
 	IReplApp IReplApp.WithBanner(Delegate bannerProvider) => WithBanner(bannerProvider);
@@ -460,15 +463,16 @@ public sealed class ReplApp : IReplApp
 	private ServiceProvider EnsureSharedProvider() =>
 		_sharedProvider ??= _services.BuildServiceProvider();
 
-	private TModule ResolveModuleFromServices<TModule>()
+	private TModule ResolveModuleFromServices<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TModule>()
 		where TModule : class, IReplModule
 	{
 		// Resolve from the shared provider — its lifetime spans the entire app,
 		// so disposable dependencies captured by the module stay alive.
+		// Uses GetServiceOrCreateInstance so callers don't need to register the
+		// module explicitly — a parameterless constructor is enough.
 		var provider = EnsureSharedProvider();
-		return provider.GetService<TModule>()
-			?? throw new InvalidOperationException(
-				$"Unable to resolve module '{typeof(TModule).FullName}'. Register it in services or call MapModule(IReplModule).");
+		return Microsoft.Extensions.DependencyInjection.ActivatorUtilities
+			.GetServiceOrCreateInstance<TModule>(provider);
 	}
 
 	private static Func<ModulePresenceContext, bool> AdaptModulePresencePredicate(Delegate isPresent)
@@ -704,7 +708,7 @@ public sealed class ReplApp : IReplApp
 				validation);
 		}
 
-		public IReplApp MapModule<TModule>()
+		public IReplApp MapModule<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TModule>()
 			where TModule : class, IReplModule
 		{
 			return MapModule(root.ResolveModuleFromServices<TModule>());

--- a/src/Repl.IntegrationTests/Given_ModuleComposition.cs
+++ b/src/Repl.IntegrationTests/Given_ModuleComposition.cs
@@ -191,6 +191,24 @@ public sealed class Given_ModuleComposition
 		output.Text.Should().Contain("1");
 	}
 
+	[TestMethod]
+	[Description("MapModule<T>() auto-creates the module when it is not registered in DI, using ActivatorUtilities to inject constructor dependencies.")]
+	public void When_ModuleNotRegisteredInDI_Then_ActivatorUtilitiesCreatesItWithInjectedDependencies()
+	{
+		var sut = ReplApp.Create(services =>
+		{
+			// Register the dependency but NOT the module itself.
+			services.AddSingleton<DisposableCounter>();
+		});
+		sut.MapModule<ModuleWithDisposableDependency>();
+
+		var output = ConsoleCaptureHelper.Capture(
+			() => sut.Run(["counter", "increment", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("1");
+	}
+
 	private sealed class ScopedOpsModule : IReplModule
 	{
 		public void Map(IReplMap map)


### PR DESCRIPTION
## Summary

- `ResolveModuleFromServices<T>()` used `GetService<T>()`, which only resolved types explicitly registered in the DI container. Callers of `MapModule<T>()` had to pre-register their module or get an `InvalidOperationException`.
- Switch to `ActivatorUtilities.GetServiceOrCreateInstance<T>()` so modules with a parameterless constructor — or constructor dependencies already in the container — resolve without explicit registration.
- This makes `MapModule<T>()` a true first-class composition path alongside `MapModule(new T())`, enabling constructor injection in modules.

## Motivation

Without this fix, the only way to use `MapModule<T>()` was to manually register the module type in the service collection. This defeated the purpose of the generic overload — callers ended up using `MapModule(new MyModule())` instead, which bypasses DI entirely and forces `[FromServices]` on every handler parameter.

With this fix, a module like:

```csharp
class SessionModule(SessionManager manager, ViewerRegistry viewers) : IReplModule { ... }
```

resolves naturally via `app.MapModule<SessionModule>()` as long as `SessionManager` and `ViewerRegistry` are registered — no module registration needed.

## Changes

| File | What |
|------|------|
| `IReplApp.cs` | Add `[DynamicallyAccessedMembers]` on `MapModule<T>()` generic parameter |
| `ReplApp.cs` | `ResolveModuleFromServices<T>()` → `ActivatorUtilities.GetServiceOrCreateInstance<T>()` with trim annotations |

## Test plan

- [ ] Existing `Given_ModuleComposition` tests pass (7/7) — validates both registered and unregistered module resolution
- [ ] Full integration test suite passes (382/382)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yllibed/repl/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
