### PR TITLE
Add result-flow paging

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,6 +67,11 @@
  	- Built-in `markdown` (with `--markdown` alias via output alias map).
  	- Global format selectors: `--json`, `--xml`, `--yaml`, `--yml`, `--output:<format>`.
  	- Unknown format returns explicit error text and non-zero exit code.
+- Result flow:
+ 	- `IReplPagingContext` lets handlers page at the data source.
+ 	- `ReplPage<T>` carries current-page data plus continuation metadata.
+ 	- Human/Spectre terminal output can use an integrated pager; redirected stdout remains pipe-friendly.
+ 	- MCP maps `_replCursor` and `_replPageSize` to structured paged tool results.
 - Numeric parsing:
  	- Numeric culture is configurable via `ParsingOptions.NumericCulture` (`Invariant` default, `Current` optional).
  	- Integer literals support C-like forms: hexadecimal (`0xFF`), binary (`0b1010` or `1010b`), and `_` separators (`1_000_000`).
@@ -101,6 +106,7 @@ The toolkit provides two application entry points for different scenarios.
 ## Related docs
 
 - Command reference: `docs/commands.md`
+- Result flow and paging: `docs/result-flow.md`
 - Parameter system: `docs/parameter-system.md`
 - Shell completion: `docs/shell-completion.md`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,7 +21,7 @@ These flags are parsed before route execution:
 - `--result:page-size <n>` / `--result:page-size=<n>`
 - `--result:cursor <value>` / `--result:cursor=<value>`
 - `--result:all`
-- `--result:pager=auto|off|more|scroll|external`
+- `--result:pager=auto|off|more|inline|full`
 - output aliases mapped by `OutputOptions.Aliases` (defaults include `--json`, `--xml`, `--yaml`, `--yml`, `--markdown`)
 - `--answer:<name>[=value]` for non-interactive prompt answers
 - custom global options registered via `options.Parsing.AddGlobalOption<T>(...)`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -18,6 +18,10 @@ These flags are parsed before route execution:
 - `--no-interactive`
 - `--no-logo`
 - `--output:<format>`
+- `--result:page-size <n>` / `--result:page-size=<n>`
+- `--result:cursor <value>` / `--result:cursor=<value>`
+- `--result:all`
+- `--result:pager=auto|off|more|scroll|external`
 - output aliases mapped by `OutputOptions.Aliases` (defaults include `--json`, `--xml`, `--yaml`, `--yml`, `--markdown`)
 - `--answer:<name>[=value]` for non-interactive prompt answers
 - custom global options registered via `options.Parsing.AddGlobalOption<T>(...)`
@@ -29,6 +33,7 @@ Global parsing notes:
 - option value syntaxes accepted by command parsing: `--name value`, `--name=value`, `--name:value`
 - use `--` to stop option parsing and force remaining tokens to positional arguments
 - response files are supported with `@file.rsp` (enabled by default); nested `@` expansion is not supported
+- result-flow options are reserved by the framework and do not bind to handler business parameters
 
 ## Declaring command options
 
@@ -249,6 +254,7 @@ Handlers can return any type. The framework renders the return value through the
 | `string` | Rendered as plain text |
 | Object / anonymous type | Rendered as key-value pairs (human) or serialized (JSON/XML/YAML) |
 | `IEnumerable<T>` | Rendered as a table (human) or collection (structured formats) |
+| `ReplPage<T>` | Rendered as the current page plus `PageInfo`; JSON uses `{ items, pageInfo }` |
 | `IReplResult` | Structured result with kind prefix (`Results.Ok`, `Error`, `NotFound`...) |
 | `ReplNavigationResult` | Renders payload and navigates scope (`Results.NavigateUp`, `NavigateTo`) |
 | `IExitResult` | Renders optional payload and sets process exit code (`Results.Exit`) |
@@ -293,6 +299,20 @@ Tuple semantics:
 - exit code is determined by the last element
 - null elements are silently skipped
 - nested tuples are not flattened — use a flat tuple instead
+
+## Paging large results
+
+Handlers that may return large result sets can request `IReplPagingContext`:
+
+```csharp
+app.Map("contacts", async (IReplPagingContext paging, ContactStore store, CancellationToken ct) =>
+{
+    var rows = await store.QueryAsync(paging.Cursor, paging.SuggestedPageSize, ct);
+    return paging.Page(rows.Items, rows.NextCursor, rows.TotalCount);
+});
+```
+
+Use this when the data source can page efficiently. See [Result Flow And Paging](result-flow.md) for CLI flags, pager behavior, MCP paging arguments, and output format details.
 
 ## Interactive prompts
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -312,6 +312,16 @@ app.Map("contacts", async (IReplPagingContext paging, ContactStore store, Cancel
 });
 ```
 
+When human users should continue through later pages without rerunning the
+command, return a page source:
+
+```csharp
+app.Map("contacts", (ContactStore store) =>
+    ReplPageSource.FromOffset<ContactRow>(
+        (offset, take, ct) => store.QueryAsync(offset, take, ct),
+        totalCount: store.Count));
+```
+
 Use this when the data source can page efficiently. See [Result Flow And Paging](result-flow.md) for CLI flags, pager behavior, MCP paging arguments, and output format details.
 
 ## Interactive prompts

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -108,6 +108,7 @@ Accessed via `ReplOptions.Output.ResultFlow`.
 - `MaxPageSize` (`int`, default: `1000`) - Maximum accepted page size.
 - `ReservedVisibleRows` (`int`, default: `2`) - Rows reserved when computing terminal-visible data rows.
 - `DefaultPagerMode` (`ReplPagerMode`, default: `Auto`) - Pager behavior for human formats.
+- `PagerRenderers` (`IList<IReplPagerRenderer>`) - Custom interactive pager renderers keyed by pager mode.
 - `ProgrammaticMaxInlineBytes` (`int`, default: `65536`) - Reserved for programmatic inline payload policy.
 
 ### OutputOptions Methods

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -95,9 +95,20 @@ Accessed via `ReplOptions.Output`.
 - `ColorizeStructuredInteractive` (`bool`, default: `true`) — Colorize JSON/XML in interactive mode.
 - `PreferredWidth` (`int?`, default: `null`) — Preferred render width. `null` uses automatic detection.
 - `FallbackWidth` (`int`, default: `120`) — Fallback width when the terminal is unavailable.
+- `ResultFlow` (`ResultFlowOptions`) - Paging and large-result behavior.
 - `JsonSerializerOptions` (`JsonSerializerOptions`, default: Web defaults + indented) — JSON serializer options.
 
 Built-in transformers: `human`, `json`, `xml`, `yaml`, `markdown`.
+
+### ResultFlowOptions
+
+Accessed via `ReplOptions.Output.ResultFlow`.
+
+- `DefaultPageSize` (`int`, default: `100`) - Page size used when no caller or terminal hint provides one.
+- `MaxPageSize` (`int`, default: `1000`) - Maximum accepted page size.
+- `ReservedVisibleRows` (`int`, default: `2`) - Rows reserved when computing terminal-visible data rows.
+- `DefaultPagerMode` (`ReplPagerMode`, default: `Auto`) - Pager behavior for human formats.
+- `ProgrammaticMaxInlineBytes` (`int`, default: `65536`) - Reserved for programmatic inline payload policy.
 
 ### OutputOptions Methods
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -108,8 +108,13 @@ Accessed via `ReplOptions.Output.ResultFlow`.
 - `MaxPageSize` (`int`, default: `1000`) - Maximum accepted page size.
 - `ReservedVisibleRows` (`int`, default: `2`) - Rows reserved when computing terminal-visible data rows.
 - `DefaultPagerMode` (`ReplPagerMode`, default: `Auto`) - Pager behavior for human formats.
-- `PagerRenderers` (`IList<IReplPagerRenderer>`) - Custom interactive pager renderers keyed by pager mode.
+- `PagerRenderers` (`IReadOnlyList<IReplPagerRenderer>`) - Custom interactive pager renderers keyed by pager mode.
+- `MaxBufferedLines` (`int`, default: `10000`) - Maximum content lines buffered by interactive viewport pagers.
 - `ProgrammaticMaxInlineBytes` (`int`, default: `65536`) - Reserved for programmatic inline payload policy.
+
+Register custom pager renderers with `UsePagerRenderer(renderer)`. Use
+`RemovePagerRenderer(mode)` or `ClearPagerRenderers()` to alter the configured
+renderer set.
 
 ### OutputOptions Methods
 

--- a/docs/mcp-agent-capabilities.md
+++ b/docs/mcp-agent-capabilities.md
@@ -335,6 +335,14 @@ Not all MCP clients support sampling and elicitation. The table below lists agen
 
 Check [mcp-availability.com](https://mcp-availability.com/) for the latest data. Support is expanding rapidly — design your commands to degrade gracefully so they work everywhere even when a capability is missing.
 
+Paged Repl tools do not require a special MCP capability for the first page:
+every client that can call tools receives a bounded result. Continuation is
+better when the client preserves structured tool results, because the raw cursor
+is carried in `StructuredContent.pageInfo.nextCursor`. For clients that mostly
+consume text, configure `ReplMcpServerOptions.PagedResultTextMode` to choose
+between compatibility (`SerializedJson`) and lower token cost (`SummaryOnly`).
+See [Paged tool results](mcp-reference.md#paged-tool-results).
+
 ## Direct MCP interfaces vs IReplInteractionChannel
 
 | | `IMcpSampling` / `IMcpElicitation` / `IMcpFeedback` | `IReplInteractionChannel` |

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -178,7 +178,7 @@ app.UseMcpServer(o => o.InteractivityMode = InteractivityMode.PrefillThenElicita
 
 | Method | Where it goes | Use? |
 |---|---|---|
-| **Return value** | `CallToolResult.Content` (JSON) | **Yes.** Preferred for all data. |
+| **Return value** | `CallToolResult.Content` and, for paged results, `StructuredContent` | **Yes.** Preferred for all data. |
 | **`IReplInteractionChannel`** | MCP primitives (progress, prompts, user-facing notices/problems) | **Yes.** Portable feedback that also works outside MCP. |
 | **`IMcpFeedback`** | MCP progress and logging/message notifications | **Yes.** MCP-specific feedback when you need direct control. |
 | **`ReplSessionIO.Output`** | Session output | Advanced cases only. |
@@ -186,6 +186,30 @@ app.UseMcpServer(o => o.InteractivityMode = InteractivityMode.PrefillThenElicita
 | **`Console.OpenStandardOutput()`** | MCP stdio transport directly | **Never.** Corrupts JSON-RPC. |
 
 > **Why this matters:** Console-style writes blur the boundary between result data, progress, logs, and protocol traffic. In MCP, this ranges from confusing agent behavior to protocol corruption.
+
+### Paged tool results
+
+Every MCP tool schema includes two reserved Repl result-flow inputs:
+
+- `_replCursor`: opaque continuation cursor returned by a previous paged result.
+- `_replPageSize`: requested page size.
+
+Handlers receive these values through `IReplPagingContext`, not as business parameters. A handler can return `ReplPage<T>`:
+
+```csharp
+app.Map("contacts", (IReplPagingContext paging, ContactStore store) =>
+{
+    var page = store.Query(paging.Cursor, paging.SuggestedPageSize);
+    return paging.Page(page.Items, page.NextCursor, page.TotalCount);
+}).ReadOnly();
+```
+
+MCP responses for `ReplPage<T>` include:
+
+- `StructuredContent`: `{ items, pageInfo }`
+- `Content`: short text summary with the next `_replCursor` when more data exists
+
+This avoids dumping large JSON arrays into a single `TextContentBlock`.
 
 `WriteProgressAsync` maps to MCP progress notifications. `WriteStatusAsync` maps to log messages (`level: info`). See [Progress](progress.md#mcp) for the centralized progress model across console, hosted sessions, Spectre, and MCP:
 

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -213,7 +213,10 @@ This avoids dumping large JSON arrays into a single `TextContentBlock`.
 The raw cursor is not interpolated into MCP text content. Repl accepts compact
 cursor tokens only: non-empty, at most 512 characters, no whitespace, no control
 characters, and not starting with `-`. Page-size tokens must be numeric and at
-most 20 characters before normal result-flow clamping is applied.
+most 10 characters before normal result-flow clamping is applied.
+Tool-call arguments are validated against the generated MCP input schema before
+Repl reconstructs CLI tokens. Undeclared keys are rejected instead of being
+converted to `--{key}` options.
 
 MCP paging continuation depends on the client preserving structured tool
 content. Repl always returns a short text fallback, but the raw cursor is only

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -189,10 +189,13 @@ app.UseMcpServer(o => o.InteractivityMode = InteractivityMode.PrefillThenElicita
 
 ### Paged tool results
 
-Every MCP tool schema includes two reserved Repl result-flow inputs:
+Paged MCP tool schemas include two reserved Repl result-flow inputs:
 
 - `_replCursor`: opaque continuation cursor returned by a previous paged result.
 - `_replPageSize`: requested page size.
+
+These inputs are emitted only for commands that accept `IReplPagingContext` or
+return a paged result. Other tools reject them like any undeclared MCP argument.
 
 Handlers receive these values through `IReplPagingContext`, not as business parameters. A handler can return `ReplPage<T>`:
 
@@ -207,27 +210,45 @@ app.Map("contacts", (IReplPagingContext paging, ContactStore store) =>
 MCP responses for `ReplPage<T>` include:
 
 - `StructuredContent`: `{ "$type": "page", items, pageInfo }`
-- `Content`: short text summary that says a cursor is available in structured content
+- `Content`: configurable text fallback for clients that do not use structured content
 
-This avoids dumping large JSON arrays into a single `TextContentBlock`.
-The raw cursor is not interpolated into MCP text content. Repl accepts compact
-cursor tokens only: non-empty, at most 512 characters, no whitespace, no control
-characters, and not starting with `-`. Page-size tokens must be numeric and at
-most 10 characters before normal result-flow clamping is applied.
-Tool-call arguments are validated against the generated MCP input schema before
-Repl reconstructs CLI tokens. Undeclared keys are rejected instead of being
-converted to `--{key}` options.
+By default, `Content` contains compact serialized JSON so agents that ignore
+`StructuredContent` can still see the first page and cursor. Applications can
+choose a cheaper text fallback:
 
-MCP paging continuation depends on the client preserving structured tool
-content. Repl always returns a short text fallback, but the raw cursor is only
-available in `StructuredContent.pageInfo.nextCursor`.
+```csharp
+app.UseMcpServer(o =>
+{
+    o.PagedResultTextMode = McpPagedResultTextMode.SummaryOnly;
+});
+```
+
+| `PagedResultTextMode` | `Content` behavior | Trade-off |
+|---|---|---|
+| `SerializedJson` (default) | Compact JSON page envelope | Best compatibility; higher token cost |
+| `SummaryOnly` | Short summary; cursor value stays only in structured content | Lowest token cost; clients must read structured content to continue |
+| `SummaryAndSerializedJson` | Summary plus compact JSON page envelope | Most verbose; useful for diagnostics and weak clients |
+
+Repl accepts compact cursor tokens only: non-empty, at most 512 characters, no
+whitespace, no control characters, and not starting with `-`. Page-size tokens
+must be numeric and at most 10 characters before normal result-flow clamping is
+applied. Tool-call arguments are validated against the generated MCP input
+schema before Repl reconstructs CLI tokens. Undeclared keys are rejected instead
+of being converted to `--{key}` options, and business argument values that start
+with `--` are rejected because the downstream CLI parser treats those as option
+tokens.
+
+MCP paging continuation works best when the client preserves structured tool
+content. When `PagedResultTextMode` includes serialized JSON, the text fallback
+also contains the page envelope; when it is `SummaryOnly`, the raw cursor stays
+only in `StructuredContent.pageInfo.nextCursor`.
 
 | Agent/client behavior | Paging support | Repl fallback |
 |---|---|---|
 | Reads `StructuredContent` and can call the same tool again | Full continuation with `_replCursor` and `_replPageSize` | Not needed |
-| Reads only `Content` text | Sees that another cursor exists, but cannot continue automatically | Text says the cursor is available in structured content |
+| Reads only `Content` text | Sees first-page JSON by default; can continue only if it can reuse the cursor text safely | Configure `SerializedJson` or `SummaryAndSerializedJson` for compatibility, `SummaryOnly` for token savings |
 | Ignores custom/reserved input properties | First page still works | Tool returns bounded first page |
-| Does not support structured content | No automatic continuation | Use CLI/programmatic output or expose a command-specific cursor option |
+| Does not support structured content | First page still works through text fallback; automatic continuation depends on `PagedResultTextMode` | Keep `SerializedJson` for weak clients or expose a command-specific cursor option |
 
 Applications should not rely on all agents supporting continuation equally.
 For important workflows, include enough data in the first page summary for the
@@ -296,6 +317,7 @@ app.UseMcpServer(o =>
     o.ResourceFallbackToTools = false;                          // also expose resources as tools
     o.PromptFallbackToTools = false;                            // also expose prompts as tools
     o.DynamicToolCompatibility = DynamicToolCompatibilityMode.Disabled; // shim for weak clients
+    o.PagedResultTextMode = McpPagedResultTextMode.SerializedJson;      // paged result text fallback
     o.EnableApps = false;                                       // usually auto-enabled by MCP App mappings
     o.CommandFilter = cmd => true;                              // filter which commands become tools
     o.Prompt("summarize", (string topic) => ...);               // explicit prompt registration
@@ -379,6 +401,8 @@ Feature support varies across agents. Check [mcp-availability.com](https://mcp-a
 | Feature | Claude Desktop | Claude Code | Codex | VS Code Copilot | Cursor | Continue |
 |---|---|---|---|---|---|---|
 | Tools | Yes | Yes | Yes | Yes | Yes | Yes |
+| Paged tools, first page | Yes | Yes | Yes | Yes | Yes | Yes |
+| Paged tools, automatic continuation | Depends on structured tool-result handling | Depends on structured tool-result handling | Depends on structured tool-result handling | Depends on structured tool-result handling | Depends on structured tool-result handling | Depends on structured tool-result handling |
 | Resources | Yes | — | — | Yes | Yes | — |
 | Prompts | Yes | — | — | Yes | — | Yes |
 | Discovery (`list_changed`) | — | Yes | — | — | — | — |

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -206,10 +206,14 @@ app.Map("contacts", (IReplPagingContext paging, ContactStore store) =>
 
 MCP responses for `ReplPage<T>` include:
 
-- `StructuredContent`: `{ items, pageInfo }`
-- `Content`: short text summary with the next `_replCursor` when more data exists
+- `StructuredContent`: `{ "$type": "page", items, pageInfo }`
+- `Content`: short text summary that says a cursor is available in structured content
 
 This avoids dumping large JSON arrays into a single `TextContentBlock`.
+The raw cursor is not interpolated into MCP text content. Repl accepts compact
+cursor tokens only: non-empty, at most 512 characters, no whitespace, no control
+characters, and not starting with `-`. Page-size tokens must be numeric and at
+most 20 characters before normal result-flow clamping is applied.
 
 `WriteProgressAsync` maps to MCP progress notifications. `WriteStatusAsync` maps to log messages (`level: info`). See [Progress](progress.md#mcp) for the centralized progress model across console, hosted sessions, Spectre, and MCP:
 

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -215,6 +215,22 @@ cursor tokens only: non-empty, at most 512 characters, no whitespace, no control
 characters, and not starting with `-`. Page-size tokens must be numeric and at
 most 20 characters before normal result-flow clamping is applied.
 
+MCP paging continuation depends on the client preserving structured tool
+content. Repl always returns a short text fallback, but the raw cursor is only
+available in `StructuredContent.pageInfo.nextCursor`.
+
+| Agent/client behavior | Paging support | Repl fallback |
+|---|---|---|
+| Reads `StructuredContent` and can call the same tool again | Full continuation with `_replCursor` and `_replPageSize` | Not needed |
+| Reads only `Content` text | Sees that another cursor exists, but cannot continue automatically | Text says the cursor is available in structured content |
+| Ignores custom/reserved input properties | First page still works | Tool returns bounded first page |
+| Does not support structured content | No automatic continuation | Use CLI/programmatic output or expose a command-specific cursor option |
+
+Applications should not rely on all agents supporting continuation equally.
+For important workflows, include enough data in the first page summary for the
+agent to decide whether it needs a follow-up call, and keep handlers safe when
+only the first page is consumed.
+
 `WriteProgressAsync` maps to MCP progress notifications. `WriteStatusAsync` maps to log messages (`level: info`). See [Progress](progress.md#mcp) for the centralized progress model across console, hosted sessions, Spectre, and MCP:
 
 ```csharp

--- a/docs/output-system.md
+++ b/docs/output-system.md
@@ -106,7 +106,7 @@ In interactive mode, when ANSI is supported, JSON output is syntax-highlighted a
 
 ## Paging
 
-Human terminal formats (`human` and `spectre`) can use the integrated result pager when rendered output exceeds the visible row capacity. The pager is never used for redirected stdout, protocol passthrough, MCP/programmatic execution, or machine formats.
+Human terminal formats (`human` and `spectre`) can use the integrated result pager when rendered output exceeds the visible row capacity or a result-flow page source has more data. The pager is never used for redirected stdout, protocol passthrough, MCP/programmatic execution, or machine formats.
 
 Paged handler results should return `ReplPage<T>` through `IReplPagingContext`. JSON serializes these as `{ items, pageInfo }`; human and Spectre formats render the current page plus continuation metadata.
 

--- a/docs/output-system.md
+++ b/docs/output-system.md
@@ -2,6 +2,8 @@
 
 The output system controls how command results are serialized and rendered to the user. It supports multiple built-in formats, custom transformers, ANSI detection, and banner rendering.
 
+Large result flow and paging are documented separately in [Result Flow And Paging](result-flow.md).
+
 ## Format Selection Precedence
 
 The active output format is resolved in this order:
@@ -102,7 +104,14 @@ The output width used for wrapping and table layout is resolved as:
 
 In interactive mode, when ANSI is supported, JSON output is syntax-highlighted automatically. This applies only to the `json` format rendered to a terminal — redirected or non-ANSI output remains plain.
 
+## Paging
+
+Human terminal formats (`human` and `spectre`) can use the integrated result pager when rendered output exceeds the visible row capacity. The pager is never used for redirected stdout, protocol passthrough, MCP/programmatic execution, or machine formats.
+
+Paged handler results should return `ReplPage<T>` through `IReplPagingContext`. JSON serializes these as `{ items, pageInfo }`; human and Spectre formats render the current page plus continuation metadata.
+
 ## See Also
 
 - [Configuration Reference](configuration-reference.md) — `OutputOptions` properties.
 - [Execution Pipeline](execution-pipeline.md) — output formatting occurs at stage 11.
+- [Result Flow And Paging](result-flow.md) - paging contracts, CLI flags, and MCP behavior.

--- a/docs/result-flow.md
+++ b/docs/result-flow.md
@@ -589,6 +589,10 @@ MCP tools expose two reserved input properties on every tool schema:
 | `_replPageSize` | Requested page size for the tool call. |
 
 These properties are consumed by the Repl MCP adapter and mapped to `IReplPagingContext`. They are not forwarded as command business options.
+MCP cursors are expected to be compact opaque values, for example base64url or
+another whitespace-free token. Repl rejects cursors that contain whitespace,
+start with `-`, or exceed 512 characters before they can be converted to CLI
+tokens.
 
 When a handler returns `ReplPage<T>`, MCP returns:
 

--- a/docs/result-flow.md
+++ b/docs/result-flow.md
@@ -392,6 +392,74 @@ Result-flow flags are global and use the `--result:` prefix so they do not colli
 input are available, then falls back to the simple `more` behavior in limited
 terminals.
 
+## Advanced: Source Paging Vs Output Paging
+
+Result flow has two different paging layers. They are related, but they solve
+different problems:
+
+| Layer | What it pages | Who controls it | Why it exists |
+|---|---|---|---|
+| Source paging | Data items fetched by the handler or `IReplPageSource<T>` | The handler/source through `ReplPageRequest.PageSize` and `Cursor` | Avoid loading too many rows, expensive API calls, or unsafe memory growth. |
+| Output paging | Rendered terminal lines already produced for human display | The interactive pager through `--result:pager` and terminal height | Avoid flooding the user's screen and provide navigation. |
+
+Source paging happens before output formatting. Output paging happens after
+formatting. A single data item can become zero, one, or many output lines,
+depending on the formatter, terminal width, ANSI/Spectre rendering, wrapping,
+and object shape.
+
+For example, this source returns data pages:
+
+```csharp
+app.Map("activity", (IReplPagingContext paging, ActivityStore store) =>
+    paging.CreateSource<ActivityRow>(async (request, ct) =>
+    {
+        var page = await store.QueryAsync(
+            cursor: request.Cursor,
+            take: request.PageSize,
+            ct);
+
+        return request.Page(
+            page.Items,
+            nextCursor: page.NextCursor,
+            totalCount: page.TotalCount);
+    }));
+```
+
+The source decides how many rows to fetch. The output pager decides how many
+rendered lines to show before prompting:
+
+```bash
+myapp activity --result:page-size=100 --result:pager=more
+```
+
+This means:
+
+- Repl asks the source for up to 100 `ActivityRow` items at a time.
+- The human formatter turns those rows into a table.
+- The `more` pager shows only the visible rendered lines, then waits for input.
+- If the user pages past the buffered rows, Repl fetches the next source page
+  using the source cursor.
+
+Do not use output paging as a substitute for source paging. Returning a
+100,000-row list and relying on the pager still allocates and formats the whole
+list before the user sees the first screen. Use `IReplPageSource<T>` or
+`ReplPage<T>` whenever the data source can page efficiently.
+
+Do not use source paging as a substitute for output paging either. A source page
+of 20 objects can still produce hundreds of terminal lines if rows contain long
+strings, nested collections, or narrow-column wrapping. Human terminal output
+still benefits from `auto`, `more`, `inline`, or `full`.
+
+Rules of thumb:
+
+- Tune `--result:page-size` for data-source cost, API limits, and memory safety.
+- Tune `--result:pager` for terminal UX.
+- Use `VisibleRowCapacityHint` only as a best-effort hint; it is not the same as
+  `PageSize` and is not a hard display contract.
+- For machine outputs, source paging still matters, but output paging is off.
+- For redirected output, Repl writes normal stdout and lets tools such as
+  `less`, `grep`, `tail`, or `jq` handle downstream paging/filtering.
+
 ## CLI And Pipe Behavior
 
 The integrated pager only applies to human terminal formats:

--- a/docs/result-flow.md
+++ b/docs/result-flow.md
@@ -386,12 +386,11 @@ Result-flow flags are global and use the `--result:` prefix so they do not colli
 | `--result:page-size <n>` or `--result:page-size=<n>` | Requested page size. Clamped to `ResultFlowOptions.MaxPageSize`. |
 | `--result:cursor <value>` or `--result:cursor=<value>` | Opaque continuation cursor. |
 | `--result:all` | Signals that the caller wants all rows. Bounded helpers such as `FromItems` can honor it; unbounded helpers such as `FromOffset` and `FromAsyncEnumerable` reject it by default. |
-| `--result:pager=auto\|off\|more\|scroll\|external` | Pager preference for human formats. |
+| `--result:pager=auto\|off\|more\|inline\|full` | Pager preference for human formats. |
 
-`auto` uses a `less`-style alternate-screen viewport when ANSI rendering and key
+`auto` uses the full-screen alternate-buffer pager when ANSI rendering and key
 input are available, then falls back to the simple `more` behavior in limited
-terminals. `external` is accepted as a forward-compatible mode and currently
-falls back to the integrated pager.
+terminals.
 
 ## CLI And Pipe Behavior
 
@@ -436,21 +435,29 @@ Supported keys:
 |---|---|
 | `Space` / `PageDown` / any unhandled key | Continue to the next screen, fetching the next data page when needed. |
 | `Enter` / `DownArrow` | Next line. |
-| `UpArrow` | Re-display one previous line window. |
-| `PageUp` | Re-display previous page window. |
+| `UpArrow` | Move up in `full` and `inline`; ignored by `more`. |
+| `PageUp` | Move up one page in `full` and `inline`; ignored by `more`. |
 | `q` / `Esc` | Quit paging. |
 
 The integrated pager has two render paths:
 
-- `more` fallback: writes page by page in the normal terminal buffer and never
-  uses cursor movement.
-- `scroll` viewport: enters the terminal alternate screen, keeps an internal
-  line buffer, redraws a viewport explicitly, and leaves the original scrollback
+- `more` fallback: writes page by page in the normal terminal buffer, never
+  uses cursor movement, and only moves forward.
+- `inline` viewport: redraws a controlled region in the normal terminal buffer
+  with ANSI cursor movement.
+- `full` viewport: enters the terminal alternate screen, keeps an internal line
+  buffer, redraws a viewport explicitly, and leaves the original scrollback
   untouched when the user exits.
 
-The scroll viewport is inspired by `less`: it does not depend on terminal
+The full viewport is inspired by `less`: it does not depend on terminal
 scrollback. It renders from an internal buffer and fetches additional
 `IReplPageSource<T>` payloads as the user pages past the buffered end.
+
+Applications that need a different terminal experience can register a custom
+`IReplPagerRenderer` in `options.Output.ResultFlow.PagerRenderers`. A custom
+renderer is selected by its `ReplPagerMode` and receives a
+`ReplPagerRenderContext` containing the rendered payload, terminal writer, key
+reader, visible row hint, and continuation fetcher.
 
 ## Testing Result Flow
 

--- a/docs/result-flow.md
+++ b/docs/result-flow.md
@@ -356,6 +356,7 @@ JSON output uses a clean automation envelope:
 
 ```json
 {
+  "$type": "page",
   "items": [
     { "id": 1, "name": "Alice" }
   ],
@@ -581,8 +582,8 @@ These properties are consumed by the Repl MCP adapter and mapped to `IReplPaging
 
 When a handler returns `ReplPage<T>`, MCP returns:
 
-- `StructuredContent`: the full `{ items, pageInfo }` envelope.
-- `Content`: a short text summary such as `Returned 1 item(s). Total: 2. Continue with _replCursor=page-2.`
+- `StructuredContent`: the full `{ "$type": "page", items, pageInfo }` envelope.
+- `Content`: a short text summary such as `Returned 1 item(s). Total: 2. Continue with _replCursor; cursor available in structured content.`
 
 This keeps agents from receiving a giant JSON string in `TextContentBlock` while still preserving structured data for clients that support it.
 

--- a/docs/result-flow.md
+++ b/docs/result-flow.md
@@ -194,6 +194,9 @@ app.Options(options =>
 
 ## See Also
 
+- [Core Basics sample](../samples/01-core-basics/README.md#result-flow-paging)
+- [Spectre sample](../samples/07-spectre/README.md#activity--paged-long-data-source)
+- [MCP Server sample](../samples/08-mcp-server/README.md#demo-workflow)
 - [Output System](output-system.md)
 - [Command Reference](commands.md)
 - [MCP Reference](mcp-reference.md)

--- a/docs/result-flow.md
+++ b/docs/result-flow.md
@@ -383,7 +383,10 @@ Result-flow flags are global and use the `--result:` prefix so they do not colli
 | `--result:all` | Signals that the caller wants all rows. Bounded helpers such as `FromItems` can honor it; unbounded helpers such as `FromOffset` and `FromAsyncEnumerable` reject it by default. |
 | `--result:pager=auto|off|more|scroll|external` | Pager preference for human formats. |
 
-Current pager behavior is implemented by the integrated pager. `external` is accepted as a forward-compatible mode and currently falls back to the integrated pager.
+`auto` uses a `less`-style alternate-screen viewport when ANSI rendering and key
+input are available, then falls back to the simple `more` behavior in limited
+terminals. `external` is accepted as a forward-compatible mode and currently
+falls back to the integrated pager.
 
 ## CLI And Pipe Behavior
 
@@ -432,14 +435,17 @@ Supported keys:
 | `PageUp` | Re-display previous page window. |
 | `q` / `Esc` | Quit paging. |
 
-The v1 pager is intentionally conservative. It is closer to `more` than a full-screen `less`: it does not own an alternate screen, does not search, and does not launch external processes.
+The integrated pager has two render paths:
 
-`less` feels different because it owns an interactive viewport over the already
-rendered stream. Repl's integrated pager currently writes through the normal
-scrollback buffer so the output remains copyable and pipe-friendly. A future
-full-screen pager can be layered on top of the same `IReplPageSource<T>` contract,
-but it should remain opt-in because alternate-screen behavior is surprising in
-automation, logs, and hosted transports.
+- `more` fallback: writes page by page in the normal terminal buffer and never
+  uses cursor movement.
+- `scroll` viewport: enters the terminal alternate screen, keeps an internal
+  line buffer, redraws a viewport explicitly, and leaves the original scrollback
+  untouched when the user exits.
+
+The scroll viewport is inspired by `less`: it does not depend on terminal
+scrollback. It renders from an internal buffer and fetches additional
+`IReplPageSource<T>` payloads as the user pages past the buffered end.
 
 ## Testing Result Flow
 

--- a/docs/result-flow.md
+++ b/docs/result-flow.md
@@ -205,10 +205,11 @@ app.Map("events", (EventStore store) =>
 ```
 
 `FromAsyncEnumerable` passes the request cancellation token to the stream factory
-and uses `WithCancellation(...)` while enumerating. It requires a replayable
-factory because later pages reopen the stream and skip to the requested offset.
-For live streams that cannot restart, emit a keyset/range cursor instead or use
-a future live/tail-oriented API.
+and uses `WithCancellation(...)` while enumerating. It requires a replayable,
+idempotent, and deterministic factory because later pages reopen the stream and
+skip to the requested offset. For live streams or changing result sets that
+cannot restart with the same ordering and contents, emit a keyset/range cursor
+instead or use a future live/tail-oriented API.
 
 Do not pass a channel, database cursor, network cursor, or shared enumerator
 instance to `FromAsyncEnumerable`. Those are single-use streams. Use
@@ -592,7 +593,8 @@ These properties are consumed by the Repl MCP adapter and mapped to `IReplPaging
 MCP cursors are expected to be compact opaque values, for example base64url or
 another whitespace-free token. Repl rejects cursors that contain whitespace,
 start with `-`, or exceed 512 characters before they can be converted to CLI
-tokens.
+tokens. MCP page-size values must be numeric and at most 20 characters before
+normal result-flow clamping is applied.
 
 When a handler returns `ReplPage<T>`, MCP returns:
 

--- a/docs/result-flow.md
+++ b/docs/result-flow.md
@@ -1,0 +1,200 @@
+# Result Flow And Paging
+
+Result flow is the layer between handler execution and output formatting. It lets commands avoid returning unbounded result sets, gives handlers a page-size hint, and lets each output surface choose the safest delivery behavior.
+
+This is separate from output format selection. `--json`, `--human`, `--spectre`, and other formats still control serialization and rendering. Result flow controls how much data is returned and whether an interactive pager is used.
+
+## Goals
+
+- Avoid flooding terminal output with very large handler results.
+- Preserve Unix pipe behavior: `| less`, `| more`, `| grep`, `| tail`, and file redirection must receive normal stdout data.
+- Give handlers enough context to page at the source instead of loading everything.
+- Return MCP results as small, structured pages instead of huge text blocks.
+- Keep `Repl.Core` dependency-free and let richer packages such as `Repl.Spectre` adapt the same contracts.
+
+## Handler Paging Context
+
+Handlers can request `IReplPagingContext` as an injected parameter:
+
+```csharp
+app.Map("contacts", async (IReplPagingContext paging, ContactStore store, CancellationToken ct) =>
+{
+    var rows = await store.QueryAsync(
+        cursor: paging.Cursor,
+        take: paging.SuggestedPageSize,
+        ct);
+
+    return paging.Page(
+        rows.Items,
+        nextCursor: rows.NextCursor,
+        totalCount: rows.TotalCount);
+});
+```
+
+The context exposes:
+
+| Member | Meaning |
+|---|---|
+| `VisibleRowCapacityHint` | Best-effort number of data rows the current surface can show. Null for redirected/programmatic surfaces. |
+| `SuggestedPageSize` | Page size after applying caller options, terminal hints, and `ResultFlowOptions.MaxPageSize`. |
+| `MaxPageSize` | Application maximum page size. |
+| `Cursor` | Opaque continuation cursor supplied by the caller. |
+| `AllRequested` | True when the caller passed `--result:all`. Handlers decide whether to honor it. |
+| `Surface` | `Console`, `Interactive`, `Hosted`, `Redirected`, or `Programmatic`. |
+| `Page<T>(...)` | Creates a `ReplPage<T>` result. |
+| `CreateSource<T>(...)` | Creates an `IReplPageSource<T>` for renderer-driven future paging. |
+
+`VisibleRowCapacityHint` is a hint, not a contract. Handlers may use it to tune `take`, but should still enforce their own data-source limits.
+
+## Result Page Shape
+
+`ReplPage<T>` contains:
+
+- `Items`: the current page.
+- `PageInfo.Cursor`: cursor used for the current page.
+- `PageInfo.NextCursor`: cursor for the next page.
+- `PageInfo.TotalCount`: optional total count.
+- `PageInfo.PageSize`: effective page size.
+- `PageInfo.HasMore`: true when `NextCursor` is present.
+
+JSON output uses a clean automation envelope:
+
+```json
+{
+  "items": [
+    { "id": 1, "name": "Alice" }
+  ],
+  "pageInfo": {
+    "cursor": "start",
+    "nextCursor": "page-2",
+    "totalCount": 42,
+    "pageSize": 1,
+    "hasMore": true
+  }
+}
+```
+
+The technical properties used by the renderer, such as `ItemType` and `UntypedItems`, are not serialized.
+
+## CLI Flags
+
+Result-flow flags are global and use the `--result:` prefix so they do not collide with command options such as `--limit` or `--cursor`.
+
+| Flag | Meaning |
+|---|---|
+| `--result:page-size <n>` or `--result:page-size=<n>` | Requested page size. Clamped to `ResultFlowOptions.MaxPageSize`. |
+| `--result:cursor <value>` or `--result:cursor=<value>` | Opaque continuation cursor. |
+| `--result:all` | Signals that the caller wants all rows. Handler decides whether this is allowed. |
+| `--result:pager=auto|off|more|scroll|external` | Pager preference for human formats. |
+
+Current pager behavior is implemented by the integrated pager. `external` is accepted as a forward-compatible mode and currently falls back to the integrated pager.
+
+## CLI And Pipe Behavior
+
+The integrated pager only applies to human terminal formats:
+
+- `human`
+- `spectre`
+
+It does not apply to machine formats:
+
+- `json`
+- `xml`
+- `yaml`
+- `markdown`
+
+It also does not apply when stdout is redirected, when input cannot read keys, in MCP/programmatic execution, or during protocol passthrough.
+
+This preserves standard shell behavior:
+
+```bash
+myapp contacts --human | less
+myapp contacts --json | jq '.items[]'
+myapp contacts --human | grep Alice
+myapp contacts --human | tail -20
+```
+
+In those cases Repl writes the normal output stream and lets the receiving Unix tool do the paging/filtering.
+
+## Integrated Pager
+
+The integrated pager activates automatically when:
+
+- the selected format is `human` or `spectre`;
+- output is an interactive terminal or hosted session with key input;
+- the rendered payload has more lines than the visible row capacity;
+- pager mode is not `off`.
+
+Supported keys:
+
+| Key | Behavior |
+|---|---|
+| `Space` / `PageDown` / any unhandled key | Next page. |
+| `Enter` / `DownArrow` | Next line. |
+| `UpArrow` | Re-display one previous line window. |
+| `PageUp` | Re-display previous page window. |
+| `q` / `Esc` | Quit paging. |
+
+The v1 pager is intentionally conservative. It is closer to `more` than a full-screen `less`: it does not own an alternate screen, does not search, and does not launch external processes.
+
+## MCP Behavior
+
+MCP tools expose two reserved input properties on every tool schema:
+
+| Property | Meaning |
+|---|---|
+| `_replCursor` | Continuation cursor from a previous paged result. |
+| `_replPageSize` | Requested page size for the tool call. |
+
+These properties are consumed by the Repl MCP adapter and mapped to `IReplPagingContext`. They are not forwarded as command business options.
+
+When a handler returns `ReplPage<T>`, MCP returns:
+
+- `StructuredContent`: the full `{ items, pageInfo }` envelope.
+- `Content`: a short text summary such as `Returned 1 item(s). Total: 2. Continue with _replCursor=page-2.`
+
+This keeps agents from receiving a giant JSON string in `TextContentBlock` while still preserving structured data for clients that support it.
+
+## Spectre Behavior
+
+`Repl.Spectre` renders `ReplPage<T>` with the same lightweight Spectre table style used for collections, followed by continuation metadata. The core paging contract remains framework-neutral; handlers do not need Spectre-specific code.
+
+The integrated pager still owns the final rendered text. Spectre live/full-screen surfaces should continue to capture or redirect regular Repl feedback as documented in [interaction.md](interaction.md#spectre-and-screen-ownership).
+
+## Configuration
+
+Configure through `ReplOptions.Output.ResultFlow`:
+
+```csharp
+app.Options(options =>
+{
+    options.Output.ResultFlow.DefaultPageSize = 100;
+    options.Output.ResultFlow.MaxPageSize = 1000;
+    options.Output.ResultFlow.ReservedVisibleRows = 2;
+    options.Output.ResultFlow.DefaultPagerMode = ReplPagerMode.Auto;
+    options.Output.ResultFlow.ProgrammaticMaxInlineBytes = 64 * 1024;
+});
+```
+
+| Option | Default | Meaning |
+|---|---:|---|
+| `DefaultPageSize` | `100` | Used when no caller or terminal hint provides a better size. |
+| `MaxPageSize` | `1000` | Maximum accepted page size. |
+| `ReservedVisibleRows` | `2` | Rows reserved for prompts/status when computing visible data rows. |
+| `DefaultPagerMode` | `Auto` | Default pager behavior for human formats. |
+| `ProgrammaticMaxInlineBytes` | `65536` | Reserved for programmatic inline-size policy. |
+
+## Implementation Notes
+
+- Existing handlers that return `IEnumerable<T>` keep their current behavior.
+- Handlers that can page efficiently should request `IReplPagingContext` and return `ReplPage<T>`.
+- `IReplPageSource<T>` is available for renderer-driven paging providers; current renderers use explicit `ReplPage<T>` results.
+- `--result:all` is advisory. Handlers should reject or cap it when the data source cannot safely return everything.
+- The pager operates after formatting. It does not fetch additional data pages by itself in v1.
+
+## See Also
+
+- [Output System](output-system.md)
+- [Command Reference](commands.md)
+- [MCP Reference](mcp-reference.md)
+- [Interaction](interaction.md)

--- a/docs/result-flow.md
+++ b/docs/result-flow.md
@@ -380,6 +380,8 @@ The technical properties used by the renderer, such as `ItemType` and `UntypedIt
 ## CLI Flags
 
 Result-flow flags are global and use the `--result:` prefix so they do not collide with command options such as `--limit` or `--cursor`.
+The reserved names are also exposed in `ReplResultFlowOptionNames` so hosts can
+avoid collisions when composing custom command surfaces.
 
 | Flag | Meaning |
 |---|---|
@@ -684,6 +686,9 @@ When a handler returns `ReplPage<T>`, MCP returns:
 - `Content`: a short text summary such as `Returned 1 item(s). Total: 2. Continue with _replCursor; cursor available in structured content.`
 
 This keeps agents from receiving a giant JSON string in `TextContentBlock` while still preserving structured data for clients that support it.
+Agents that preserve `StructuredContent` can continue by sending `_replCursor`
+with the value from `pageInfo.nextCursor`. Agents that only read text receive a
+safe fallback summary, but Repl does not place the raw cursor in text content.
 
 ## Spectre Behavior
 

--- a/docs/result-flow.md
+++ b/docs/result-flow.md
@@ -46,6 +46,301 @@ The context exposes:
 
 `VisibleRowCapacityHint` is a hint, not a contract. Handlers may use it to tune `take`, but should still enforce their own data-source limits.
 
+For interactive human output, prefer a page source when the data source can fetch
+later pages. The integrated pager can then continue in the same command run
+instead of asking the user to rerun with a cursor.
+
+For in-memory data:
+
+```csharp
+app.Map("contacts", (ContactStore store) =>
+    ReplPageSource.FromItems(store.List()));
+```
+
+For offset-based stores:
+
+```csharp
+app.Map("contacts", (ContactStore store) =>
+    ReplPageSource.FromOffset<ContactRow>(
+        (offset, take, ct) => store.QueryAsync(offset, take, ct),
+        totalCount: store.Count));
+```
+
+For replayable async streams:
+
+```csharp
+app.Map("logs", (LogStore store) =>
+    ReplPageSource.FromAsyncEnumerable(ct => store.StreamAsync(ct)));
+```
+
+Helpers also have state overloads so handlers can use static lambdas instead of
+capturing local variables:
+
+```csharp
+app.Map("contacts", (ContactStore store) =>
+    ReplPageSource.FromOffset<ContactRow, ContactStore>(
+        store,
+        static (state, offset, take, ct) => state.QueryAsync(offset, take, ct),
+        totalCount: store.Count));
+```
+
+When a data source cannot apply a filter server-side, helpers can apply a
+client-side filter before the final page is emitted:
+
+```csharp
+app.Map("contacts", (ContactStore store, string search) =>
+    ReplPageSource.FromOffset<ContactRow, ContactStore>(
+        store,
+        static (state, offset, take, ct) => state.QueryAsync(offset, take, ct),
+        filter: (_, row) => row.Name.Contains(search, StringComparison.OrdinalIgnoreCase)));
+```
+
+Client-side filtering is a fallback, not the preferred path. Repl may fetch and
+discard source rows while it fills one visible page, and the true filtered total
+count is usually unknown unless the handler computes it separately. Prefer
+pushing filters, search terms, tenant constraints, and sorting into the data
+source whenever possible.
+
+For opaque cursors, API tokens, and keyset paging, use `CreateSource<T>(...)`:
+
+```csharp
+app.Map("contacts", (IReplPagingContext paging, ContactStore store) =>
+    paging.CreateSource<ContactRow>(async (request, ct) =>
+    {
+        var rows = await store.QueryAsync(
+            cursor: request.Cursor,
+            take: request.PageSize,
+            ct);
+
+        return request.Page(
+            rows.Items,
+            nextCursor: rows.NextCursor,
+            totalCount: rows.TotalCount);
+    }));
+```
+
+## Cursor Basics
+
+A cursor is an opaque bookmark owned by the handler. Repl does not interpret it.
+The handler consumes `request.Cursor` or `paging.Cursor`, and emits the next
+bookmark as `nextCursor`.
+
+The contract is:
+
+```csharp
+var currentCursor = request.Cursor;       // consume
+var rows = await store.QueryAsync(currentCursor, request.PageSize, ct);
+return request.Page(rows.Items, rows.NextCursor, rows.TotalCount); // emit
+```
+
+Rules of thumb:
+
+- `null` or empty cursor means "first page".
+- `nextCursor: null` means "there is no next page".
+- `PageInfo.HasMore` is derived from `nextCursor` by the helpers.
+- Treat incoming cursors as untrusted input. Validate and bound them.
+- Prefer opaque, versioned cursor formats over exposing database internals.
+- Include filters/sort/snapshot information in the cursor when changing those values would make the bookmark unsafe.
+
+Use `ReplPage<T>` when the command returns one explicit page and expects callers
+to pass `--result:cursor` for the next page. Use `IReplPageSource<T>` when human
+users should continue interactively in the same run.
+
+## Pagination Mode Matrix
+
+| Mode | Cursor shape | What the handler/source needs | Best fit | Built-in helper |
+|---|---|---|---|---|
+| In-memory list | Offset string such as `25` | A bounded `IReadOnlyList<T>` | Samples, small cached data, tests | `ReplPageSource.FromItems(items)` |
+| Async enumerable | Offset string such as `25` | A replayable `IAsyncEnumerable<T>` factory and cancellation-aware enumeration | Streams from files, SDK pagers exposed as async streams, tests | `ReplPageSource.FromAsyncEnumerable(ct => source.StreamAsync(ct))` |
+| Offset/limit | Offset string such as `100` | Query by `offset` and `take`; ideally deterministic sort | SQL `Skip/Take`, search indexes, admin tables | `ReplPageSource.FromOffset((offset, take, ct) => ...)` |
+| Page index | Page number or zero-based index | Query by page index and page size; agreement on one-based vs zero-based | APIs that already expose page numbers | Custom `CreateSource<T>` |
+| Range/window | Encoded range, for example `2026-01-01..2026-01-31` | Stable ordering and a next range boundary | Time-series, logs, reporting windows | Custom `CreateSource<T>` |
+| Keyset/seek | Last sort key, often encoded JSON | Deterministic sort and unique tie-breaker | Large mutable tables | Custom `CreateSource<T>` |
+| Opaque cursor | Signed/encrypted bookmark | Cursor encoder/decoder and validation | Multi-tenant data, private filters, versioned cursors | Custom `CreateSource<T>` |
+| External API token | Provider page token | API client that accepts a page token and returns the next token | REST/Graph/Cloud SDK paging | Custom `CreateSource<T>` |
+| External nextLink | Provider URL | Validation that the URL belongs to the expected API | APIs that return full continuation links | Custom `CreateSource<T>` |
+| Snapshot cursor | Snapshot id plus offset/key | Snapshot creation and cleanup policy | Consistent reports over changing data | Custom `CreateSource<T>` |
+
+`FromOffset` and `FromAsyncEnumerable` fetch one extra matching item (`pageSize + 1`)
+to detect whether another page exists without requiring a total count. When a
+total is cheap and represents the final result set, pass it to `FromOffset` so
+human output can show "Showing x of y". If the total is expensive, unknown, or
+not meaningful for the current feed, leave it null.
+
+Offset-style helpers are intentionally simple. They re-read or re-skip from the
+start for later pages. For deep paging, mutable datasets, or live infinite
+streams, prefer keyset, range, or an external provider cursor. Live feeds that
+never finish are a separate use case; do not expose them through `--result:all`
+or an unbounded in-memory list.
+
+## Cursor Patterns
+
+### Offset Cursor
+
+Offset cursors are simple and work well for stable, append-only, or demo data.
+They are not ideal for frequently changing result sets because inserts/deletes
+can shift rows between requests.
+
+For a store that can query by offset and take:
+
+```csharp
+app.Map("events", (EventStore store) =>
+    ReplPageSource.FromOffset<EventRow>(
+        (offset, take, ct) => store.QueryAsync(offset, take, ct),
+        totalCount: store.Count));
+```
+
+For the common in-memory version:
+
+```csharp
+app.Map("events", (EventStore store) =>
+    ReplPageSource.FromItems(store.AllEvents));
+```
+
+For a replayable async stream:
+
+```csharp
+app.Map("events", (EventStore store) =>
+    ReplPageSource.FromAsyncEnumerable(ct => store.StreamAsync(ct)));
+```
+
+`FromAsyncEnumerable` passes the request cancellation token to the stream factory
+and uses `WithCancellation(...)` while enumerating. It requires a replayable
+factory because later pages reopen the stream and skip to the requested offset.
+For live streams that cannot restart, emit a keyset/range cursor instead or use
+a future live/tail-oriented API.
+
+When you author the async iterator, accept cancellation with
+`[EnumeratorCancellation]`:
+
+```csharp
+using System.Runtime.CompilerServices;
+
+public async IAsyncEnumerable<LogRow> StreamAsync(
+    [EnumeratorCancellation] CancellationToken ct = default)
+{
+    await foreach (var row in sdk.ReadLogsAsync(ct).WithCancellation(ct))
+    {
+        yield return row;
+    }
+}
+```
+
+### Keyset Cursor
+
+Keyset cursors are better for databases and changing result sets. The cursor
+contains the last row's sort key, not a row offset.
+
+```csharp
+using System.Text.Json;
+
+record EventCursor(DateTimeOffset CreatedAt, long Id);
+
+app.Map("events", (IReplPagingContext paging, EventDb db) =>
+    paging.CreateSource<EventRow>(async (request, ct) =>
+    {
+        var cursor = DecodeCursor(request.Cursor);
+        var query = db.Events.AsQueryable();
+
+        if (cursor is not null)
+        {
+            query = query.Where(e =>
+                e.CreatedAt > cursor.CreatedAt
+                || (e.CreatedAt == cursor.CreatedAt && e.Id > cursor.Id));
+        }
+
+        var rows = await query
+            .OrderBy(e => e.CreatedAt)
+            .ThenBy(e => e.Id)
+            .Take(request.PageSize)
+            .Select(e => new EventRow(e.Id, e.CreatedAt, e.Summary))
+            .ToListAsync(ct);
+
+        var nextCursor = rows.Count == request.PageSize
+            ? EncodeCursor(new EventCursor(rows[^1].CreatedAt, rows[^1].Id))
+            : null;
+
+        return request.Page(rows, nextCursor);
+    }));
+
+static string EncodeCursor(EventCursor cursor) =>
+    Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(cursor));
+
+static EventCursor? DecodeCursor(string? cursor) =>
+    string.IsNullOrWhiteSpace(cursor)
+        ? null
+        : JsonSerializer.Deserialize<EventCursor>(Convert.FromBase64String(cursor));
+```
+
+For production, consider signing or encrypting cursor payloads when they contain
+tenant ids, filters, or other sensitive data.
+
+### External API Page Token
+
+Many APIs already expose a page token. Pass Repl's cursor through to that API,
+then emit the API's next token.
+
+```csharp
+app.Map("incidents", (IReplPagingContext paging, IncidentApi api) =>
+    paging.CreateSource<IncidentRow>(async (request, ct) =>
+    {
+        var response = await api.SearchAsync(
+            pageSize: request.PageSize,
+            pageToken: request.Cursor,
+            ct);
+
+        return request.Page(
+            response.Items,
+            nextCursor: response.NextPageToken,
+            totalCount: response.TotalCount);
+    }));
+```
+
+### External API Next Link
+
+Some APIs return a full `nextLink` URL instead of a token. The cursor can be that
+link, as long as the handler validates that it belongs to the expected API.
+
+```csharp
+app.Map("messages", (IReplPagingContext paging, MailApi api) =>
+    paging.CreateSource<MessageRow>(async (request, ct) =>
+    {
+        var response = string.IsNullOrWhiteSpace(request.Cursor)
+            ? await api.ListMessagesAsync(request.PageSize, ct)
+            : await api.GetNextPageAsync(request.Cursor, ct);
+
+        return request.Page(response.Items, response.NextLink);
+    }));
+```
+
+### Snapshot Cursor
+
+When users expect a consistent report, include a snapshot id or timestamp in the
+cursor. The first request creates the snapshot, later requests continue inside it.
+
+```csharp
+record AuditCursor(string SnapshotId, int Offset);
+
+app.Map("audit", (IReplPagingContext paging, AuditStore store) =>
+    paging.CreateSource<AuditRow>(async (request, ct) =>
+    {
+        var cursor = DecodeAuditCursor(request.Cursor)
+            ?? new AuditCursor(await store.CreateSnapshotAsync(ct), Offset: 0);
+
+        var page = await store.ReadSnapshotAsync(
+            cursor.SnapshotId,
+            cursor.Offset,
+            request.PageSize,
+            ct);
+
+        var nextCursor = page.HasMore
+            ? EncodeAuditCursor(cursor with { Offset = cursor.Offset + page.Items.Count })
+            : null;
+
+        return request.Page(page.Items, nextCursor, page.TotalCount);
+    }));
+```
+
 ## Result Page Shape
 
 `ReplPage<T>` contains:
@@ -84,7 +379,7 @@ Result-flow flags are global and use the `--result:` prefix so they do not colli
 |---|---|
 | `--result:page-size <n>` or `--result:page-size=<n>` | Requested page size. Clamped to `ResultFlowOptions.MaxPageSize`. |
 | `--result:cursor <value>` or `--result:cursor=<value>` | Opaque continuation cursor. |
-| `--result:all` | Signals that the caller wants all rows. Handler decides whether this is allowed. |
+| `--result:all` | Signals that the caller wants all rows. Bounded helpers such as `FromItems` can honor it; unbounded helpers such as `FromOffset` and `FromAsyncEnumerable` reject it by default. |
 | `--result:pager=auto|off|more|scroll|external` | Pager preference for human formats. |
 
 Current pager behavior is implemented by the integrated pager. `external` is accepted as a forward-compatible mode and currently falls back to the integrated pager.
@@ -122,20 +417,156 @@ The integrated pager activates automatically when:
 
 - the selected format is `human` or `spectre`;
 - output is an interactive terminal or hosted session with key input;
-- the rendered payload has more lines than the visible row capacity;
+- the rendered payload has more lines than the visible row capacity, or an
+  `IReplPageSource<T>` reports another data page;
 - pager mode is not `off`.
 
 Supported keys:
 
 | Key | Behavior |
 |---|---|
-| `Space` / `PageDown` / any unhandled key | Next page. |
+| `Space` / `PageDown` / any unhandled key | Continue to the next screen, fetching the next data page when needed. |
 | `Enter` / `DownArrow` | Next line. |
 | `UpArrow` | Re-display one previous line window. |
 | `PageUp` | Re-display previous page window. |
 | `q` / `Esc` | Quit paging. |
 
 The v1 pager is intentionally conservative. It is closer to `more` than a full-screen `less`: it does not own an alternate screen, does not search, and does not launch external processes.
+
+`less` feels different because it owns an interactive viewport over the already
+rendered stream. Repl's integrated pager currently writes through the normal
+scrollback buffer so the output remains copyable and pipe-friendly. A future
+full-screen pager can be layered on top of the same `IReplPageSource<T>` contract,
+but it should remain opt-in because alternate-screen behavior is surprising in
+automation, logs, and hosted transports.
+
+## Testing Result Flow
+
+Test the cursor contract first. A page source can be exercised without a console:
+
+```csharp
+[TestMethod]
+public async Task Contacts_ArePagedByCursor()
+{
+    var source = ReplPageSource.FromItems([
+        new ContactRow(1, "Alice"),
+        new ContactRow(2, "Bob"),
+        new ContactRow(3, "Carla"),
+    ]);
+
+    var first = await source.FetchAsync(new ReplPageRequest(
+        PageSize: 2,
+        Cursor: null,
+        VisibleRowCapacityHint: null,
+        AllRequested: false,
+        Surface: ReplResultSurface.Programmatic));
+
+    var second = await source.FetchAsync(new ReplPageRequest(
+        PageSize: 2,
+        Cursor: first.PageInfo.NextCursor,
+        VisibleRowCapacityHint: null,
+        AllRequested: false,
+        Surface: ReplResultSurface.Programmatic));
+
+    first.Items.Select(c => c.Name).Should().Equal("Alice", "Bob");
+    first.PageInfo.NextCursor.Should().Be("2");
+    second.Items.Select(c => c.Name).Should().Equal("Carla");
+    second.PageInfo.HasMore.Should().BeFalse();
+}
+```
+
+For CLI JSON, assert the automation envelope:
+
+```csharp
+var output = CaptureConsole(() =>
+    app.Run([
+        "contacts",
+        "--json",
+        "--result:page-size=2",
+        "--no-logo",
+    ]));
+
+var page = JsonSerializer.Deserialize<PageEnvelope<ContactRow>>(output.Text);
+page!.Items.Should().HaveCount(2);
+page.PageInfo.NextCursor.Should().NotBeNull();
+
+public sealed record PageEnvelope<T>(
+    IReadOnlyList<T> Items,
+    ReplPageInfo PageInfo);
+```
+
+For MCP, call the generated tool twice. MCP uses `_replPageSize` and
+`_replCursor`, and returns `pageInfo` in structured content:
+
+```csharp
+var first = await mcpClient.CallToolAsync(
+    "contacts",
+    new Dictionary<string, object?>(StringComparer.Ordinal)
+    {
+        ["_replPageSize"] = 2,
+    });
+
+var firstRoot = first.StructuredContent!.Value;
+var nextCursor = firstRoot
+    .GetProperty("pageInfo")
+    .GetProperty("nextCursor")
+    .GetString();
+
+var second = await mcpClient.CallToolAsync(
+    "contacts",
+    new Dictionary<string, object?>(StringComparer.Ordinal)
+    {
+        ["_replPageSize"] = 2,
+        ["_replCursor"] = nextCursor,
+    });
+
+second.StructuredContent!.Value
+    .GetProperty("pageInfo")
+    .GetProperty("cursor")
+    .GetString()
+    .Should().Be(nextCursor);
+```
+
+For Spectre CLI output, use the same command surface with the Spectre renderer
+enabled. Assert content and, when ANSI is enabled, styling:
+
+```csharp
+var app = ReplApp.Create(services => services.AddSpectreConsole())
+    .UseSpectreConsole();
+
+app.Map("contacts", () => ReplPageSource.FromItems(rows));
+
+var output = CaptureConsole(() =>
+    app.Run([
+        "contacts",
+        "--spectre",
+        "--result:page-size=2",
+        "--result:pager=off",
+        "--no-logo",
+    ]));
+
+output.Text.Should().Contain("Alice");
+output.Text.Should().Contain("Next data page:");
+```
+
+For a Spectre TUI command, use Spectre prompts for selection workflows rather
+than the result-flow pager. `SelectionPrompt<T>` and `MultiSelectionPrompt<T>`
+support `.PageSize(...)` and `.MoreChoicesText(...)`, which is useful for
+choosing an item from a page:
+
+```csharp
+var selected = AnsiConsole.Prompt(
+    new SelectionPrompt<ContactRow>()
+        .Title("Select a contact")
+        .PageSize(10)
+        .MoreChoicesText("[grey](Use arrows to see more contacts)[/]")
+        .UseConverter(c => $"[bold]{c.Name}[/] [grey]{c.Email}[/]")
+        .AddChoices(page.Items));
+```
+
+Use Spectre `Live(...)` for dashboards or dynamic refreshes. It is not a
+replacement for a `less`-style pager, but it is a good fit for a TUI screen that
+owns its render area.
 
 ## MCP Behavior
 
@@ -157,7 +588,7 @@ This keeps agents from receiving a giant JSON string in `TextContentBlock` while
 
 ## Spectre Behavior
 
-`Repl.Spectre` renders `ReplPage<T>` with the same lightweight Spectre table style used for collections, followed by continuation metadata. The core paging contract remains framework-neutral; handlers do not need Spectre-specific code.
+`Repl.Spectre` renders `ReplPage<T>` with the same lightweight Spectre table style used for collections, followed by continuation metadata when the output is not being driven by the interactive pager. The core paging contract remains framework-neutral; handlers do not need Spectre-specific code.
 
 The integrated pager still owns the final rendered text. Spectre live/full-screen surfaces should continue to capture or redirect regular Repl feedback as documented in [interaction.md](interaction.md#spectre-and-screen-ownership).
 
@@ -188,9 +619,10 @@ app.Options(options =>
 
 - Existing handlers that return `IEnumerable<T>` keep their current behavior.
 - Handlers that can page efficiently should request `IReplPagingContext` and return `ReplPage<T>`.
-- `IReplPageSource<T>` is available for renderer-driven paging providers; current renderers use explicit `ReplPage<T>` results.
-- `--result:all` is advisory. Handlers should reject or cap it when the data source cannot safely return everything.
-- The pager operates after formatting. It does not fetch additional data pages by itself in v1.
+- Handlers that want human users to continue without rerunning the command should return `IReplPageSource<T>`.
+- Non-interactive and machine outputs fetch the first source page and preserve the continuation cursor in the rendered page metadata.
+- `--result:all` is advisory. Handlers should reject or cap it when the data source cannot safely return everything; built-in unbounded page-source helpers reject it by default.
+- The pager operates after formatting for line navigation, and can fetch additional data pages when the handler returns `IReplPageSource<T>`.
 
 ## See Also
 

--- a/docs/result-flow.md
+++ b/docs/result-flow.md
@@ -522,10 +522,16 @@ scrollback. It renders from an internal buffer and fetches additional
 `IReplPageSource<T>` payloads as the user pages past the buffered end.
 
 Applications that need a different terminal experience can register a custom
-`IReplPagerRenderer` in `options.Output.ResultFlow.PagerRenderers`. A custom
-renderer is selected by its `ReplPagerMode` and receives a
-`ReplPagerRenderContext` containing the rendered payload, terminal writer, key
-reader, visible row hint, and continuation fetcher.
+`IReplPagerRenderer` with
+`options.Output.ResultFlow.UsePagerRenderer(renderer)`. A custom renderer is
+selected by its `ReplPagerMode` and receives a `ReplPagerRenderContext`
+containing the rendered payload, terminal writer, key reader, visible row hint,
+and continuation fetcher.
+
+The built-in `inline` and `full` pagers keep a bounded in-memory line buffer.
+`MaxBufferedLines` defaults to `10_000`. When the limit is reached, Repl stops
+fetching additional pages, keeps navigation inside the known content, and shows
+a `buffer limit reached` status instead of growing memory indefinitely.
 
 ## Testing Result Flow
 
@@ -665,11 +671,12 @@ MCP tools expose two reserved input properties on every tool schema:
 | `_replPageSize` | Requested page size for the tool call. |
 
 These properties are consumed by the Repl MCP adapter and mapped to `IReplPagingContext`. They are not forwarded as command business options.
-MCP cursors are expected to be compact opaque values, for example base64url or
-another whitespace-free token. Repl rejects cursors that contain whitespace,
-start with `-`, or exceed 512 characters before they can be converted to CLI
-tokens. MCP page-size values must be numeric and at most 20 characters before
-normal result-flow clamping is applied.
+MCP and CLI cursors are expected to be compact opaque values, for example
+base64url or another whitespace-free token. Repl rejects cursors that are empty,
+contain whitespace or control characters, start with `-`, or exceed 512
+characters before they can be converted to CLI tokens. MCP page-size values must
+be numeric and at most 20 characters before normal result-flow clamping is
+applied.
 
 When a handler returns `ReplPage<T>`, MCP returns:
 
@@ -695,6 +702,7 @@ app.Options(options =>
     options.Output.ResultFlow.MaxPageSize = 1000;
     options.Output.ResultFlow.ReservedVisibleRows = 2;
     options.Output.ResultFlow.DefaultPagerMode = ReplPagerMode.Auto;
+    options.Output.ResultFlow.MaxBufferedLines = 10_000;
     options.Output.ResultFlow.ProgrammaticMaxInlineBytes = 64 * 1024;
 });
 ```
@@ -705,7 +713,24 @@ app.Options(options =>
 | `MaxPageSize` | `1000` | Maximum accepted page size. |
 | `ReservedVisibleRows` | `2` | Rows reserved for prompts/status when computing visible data rows. |
 | `DefaultPagerMode` | `Auto` | Default pager behavior for human formats. |
+| `MaxBufferedLines` | `10000` | Maximum content lines buffered by interactive viewport pagers. |
 | `ProgrammaticMaxInlineBytes` | `65536` | Reserved for programmatic inline-size policy. |
+
+Use `UsePagerRenderer(renderer)` to register one custom renderer per
+`ReplPagerMode`. Registering another renderer for the same mode replaces the
+previous one. `RemovePagerRenderer(mode)` and `ClearPagerRenderers()` are
+available for test setup or host-specific composition.
+
+## Diagnostics
+
+`Repl.Core` exposes `IReplResultFlowDiagnostics` for dependency-free paging
+diagnostics. Implementations receive page-fetch start, success, and failure
+events with cursor and page-size metadata.
+
+`Repl.Logging` registers a bridge automatically when `AddReplLogging()` is used:
+
+- `Debug`: page fetch starting/succeeded.
+- `Warning`: page fetch failed, including the exception.
 
 ## Implementation Notes
 

--- a/docs/result-flow.md
+++ b/docs/result-flow.md
@@ -747,6 +747,11 @@ events with cursor and page-size metadata.
 - `Debug`: page fetch starting/succeeded.
 - `Error`: page fetch failed, including the exception.
 
+Apps created through `ReplApp.Create()` or `AddRepl(...)` get this bridge by
+default through the defaults package. Apps built directly on `Repl.Core` remain
+dependency-free and can opt in by registering their own
+`IReplResultFlowDiagnostics` implementation.
+
 ## Implementation Notes
 
 - Existing handlers that return `IEnumerable<T>` keep their current behavior.

--- a/docs/result-flow.md
+++ b/docs/result-flow.md
@@ -386,7 +386,7 @@ Result-flow flags are global and use the `--result:` prefix so they do not colli
 | `--result:page-size <n>` or `--result:page-size=<n>` | Requested page size. Clamped to `ResultFlowOptions.MaxPageSize`. |
 | `--result:cursor <value>` or `--result:cursor=<value>` | Opaque continuation cursor. |
 | `--result:all` | Signals that the caller wants all rows. Bounded helpers such as `FromItems` can honor it; unbounded helpers such as `FromOffset` and `FromAsyncEnumerable` reject it by default. |
-| `--result:pager=auto|off|more|scroll|external` | Pager preference for human formats. |
+| `--result:pager=auto\|off\|more\|scroll\|external` | Pager preference for human formats. |
 
 `auto` uses a `less`-style alternate-screen viewport when ANSI rendering and key
 input are available, then falls back to the simple `more` behavior in limited

--- a/docs/result-flow.md
+++ b/docs/result-flow.md
@@ -665,14 +665,16 @@ owns its render area.
 
 ## MCP Behavior
 
-MCP tools expose two reserved input properties on every tool schema:
+Paged MCP tools expose two reserved input properties in their input schema:
 
 | Property | Meaning |
 |---|---|
 | `_replCursor` | Continuation cursor from a previous paged result. |
 | `_replPageSize` | Requested page size for the tool call. |
 
-These properties are consumed by the Repl MCP adapter and mapped to `IReplPagingContext`. They are not forwarded as command business options.
+These properties are emitted only for commands that accept `IReplPagingContext`
+or return a paged result. They are consumed by the Repl MCP adapter and mapped
+to `IReplPagingContext`; they are not forwarded as command business options.
 MCP and CLI cursors are expected to be compact opaque values, for example
 base64url or another whitespace-free token. Repl rejects cursors that are empty,
 contain whitespace or control characters, start with `-`, or exceed 512
@@ -681,17 +683,22 @@ be numeric and at most 10 characters before normal result-flow clamping is
 applied.
 MCP arguments are also validated against the generated tool schema before they
 are reconstructed as CLI tokens, so arbitrary JSON keys cannot inject global or
-result-flow options.
+result-flow options. Business argument values starting with `--` are rejected
+because those values would be ambiguous once Repl reconstructs CLI tokens.
 
 When a handler returns `ReplPage<T>`, MCP returns:
 
 - `StructuredContent`: the full `{ "$type": "page", items, pageInfo }` envelope.
-- `Content`: a short text summary such as `Returned 1 item(s). Total: 2. Continue with _replCursor; cursor available in structured content.`
+- `Content`: a configurable text fallback.
 
-This keeps agents from receiving a giant JSON string in `TextContentBlock` while still preserving structured data for clients that support it.
+By default, `Content` contains compact serialized JSON for compatibility with
+clients that ignore structured content. `ReplMcpServerOptions.PagedResultTextMode`
+can switch to `SummaryOnly` to reduce token cost, or `SummaryAndSerializedJson`
+for a diagnostic-friendly fallback.
 Agents that preserve `StructuredContent` can continue by sending `_replCursor`
-with the value from `pageInfo.nextCursor`. Agents that only read text receive a
-safe fallback summary, but Repl does not place the raw cursor in text content.
+with the value from `pageInfo.nextCursor`. Agents that only read text can still
+consume the first page when serialized JSON fallback is enabled, but automatic
+continuation depends on the client being able to reuse the cursor safely.
 
 ## Spectre Behavior
 

--- a/docs/result-flow.md
+++ b/docs/result-flow.md
@@ -677,8 +677,11 @@ MCP and CLI cursors are expected to be compact opaque values, for example
 base64url or another whitespace-free token. Repl rejects cursors that are empty,
 contain whitespace or control characters, start with `-`, or exceed 512
 characters before they can be converted to CLI tokens. MCP page-size values must
-be numeric and at most 20 characters before normal result-flow clamping is
+be numeric and at most 10 characters before normal result-flow clamping is
 applied.
+MCP arguments are also validated against the generated tool schema before they
+are reconstructed as CLI tokens, so arbitrary JSON keys cannot inject global or
+result-flow options.
 
 When a handler returns `ReplPage<T>`, MCP returns:
 
@@ -735,7 +738,7 @@ events with cursor and page-size metadata.
 `Repl.Logging` registers a bridge automatically when `AddReplLogging()` is used:
 
 - `Debug`: page fetch starting/succeeded.
-- `Warning`: page fetch failed, including the exception.
+- `Error`: page fetch failed, including the exception.
 
 ## Implementation Notes
 

--- a/docs/result-flow.md
+++ b/docs/result-flow.md
@@ -210,6 +210,10 @@ factory because later pages reopen the stream and skip to the requested offset.
 For live streams that cannot restart, emit a keyset/range cursor instead or use
 a future live/tail-oriented API.
 
+Do not pass a channel, database cursor, network cursor, or shared enumerator
+instance to `FromAsyncEnumerable`. Those are single-use streams. Use
+`ReplPageSource.Create(...)` and emit an opaque source-owned cursor instead.
+
 When you author the async iterator, accept cancellation with
 `[EnumeratorCancellation]`:
 

--- a/samples/01-core-basics/ActivityFeed.cs
+++ b/samples/01-core-basics/ActivityFeed.cs
@@ -1,0 +1,59 @@
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using Repl;
+
+sealed record ActivityEvent(
+	[property: Display(Name = "#", Order = 0)] int Id,
+	[property: Display(Name = "At", Order = 1)] string At,
+	[property: Display(Name = "Area", Order = 2)] string Area,
+	[property: Display(Name = "Event", Order = 3)] string Event,
+	[property: Display(Name = "Summary", Order = 4)] string Summary);
+
+internal sealed class ActivityFeed
+{
+	private readonly List<ActivityEvent> _items = CreateItems();
+
+	public ReplPage<ActivityEvent> Query(IReplPagingContext paging)
+	{
+		ArgumentNullException.ThrowIfNull(paging);
+
+		var offset = paging.AllRequested ? 0 : ParseOffset(paging.Cursor);
+		var items = paging.AllRequested
+			? _items
+			: _items.Skip(offset).Take(paging.SuggestedPageSize).ToList();
+
+		var nextOffset = offset + items.Count;
+		var nextCursor = !paging.AllRequested && nextOffset < _items.Count
+			? nextOffset.ToString(CultureInfo.InvariantCulture)
+			: null;
+
+		return paging.Page(items, nextCursor, _items.Count);
+	}
+
+	private static int ParseOffset(string? cursor) =>
+		int.TryParse(cursor, NumberStyles.None, CultureInfo.InvariantCulture, out var offset) && offset > 0
+			? offset
+			: 0;
+
+	private static List<ActivityEvent> CreateItems()
+	{
+		string[] areas = ["identity", "billing", "catalog", "search", "import", "reporting"];
+		string[] events = ["validated", "queued", "indexed", "exported", "reconciled", "notified"];
+		var start = new DateTimeOffset(2026, 1, 12, 8, 0, 0, TimeSpan.Zero);
+
+		return Enumerable.Range(1, 250)
+			.Select(i =>
+			{
+				var area = areas[(i - 1) % areas.Length];
+				var eventName = events[(i - 1) % events.Length];
+
+				return new ActivityEvent(
+					i,
+					start.AddMinutes(i * 7).ToString("yyyy-MM-dd HH:mm'Z'", CultureInfo.InvariantCulture),
+					area,
+					eventName,
+					$"{area} batch {((i - 1) / 5) + 1} {eventName} successfully");
+			})
+			.ToList();
+	}
+}

--- a/samples/01-core-basics/ActivityFeed.cs
+++ b/samples/01-core-basics/ActivityFeed.cs
@@ -38,7 +38,7 @@ internal sealed class ActivityFeed
 
 				return new ActivityEvent(
 					i,
-					start.AddMinutes(i * 7).ToString("yyyy-MM-dd HH:mm'Z'", CultureInfo.InvariantCulture),
+					start.AddMinutes(i * 7d).ToString("yyyy-MM-dd HH:mm'Z'", CultureInfo.InvariantCulture),
 					area,
 					eventName,
 					$"{area} batch {((i - 1) / 5) + 1} {eventName} successfully");

--- a/samples/01-core-basics/ActivityFeed.cs
+++ b/samples/01-core-basics/ActivityFeed.cs
@@ -13,27 +13,16 @@ internal sealed class ActivityFeed
 {
 	private readonly List<ActivityEvent> _items = CreateItems();
 
-	public ReplPage<ActivityEvent> Query(IReplPagingContext paging)
+	public IReplPageSource<ActivityEvent> Query(IReplPagingContext paging)
 	{
 		ArgumentNullException.ThrowIfNull(paging);
 
-		var offset = paging.AllRequested ? 0 : ParseOffset(paging.Cursor);
-		var items = paging.AllRequested
-			? _items
-			: _items.Skip(offset).Take(paging.SuggestedPageSize).ToList();
-
-		var nextOffset = offset + items.Count;
-		var nextCursor = !paging.AllRequested && nextOffset < _items.Count
-			? nextOffset.ToString(CultureInfo.InvariantCulture)
-			: null;
-
-		return paging.Page(items, nextCursor, _items.Count);
+		return ReplPageSource.FromOffset<ActivityEvent>(
+			(offset, take, _) =>
+				ValueTask.FromResult<IReadOnlyList<ActivityEvent>>(
+					_items.Skip(offset).Take(take).ToList()),
+			_items.Count);
 	}
-
-	private static int ParseOffset(string? cursor) =>
-		int.TryParse(cursor, NumberStyles.None, CultureInfo.InvariantCulture, out var offset) && offset > 0
-			? offset
-			: 0;
 
 	private static List<ActivityEvent> CreateItems()
 	{

--- a/samples/01-core-basics/Program.cs
+++ b/samples/01-core-basics/Program.cs
@@ -6,19 +6,21 @@ using Repl.Parameters;
 // - minimal CoreReplApp (no DI package)
 // - simple contact commands + metadata attributes
 var store = new ContactStore();
-var commands = new ContactCommands(store);
+var activityFeed = new ActivityFeed();
+var commands = new ContactCommands(store, activityFeed);
 
 var app = CoreReplApp.Create()
 	.WithDescription("Core basics sample: minimal contacts REPL without DI dependencies.")
 	.WithBanner("""
-		  Try: list, add Alice alice@test.com, show 1, count
-		  Also: error (exception handling), debug reset
+		  Try: list, add Alice alice@test.com, show 1, count, activity
+		  Also: activity --result:page-size=12, error (exception handling), debug reset
 		""");
 
 app.Map("list", commands.List);
 app.Map("add {name} {email:email}", commands.Add);
 app.Map("show {id:int}", commands.Show);
 app.Map("count", commands.Count);
+app.Map("activity", commands.Activity);
 app.Map("report period", commands.ReportPeriod);
 app.Map("error", ErrorCommand);
 app.Map("debug reset", commands.Reset);
@@ -28,7 +30,7 @@ return app.Run(args);
 static object ErrorCommand() =>
 	throw new ApplicationException("this is an error.");
 
-file sealed class ContactCommands(ContactStore store)
+file sealed class ContactCommands(ContactStore store, ActivityFeed activityFeed)
 {
 	[Description("List all contacts.")]
 	public List<Contact> List(SampleOutputOptions output)
@@ -56,6 +58,10 @@ file sealed class ContactCommands(ContactStore store)
 
 	[Description("Return the number of contacts.")]
 	public object Count() => Results.Success("Contact count.", store.Count());
+
+	[Description("Return a paged activity log generated from a long data source.")]
+	public ReplPage<ActivityEvent> Activity(IReplPagingContext paging) =>
+		activityFeed.Query(paging);
 
 	[Description("Render a date-only reporting period from a temporal range literal.")]
 	public string ReportPeriod(ReplDateRange period) =>

--- a/samples/01-core-basics/Program.cs
+++ b/samples/01-core-basics/Program.cs
@@ -60,7 +60,7 @@ file sealed class ContactCommands(ContactStore store, ActivityFeed activityFeed)
 	public object Count() => Results.Success("Contact count.", store.Count());
 
 	[Description("Return a paged activity log generated from a long data source.")]
-	public ReplPage<ActivityEvent> Activity(IReplPagingContext paging) =>
+	public IReplPageSource<ActivityEvent> Activity(IReplPagingContext paging) =>
 		activityFeed.Query(paging);
 
 	[Description("Render a date-only reporting period from a temporal range literal.")]

--- a/samples/01-core-basics/README.md
+++ b/samples/01-core-basics/README.md
@@ -35,6 +35,7 @@ Commands:
   add {name} {email}
   show {id}
   count
+  activity
 ```
 
 **Same commands, interactive**
@@ -87,7 +88,8 @@ myapp
 ├── list
 ├── add {name} {email}
 ├── show {id:int}
-└── count
+├── count
+└── activity
 ```
 
 - There is **no** `help` node in the graph.
@@ -120,6 +122,7 @@ app.Map("list", commands.List);
 app.Map("add {name} {email:email}", commands.Add);
 app.Map("show {id:int}", commands.Show);
 app.Map("count", commands.Count);
+app.Map("activity", commands.Activity);
 app.Map("report period", commands.ReportPeriod);
 app.Map("error", ErrorCommand);
 app.Map("debug reset", commands.Reset);
@@ -139,6 +142,7 @@ return app.Run(args);
   - `[Browsable(false)]` hides a command from discovery.
 - **Return values are semantic**:
   - `IEnumerable<Contact>` → table
+  - `ReplPage<ActivityEvent>` → paged table with continuation metadata
   - `Contact` → structured output (or JSON with `--json`)
   - `string` → plain text.
 
@@ -155,6 +159,7 @@ Commands:
   add {name} {email}
   show {id}
   count
+  activity
 ```
 
 ```text
@@ -197,6 +202,21 @@ Expected behavior:
 - `--format` and `--no-verbose` are provided by a shared options-group object.
 - `report period` accepts `start..end` and `start@duration`.
 - `ReplDateRange` accepts whole-day durations only.
+
+## Result-flow paging
+
+The `activity` command returns a synthetic long data source through
+`IReplPagingContext` and `ReplPage<T>`. The handler only returns the requested
+page, plus a continuation cursor when more rows exist.
+
+```text
+myapp activity --result:page-size=5
+myapp activity --result:page-size=5 --result:cursor=5
+myapp activity --json --result:page-size=2
+```
+
+Human output renders a compact table and a continuation hint. JSON output returns
+an `{ items, pageInfo }` envelope for automation.
 
 Validation example:
 

--- a/samples/01-core-basics/README.md
+++ b/samples/01-core-basics/README.md
@@ -142,7 +142,7 @@ return app.Run(args);
   - `[Browsable(false)]` hides a command from discovery.
 - **Return values are semantic**:
   - `IEnumerable<Contact>` → table
-  - `ReplPage<ActivityEvent>` → paged table with continuation metadata
+  - `IReplPageSource<ActivityEvent>` → paged table with interactive continuation
   - `Contact` → structured output (or JSON with `--json`)
   - `string` → plain text.
 
@@ -206,8 +206,10 @@ Expected behavior:
 ## Result-flow paging
 
 The `activity` command returns a synthetic long data source through
-`IReplPagingContext` and `ReplPage<T>`. The handler only returns the requested
-page, plus a continuation cursor when more rows exist.
+`IReplPagingContext` and `IReplPageSource<T>`. The handler fetches only the
+requested page, and human output can continue to the next page in the same run.
+The sample uses `ReplPageSource.FromOffset(...)` so it does not have to parse or
+emit offset cursors manually.
 
 ```text
 myapp activity --result:page-size=5
@@ -215,8 +217,8 @@ myapp activity --result:page-size=5 --result:cursor=5
 myapp activity --json --result:page-size=2
 ```
 
-Human output renders a compact table and a continuation hint. JSON output returns
-an `{ items, pageInfo }` envelope for automation.
+Human output renders a compact table with an integrated pager. JSON output
+returns an `{ items, pageInfo }` envelope for automation.
 
 Validation example:
 

--- a/samples/07-spectre/ActivityFeed.cs
+++ b/samples/07-spectre/ActivityFeed.cs
@@ -1,0 +1,59 @@
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using Repl;
+
+internal sealed record ActivityEvent(
+	[property: Display(Name = "#", Order = 0)] int Id,
+	[property: Display(Name = "At", Order = 1)] string At,
+	[property: Display(Name = "Team", Order = 2)] string Team,
+	[property: Display(Name = "Status", Order = 3)] string Status,
+	[property: Display(Name = "Work Item", Order = 4)] string WorkItem);
+
+internal sealed class ActivityFeed
+{
+	private readonly List<ActivityEvent> _items = CreateItems();
+
+	public ReplPage<ActivityEvent> Query(IReplPagingContext paging)
+	{
+		ArgumentNullException.ThrowIfNull(paging);
+
+		var offset = paging.AllRequested ? 0 : ParseOffset(paging.Cursor);
+		var items = paging.AllRequested
+			? _items
+			: _items.Skip(offset).Take(paging.SuggestedPageSize).ToList();
+
+		var nextOffset = offset + items.Count;
+		var nextCursor = !paging.AllRequested && nextOffset < _items.Count
+			? nextOffset.ToString(CultureInfo.InvariantCulture)
+			: null;
+
+		return paging.Page(items, nextCursor, _items.Count);
+	}
+
+	private static int ParseOffset(string? cursor) =>
+		int.TryParse(cursor, NumberStyles.None, CultureInfo.InvariantCulture, out var offset) && offset > 0
+			? offset
+			: 0;
+
+	private static List<ActivityEvent> CreateItems()
+	{
+		string[] teams = ["platform", "growth", "support", "data", "security"];
+		string[] statuses = ["triaged", "running", "blocked", "reviewed", "done"];
+		var start = new DateTimeOffset(2026, 2, 9, 9, 30, 0, TimeSpan.Zero);
+
+		return Enumerable.Range(1, 320)
+			.Select(i =>
+			{
+				var team = teams[(i - 1) % teams.Length];
+				var status = statuses[(i - 1) % statuses.Length];
+
+				return new ActivityEvent(
+					i,
+					start.AddMinutes(i * 11).ToString("yyyy-MM-dd HH:mm'Z'", CultureInfo.InvariantCulture),
+					team,
+					status,
+					$"{team}-{i:0000} {status}");
+			})
+			.ToList();
+	}
+}

--- a/samples/07-spectre/ActivityFeed.cs
+++ b/samples/07-spectre/ActivityFeed.cs
@@ -38,7 +38,7 @@ internal sealed class ActivityFeed
 
 				return new ActivityEvent(
 					i,
-					start.AddMinutes(i * 11).ToString("yyyy-MM-dd HH:mm'Z'", CultureInfo.InvariantCulture),
+					start.AddMinutes(i * 11d).ToString("yyyy-MM-dd HH:mm'Z'", CultureInfo.InvariantCulture),
 					team,
 					status,
 					$"{team}-{i:0000} {status}");

--- a/samples/07-spectre/ActivityFeed.cs
+++ b/samples/07-spectre/ActivityFeed.cs
@@ -13,27 +13,16 @@ internal sealed class ActivityFeed
 {
 	private readonly List<ActivityEvent> _items = CreateItems();
 
-	public ReplPage<ActivityEvent> Query(IReplPagingContext paging)
+	public IReplPageSource<ActivityEvent> Query(IReplPagingContext paging)
 	{
 		ArgumentNullException.ThrowIfNull(paging);
 
-		var offset = paging.AllRequested ? 0 : ParseOffset(paging.Cursor);
-		var items = paging.AllRequested
-			? _items
-			: _items.Skip(offset).Take(paging.SuggestedPageSize).ToList();
-
-		var nextOffset = offset + items.Count;
-		var nextCursor = !paging.AllRequested && nextOffset < _items.Count
-			? nextOffset.ToString(CultureInfo.InvariantCulture)
-			: null;
-
-		return paging.Page(items, nextCursor, _items.Count);
+		return ReplPageSource.FromOffset<ActivityEvent>(
+			(offset, take, _) =>
+				ValueTask.FromResult<IReadOnlyList<ActivityEvent>>(
+					_items.Skip(offset).Take(take).ToList()),
+			_items.Count);
 	}
-
-	private static int ParseOffset(string? cursor) =>
-		int.TryParse(cursor, NumberStyles.None, CultureInfo.InvariantCulture, out var offset) && offset > 0
-			? offset
-			: 0;
 
 	private static List<ActivityEvent> CreateItems()
 	{

--- a/samples/07-spectre/Program.cs
+++ b/samples/07-spectre/Program.cs
@@ -6,14 +6,15 @@ using Repl;
 var app = ReplApp.Create(services =>
 	{
 		services.AddSingleton<IContactStore, InMemoryContactStore>();
+		services.AddSingleton<ActivityFeed>();
 		services.AddSpectreConsole();
 	})
 	.WithDescription("Spectre.Console integration: rich renderables, interactive prompts, data visualization.")
 	.WithBanner((IAnsiConsole console) =>
 	{
 		console.Write(new FigletText("Spectre").Color(Color.Blue));
-		console.MarkupLine("  [grey]Commands:[/] tour, list, detail, chart, tree, json, path, calendar,");
-		console.MarkupLine("           figlet, status, progress, add, configure, login");
+		console.MarkupLine("  [grey]Commands:[/] tour, list, activity, detail, chart, tree, json, path,");
+		console.MarkupLine("           calendar, figlet, status, progress, add, configure, login");
 	})
 	.UseDefaultInteractive()
 	.UseCliProfile()
@@ -132,6 +133,13 @@ app.Map("tour",
 app.Map("list",
 	[Description("List all contacts (auto-rendered table)")]
 	(IContactStore store) => store.All());
+
+// ──────────────────────────────────────────────────────────────
+// activity — Paged long data source
+// ──────────────────────────────────────────────────────────────
+app.Map("activity",
+	[Description("List a paged activity feed generated from a long data source")]
+	(ActivityFeed feed, IReplPagingContext paging) => feed.Query(paging));
 
 // ──────────────────────────────────────────────────────────────
 // detail — Panel + Grid

--- a/samples/07-spectre/README.md
+++ b/samples/07-spectre/README.md
@@ -3,7 +3,7 @@
 **Rich Spectre.Console integration: renderables, visualizations, and interactive prompts**
 
 This sample showcases the `Repl.Spectre` package with **21 Spectre.Console features**
-across **14 commands**. It demonstrates both direct `IAnsiConsole` usage for custom
+across **15 commands**. It demonstrates both direct `IAnsiConsole` usage for custom
 renderables and the transparent prompt upgrade where `IReplInteractionChannel` calls
 are automatically rendered as Spectre prompts.
 
@@ -38,6 +38,17 @@ A multi-step flow chaining 10 Spectre features sequentially:
 
 Returns a collection; the `"spectre"` output transformer renders it as a bordered
 table automatically. Zero rendering code in the handler.
+
+### `activity` — Paged long data source
+
+Returns a synthetic activity feed through `IReplPagingContext` and `ReplPage<T>`.
+The Spectre output transformer renders only the requested page and appends the
+continuation cursor.
+
+```bash
+dotnet run --project samples/07-spectre/SpectreOpsSample.csproj -- activity --result:page-size=8
+dotnet run --project samples/07-spectre/SpectreOpsSample.csproj -- activity --result:page-size=8 --result:cursor=8
+```
 
 ### `detail {name}` — Panel + Grid
 
@@ -101,7 +112,7 @@ Uses `AskSecretAsync` which renders as a Spectre `TextPrompt` with masked input.
 |---------|-------|---------|
 | FigletText | `FigletText` | `tour`, `figlet`, banner |
 | Table | `Table` | `tour` |
-| Table (auto) | via output transformer | `list` |
+| Table (auto) | via output transformer | `list`, `activity` |
 | Tree | `Tree` | `tour`, `tree` |
 | Panel | `Panel` | `tour`, `detail`, `json`, `calendar`, `chart` |
 | Rule | `Rule` | `tour` |

--- a/samples/07-spectre/README.md
+++ b/samples/07-spectre/README.md
@@ -41,9 +41,9 @@ table automatically. Zero rendering code in the handler.
 
 ### `activity` — Paged long data source
 
-Returns a synthetic activity feed through `IReplPagingContext` and `ReplPage<T>`.
-The Spectre output transformer renders only the requested page and appends the
-continuation cursor.
+Returns a synthetic activity feed through `IReplPagingContext` and
+`IReplPageSource<T>`. The Spectre output transformer renders the requested page,
+and the integrated pager can fetch more data in the same run.
 
 ```bash
 dotnet run --project samples/07-spectre/SpectreOpsSample.csproj -- activity --result:page-size=8

--- a/samples/08-mcp-server/DirectoryContactFeed.cs
+++ b/samples/08-mcp-server/DirectoryContactFeed.cs
@@ -1,0 +1,60 @@
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using Repl;
+
+internal sealed record DirectoryContact(
+	[property: Display(Name = "#", Order = 0)] int Id,
+	[property: Display(Name = "Name", Order = 1)] string Name,
+	[property: Display(Name = "Email", Order = 2)] string Email,
+	[property: Display(Name = "Department", Order = 3)] string Department,
+	[property: Display(Name = "Region", Order = 4)] string Region);
+
+internal sealed class DirectoryContactFeed
+{
+	private readonly List<DirectoryContact> _items = CreateItems();
+
+	public ReplPage<DirectoryContact> Query(IReplPagingContext paging)
+	{
+		ArgumentNullException.ThrowIfNull(paging);
+
+		var offset = paging.AllRequested ? 0 : ParseOffset(paging.Cursor);
+		var items = paging.AllRequested
+			? _items
+			: _items.Skip(offset).Take(paging.SuggestedPageSize).ToList();
+
+		var nextOffset = offset + items.Count;
+		var nextCursor = !paging.AllRequested && nextOffset < _items.Count
+			? nextOffset.ToString(CultureInfo.InvariantCulture)
+			: null;
+
+		return paging.Page(items, nextCursor, _items.Count);
+	}
+
+	private static int ParseOffset(string? cursor) =>
+		int.TryParse(cursor, NumberStyles.None, CultureInfo.InvariantCulture, out var offset) && offset > 0
+			? offset
+			: 0;
+
+	private static List<DirectoryContact> CreateItems()
+	{
+		string[] firstNames = ["Alice", "Bob", "Charlie", "Diana", "Eve", "Frank", "Grace", "Heidi"];
+		string[] lastNames = ["Martin", "Tremblay", "Singh", "Nguyen", "Roy", "Garcia", "Smith", "Brown"];
+		string[] departments = ["Engineering", "Sales", "Support", "Marketing", "Finance", "Operations"];
+		string[] regions = ["NA", "EMEA", "APAC", "LATAM"];
+
+		return Enumerable.Range(1, 500)
+			.Select(i =>
+			{
+				var firstName = firstNames[(i - 1) % firstNames.Length];
+				var lastName = lastNames[((i - 1) / firstNames.Length) % lastNames.Length];
+
+				return new DirectoryContact(
+					i,
+					$"{firstName} {lastName} {i:000}",
+					$"{firstName.ToLowerInvariant()}.{lastName.ToLowerInvariant()}{i:000}@example.com",
+					departments[(i - 1) % departments.Length],
+					regions[(i - 1) % regions.Length]);
+			})
+			.ToList();
+	}
+}

--- a/samples/08-mcp-server/Program.cs
+++ b/samples/08-mcp-server/Program.cs
@@ -16,6 +16,7 @@ using Repl.Mcp;
 var app = ReplApp.Create(services =>
 {
 	services.AddSingleton<ContactStore>();
+	services.AddSingleton<DirectoryContactFeed>();
 }).UseDefaultInteractive();
 
 app.UseMcpServer(o =>
@@ -29,6 +30,14 @@ app.Map("contacts", (ContactStore contacts) => contacts.All)
 	.WithDescription("List all contacts")
 	.ReadOnly()
 	.AsResource();
+
+app.Map("contacts paged", (DirectoryContactFeed contacts, IReplPagingContext paging) => contacts.Query(paging))
+	.WithDescription("List the large contact directory as a paged result")
+	.WithDetails("""
+		Demonstrates result-flow paging on both CLI and MCP surfaces.
+		In MCP mode, continue with the reserved _replCursor input returned by pageInfo.nextCursor.
+		""")
+	.ReadOnly();
 
 app.Map("contacts dashboard", (ContactStore contacts) =>
 	{

--- a/samples/08-mcp-server/README.md
+++ b/samples/08-mcp-server/README.md
@@ -5,6 +5,7 @@ Expose a Repl command graph as an MCP server for AI agents, including a minimal 
 ## What this sample shows
 
 - `app.UseMcpServer()` — one line to enable MCP stdio server
+- `contacts paged` — paged structured output for large result sets
 - `IReplInteractionChannel` in MCP mode — portable notices, warnings, problems, and progress updates
 - `feedback demo` / `feedback fail` — deterministic progress sequences that are easy to inspect in MCP Inspector
 - `.ReadOnly()` / `.Destructive()` / `.OpenWorld()` — behavioral annotations
@@ -44,6 +45,8 @@ In the current Repl.Mcp version, MCP Apps are experimental and the UI handler re
 
 In the interactive REPL, try:
 
+- `contacts paged --result:page-size=5` to inspect the first page of a synthetic long directory
+- `contacts paged --result:page-size=5 --result:cursor=5` to continue from the next cursor
 - `feedback demo` to emit a successful sequence with normal, indeterminate, and warning progress states
 - `feedback fail` to emit warning and error progress, then finish with a problem result
 - `import contacts.csv` to see the realistic workflow that uses sampling and elicitation when the connected client supports them
@@ -51,11 +54,13 @@ In the interactive REPL, try:
 In MCP Inspector:
 
 1. Start the sample in MCP mode.
-2. Call `feedback_demo`.
-3. Watch the tool emit `notifications/progress` during the run.
-4. Call `feedback_fail`.
-5. Watch the warning/error feedback arrive before the final tool error result.
-6. Call `import` with any file name to see the longer workflow:
+2. Call `contacts_paged` with `_replPageSize` set to `5`.
+3. Call `contacts_paged` again with `_replPageSize` set to `5` and `_replCursor` set to the returned `pageInfo.nextCursor`.
+4. Call `feedback_demo`.
+5. Watch the tool emit `notifications/progress` during the run.
+6. Call `feedback_fail`.
+7. Watch the warning/error feedback arrive before the final tool error result.
+8. Call `import` with any file name to see the longer workflow:
    the tool reports progress while reading, column-mapping, duplicate review, and commit.
 
 The deterministic `feedback_*` tools make it easy to verify the host's notification rendering without depending on a real CSV file.

--- a/samples/README.md
+++ b/samples/README.md
@@ -7,7 +7,7 @@ If you’re new, start with **01**, then follow the sequence.
 ## Index (recommended order)
 
 1. [01 — Core Basics](01-core-basics/)  
-   `Repl.Core` only: routing, parsing/binding, typed params + constraints, reusable options groups, temporal ranges, help/discovery, CLI + REPL from the same command graph.
+   `Repl.Core` only: routing, parsing/binding, typed params + constraints, reusable options groups, temporal ranges, result-flow paging, help/discovery, CLI + REPL from the same command graph.
 2. [02 — Scoped Contacts](02-scoped-contacts/)  
    Dynamic scopes + REPL navigation (`..`) + DI-backed handlers.
 3. [03 — Modular Ops](03-modular-ops/)  
@@ -19,9 +19,9 @@ If you’re new, start with **01**, then follow the sequence.
 6. [06 — Testing](06-testing/)
    `Repl.Testing` harness: multi-step + multi-session, typed results, interaction/timeline events, metadata snapshots.
 7. [07 — Spectre](07-spectre/)
-   `Repl.Spectre` integration: FigletText, Table, Panel, Tree, BarChart, BreakdownChart, Calendar, JsonText, TextPath, Grid, Columns, Rule, Status, Progress, and all Spectre-powered prompts.
+   `Repl.Spectre` integration: FigletText, Table, paged result tables, Panel, Tree, BarChart, BreakdownChart, Calendar, JsonText, TextPath, Grid, Columns, Rule, Status, Progress, and all Spectre-powered prompts.
 8. [08 — MCP Server](08-mcp-server/)
-   MCP server mode: tools, resources, prompts, behavioral annotations, automation visibility, and a minimal MCP Apps UI.
+   MCP server mode: tools, paged structured results, resources, prompts, behavioral annotations, automation visibility, and a minimal MCP Apps UI.
 
 ## Run
 

--- a/src/Repl.Core/CoreReplApp.Execution.cs
+++ b/src/Repl.Core/CoreReplApp.Execution.cs
@@ -762,6 +762,7 @@ public sealed partial class CoreReplApp
 				ReplSessionIO.Output,
 				keyReader,
 				visibleRows,
+				ResolvePagerVisibleRows,
 				pagerMode,
 				ansiEnabled,
 				page.PageInfo.HasMore,
@@ -871,12 +872,17 @@ public sealed partial class CoreReplApp
 
 	private bool TryResolvePagerVisibleRows(out int visibleRows)
 	{
+		visibleRows = ResolvePagerVisibleRows();
+		return visibleRows > 0;
+	}
+
+	private int ResolvePagerVisibleRows()
+	{
 		var height = ReplSessionIO.WindowSize?.Height ?? TryGetConsoleWindowHeight();
 		var reservedRows = Math.Max(0, _options.Output.ResultFlow.ReservedVisibleRows);
-		visibleRows = height is > 0
+		return height is > 0
 			? Math.Max(1, height.Value - reservedRows)
 			: Math.Max(1, _options.Output.ResultFlow.DefaultPageSize);
-		return visibleRows > 0;
 	}
 
 	private static bool TryResolvePagerKeyReader([NotNullWhen(true)] out IReplKeyReader? keyReader)

--- a/src/Repl.Core/CoreReplApp.Execution.cs
+++ b/src/Repl.Core/CoreReplApp.Execution.cs
@@ -767,6 +767,7 @@ public sealed partial class CoreReplApp
 				ansiEnabled,
 				page.PageInfo.HasMore,
 				FetchNextPayloadAsync,
+				_options.Output.ResultFlow.PagerRenderers,
 				cancellationToken)
 			.ConfigureAwait(false);
 		return true;
@@ -808,8 +809,12 @@ public sealed partial class CoreReplApp
 					ReplSessionIO.Output,
 					keyReader,
 					visibleRows,
+					visibleRowsProvider: null,
 					pagerMode,
 					ansiEnabled,
+					hasMorePayload: false,
+					fetchNextPayload: null,
+					_options.Output.ResultFlow.PagerRenderers,
 					cancellationToken)
 				.ConfigureAwait(false);
 			return;

--- a/src/Repl.Core/CoreReplApp.Execution.cs
+++ b/src/Repl.Core/CoreReplApp.Execution.cs
@@ -743,7 +743,9 @@ public sealed partial class CoreReplApp
 				resultFlow,
 				page.PageInfo.HasMore,
 				out var keyReader,
-				out var visibleRows))
+				out var visibleRows,
+				out var pagerMode,
+				out var ansiEnabled))
 		{
 			if (!string.IsNullOrEmpty(payload))
 			{
@@ -762,6 +764,8 @@ public sealed partial class CoreReplApp
 				ReplSessionIO.Output,
 				keyReader,
 				visibleRows,
+				pagerMode,
+				ansiEnabled,
 				page.PageInfo.HasMore,
 				FetchNextPayloadAsync,
 				cancellationToken)
@@ -791,13 +795,22 @@ public sealed partial class CoreReplApp
 		ResultFlowInvocationOptions? resultFlow,
 		CancellationToken cancellationToken)
 	{
-		if (TryCreatePager(payload, format, resultFlow, out var keyReader, out var visibleRows))
+		if (TryCreatePager(
+				payload,
+				format,
+				resultFlow,
+				out var keyReader,
+				out var visibleRows,
+				out var pagerMode,
+				out var ansiEnabled))
 		{
 			await ResultFlowPager.WriteAsync(
 					payload,
 					ReplSessionIO.Output,
 					keyReader,
 					visibleRows,
+					pagerMode,
+					ansiEnabled,
 					cancellationToken)
 				.ConfigureAwait(false);
 			return;
@@ -811,14 +824,18 @@ public sealed partial class CoreReplApp
 		string format,
 		ResultFlowInvocationOptions? resultFlow,
 		[NotNullWhen(true)] out IReplKeyReader? keyReader,
-		out int visibleRows)
+		out int visibleRows,
+		out ReplPagerMode pagerMode,
+		out bool ansiEnabled)
 		=> TryCreatePager(
 			payload,
 			format,
 			resultFlow,
 			hasMorePayload: false,
 			out keyReader,
-			out visibleRows);
+			out visibleRows,
+			out pagerMode,
+			out ansiEnabled);
 
 	private bool TryCreatePager(
 		string payload,
@@ -826,12 +843,15 @@ public sealed partial class CoreReplApp
 		ResultFlowInvocationOptions? resultFlow,
 		bool hasMorePayload,
 		[NotNullWhen(true)] out IReplKeyReader? keyReader,
-		out int visibleRows)
+		out int visibleRows,
+		out ReplPagerMode pagerMode,
+		out bool ansiEnabled)
 	{
 		keyReader = null;
 		visibleRows = 0;
+		ansiEnabled = false;
 
-		var pagerMode = resultFlow?.PagerMode ?? _options.Output.ResultFlow.DefaultPagerMode;
+		pagerMode = resultFlow?.PagerMode ?? _options.Output.ResultFlow.DefaultPagerMode;
 		if (pagerMode == ReplPagerMode.Off
 			|| ReplSessionIO.IsProgrammatic
 			|| ReplSessionIO.IsProtocolPassthrough
@@ -847,6 +867,7 @@ public sealed partial class CoreReplApp
 			return false;
 		}
 
+		ansiEnabled = _options.Output.IsAnsiEnabled();
 		return true;
 	}
 

--- a/src/Repl.Core/CoreReplApp.Execution.cs
+++ b/src/Repl.Core/CoreReplApp.Execution.cs
@@ -705,12 +705,11 @@ public sealed partial class CoreReplApp
 		if (result is IReplPageSource pageSource)
 		{
 			return await RenderPageSourceAsync(
-					pageSource,
-					transformer,
-					format,
-					isInteractive,
-					resultFlow,
-					cancellationToken)
+				pageSource,
+				transformer,
+				isInteractive,
+				resultFlow,
+				cancellationToken)
 				.ConfigureAwait(false);
 		}
 
@@ -718,7 +717,7 @@ public sealed partial class CoreReplApp
 		payload = TryColorizeStructuredPayload(payload, format, isInteractive);
 		if (!string.IsNullOrEmpty(payload))
 		{
-			await WritePayloadAsync(payload, format, resultFlow, cancellationToken).ConfigureAwait(false);
+			await WritePayloadAsync(payload, transformer, resultFlow, cancellationToken).ConfigureAwait(false);
 		}
 
 		return true;
@@ -727,7 +726,6 @@ public sealed partial class CoreReplApp
 	private async ValueTask<bool> RenderPageSourceAsync(
 		IReplPageSource source,
 		IOutputTransformer transformer,
-		string format,
 		bool isInteractive,
 		ResultFlowInvocationOptions? resultFlow,
 		CancellationToken cancellationToken)
@@ -735,11 +733,11 @@ public sealed partial class CoreReplApp
 		var request = CreatePageSourceRequest(resultFlow);
 		var page = await FetchPageSourceAsync(source, request, cancellationToken).ConfigureAwait(false);
 		var payload = await transformer.TransformAsync(page, cancellationToken).ConfigureAwait(false);
-		payload = TryColorizeStructuredPayload(payload, format, isInteractive);
+		payload = TryColorizeStructuredPayload(payload, transformer.Name, isInteractive);
 
 		if (!TryCreatePager(
 				payload,
-				format,
+				transformer,
 				resultFlow,
 				page.PageInfo.HasMore,
 				out var keyReader,
@@ -749,7 +747,7 @@ public sealed partial class CoreReplApp
 		{
 			if (!string.IsNullOrEmpty(payload))
 			{
-				await WritePayloadAsync(payload, format, resultFlow, cancellationToken).ConfigureAwait(false);
+				await ReplSessionIO.Output.WriteLineAsync(payload).ConfigureAwait(false);
 			}
 
 			return true;
@@ -758,7 +756,7 @@ public sealed partial class CoreReplApp
 		var nextCursor = page.PageInfo.NextCursor;
 		var pagerPayload = await transformer.TransformAsync(CreatePagerDisplayPage(page), cancellationToken)
 			.ConfigureAwait(false);
-		pagerPayload = TryColorizeStructuredPayload(pagerPayload, format, isInteractive);
+		pagerPayload = TryColorizeStructuredPayload(pagerPayload, transformer.Name, isInteractive);
 		await ResultFlowPager.WriteAsync(
 				pagerPayload,
 				ReplSessionIO.Output,
@@ -784,20 +782,20 @@ public sealed partial class CoreReplApp
 			nextCursor = nextPage.PageInfo.NextCursor;
 			var nextPayload = await transformer.TransformAsync(CreatePagerDisplayPage(nextPage), token)
 				.ConfigureAwait(false);
-			nextPayload = TryColorizeStructuredPayload(nextPayload, format, isInteractive);
+			nextPayload = TryColorizeStructuredPayload(nextPayload, transformer.Name, isInteractive);
 			return new ResultFlowPagerPage(nextPayload, nextPage.PageInfo.HasMore);
 		}
 	}
 
 	private async ValueTask WritePayloadAsync(
 		string payload,
-		string format,
+		IOutputTransformer transformer,
 		ResultFlowInvocationOptions? resultFlow,
 		CancellationToken cancellationToken)
 	{
 		if (TryCreatePager(
 				payload,
-				format,
+				transformer,
 				resultFlow,
 				out var keyReader,
 				out var visibleRows,
@@ -821,7 +819,7 @@ public sealed partial class CoreReplApp
 
 	private bool TryCreatePager(
 		string payload,
-		string format,
+		IOutputTransformer transformer,
 		ResultFlowInvocationOptions? resultFlow,
 		[NotNullWhen(true)] out IReplKeyReader? keyReader,
 		out int visibleRows,
@@ -829,7 +827,7 @@ public sealed partial class CoreReplApp
 		out bool ansiEnabled)
 		=> TryCreatePager(
 			payload,
-			format,
+			transformer,
 			resultFlow,
 			hasMorePayload: false,
 			out keyReader,
@@ -839,7 +837,7 @@ public sealed partial class CoreReplApp
 
 	private bool TryCreatePager(
 		string payload,
-		string format,
+		IOutputTransformer transformer,
 		ResultFlowInvocationOptions? resultFlow,
 		bool hasMorePayload,
 		[NotNullWhen(true)] out IReplKeyReader? keyReader,
@@ -855,7 +853,7 @@ public sealed partial class CoreReplApp
 		if (pagerMode == ReplPagerMode.Off
 			|| ReplSessionIO.IsProgrammatic
 			|| ReplSessionIO.IsProtocolPassthrough
-			|| !IsPagedHumanFormat(format))
+			|| !transformer.SupportsInteractivePaging)
 		{
 			return false;
 		}
@@ -899,10 +897,6 @@ public sealed partial class CoreReplApp
 		return false;
 	}
 
-	private static bool IsPagedHumanFormat(string format) =>
-		string.Equals(format, "human", StringComparison.OrdinalIgnoreCase)
-		|| string.Equals(format, "spectre", StringComparison.OrdinalIgnoreCase);
-
 	private ReplPageRequest CreatePageSourceRequest(ResultFlowInvocationOptions? resultFlow)
 	{
 		var surface = ResolveResultSurface();
@@ -924,7 +918,6 @@ public sealed partial class CoreReplApp
 		var pageInfo = page.PageInfo with
 		{
 			NextCursor = null,
-			HasMore = false,
 		};
 		return new ReplPageDisplaySnapshot(page, pageInfo);
 	}

--- a/src/Repl.Core/CoreReplApp.Execution.cs
+++ b/src/Repl.Core/CoreReplApp.Execution.cs
@@ -516,7 +516,12 @@ public sealed partial class CoreReplApp
 				{
 					if (enterInteractive.Payload is not null)
 					{
-						_ = await RenderOutputAsync(enterInteractive.Payload, globalOptions.OutputFormat, cancellationToken, scopeTokens is not null)
+						_ = await RenderOutputAsync(
+								enterInteractive.Payload,
+								globalOptions.OutputFormat,
+								cancellationToken,
+								scopeTokens is not null,
+								globalOptions.ResultFlow)
 							.ConfigureAwait(false);
 					}
 
@@ -525,7 +530,12 @@ public sealed partial class CoreReplApp
 
 				var normalizedResult = ApplyNavigationResult(result, scopeTokens);
 				ExecutionObserver?.OnResult(normalizedResult);
-				var rendered = await RenderOutputAsync(normalizedResult, globalOptions.OutputFormat, cancellationToken, scopeTokens is not null)
+				var rendered = await RenderOutputAsync(
+						normalizedResult,
+						globalOptions.OutputFormat,
+						cancellationToken,
+						scopeTokens is not null,
+						globalOptions.ResultFlow)
 					.ConfigureAwait(false);
 				return (rendered ? ComputeExitCode(normalizedResult) : 1, false);
 		}
@@ -617,7 +627,12 @@ public sealed partial class CoreReplApp
 
 			ExecutionObserver?.OnResult(normalized);
 
-			var rendered = await RenderOutputAsync(normalized, globalOptions.OutputFormat, cancellationToken, isInteractive)
+			var rendered = await RenderOutputAsync(
+					normalized,
+					globalOptions.OutputFormat,
+					cancellationToken,
+					isInteractive,
+					globalOptions.ResultFlow)
 				.ConfigureAwait(false);
 
 			if (!rendered)
@@ -664,7 +679,8 @@ public sealed partial class CoreReplApp
 		object? result,
 		string? requestedFormat,
 		CancellationToken cancellationToken,
-		bool isInteractive = false)
+		bool isInteractive = false,
+		ResultFlowInvocationOptions? resultFlow = null)
 	{
 		if (result is IExitResult exitResult)
 		{
@@ -690,11 +706,93 @@ public sealed partial class CoreReplApp
 		payload = TryColorizeStructuredPayload(payload, format, isInteractive);
 		if (!string.IsNullOrEmpty(payload))
 		{
-			await ReplSessionIO.Output.WriteLineAsync(payload).ConfigureAwait(false);
+			await WritePayloadAsync(payload, format, resultFlow, cancellationToken).ConfigureAwait(false);
 		}
 
 		return true;
 	}
+
+	private async ValueTask WritePayloadAsync(
+		string payload,
+		string format,
+		ResultFlowInvocationOptions? resultFlow,
+		CancellationToken cancellationToken)
+	{
+		if (TryCreatePager(payload, format, resultFlow, out var keyReader, out var visibleRows))
+		{
+			await ResultFlowPager.WriteAsync(
+					payload,
+					ReplSessionIO.Output,
+					keyReader,
+					visibleRows,
+					cancellationToken)
+				.ConfigureAwait(false);
+			return;
+		}
+
+		await ReplSessionIO.Output.WriteLineAsync(payload).ConfigureAwait(false);
+	}
+
+	private bool TryCreatePager(
+		string payload,
+		string format,
+		ResultFlowInvocationOptions? resultFlow,
+		[NotNullWhen(true)] out IReplKeyReader? keyReader,
+		out int visibleRows)
+	{
+		keyReader = null;
+		visibleRows = 0;
+
+		var pagerMode = resultFlow?.PagerMode ?? _options.Output.ResultFlow.DefaultPagerMode;
+		if (pagerMode == ReplPagerMode.Off
+			|| ReplSessionIO.IsProgrammatic
+			|| ReplSessionIO.IsProtocolPassthrough
+			|| !IsPagedHumanFormat(format))
+		{
+			return false;
+		}
+
+		if (!TryResolvePagerVisibleRows(out visibleRows)
+			|| ResultFlowPager.CountLines(payload) <= visibleRows
+			|| !TryResolvePagerKeyReader(out keyReader))
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	private bool TryResolvePagerVisibleRows(out int visibleRows)
+	{
+		var height = ReplSessionIO.WindowSize?.Height ?? TryGetConsoleWindowHeight();
+		var reservedRows = Math.Max(0, _options.Output.ResultFlow.ReservedVisibleRows);
+		visibleRows = height is > 0
+			? Math.Max(1, height.Value - reservedRows)
+			: Math.Max(1, _options.Output.ResultFlow.DefaultPageSize);
+		return visibleRows > 0;
+	}
+
+	private static bool TryResolvePagerKeyReader([NotNullWhen(true)] out IReplKeyReader? keyReader)
+	{
+		if (ReplSessionIO.KeyReader is { } sessionKeyReader)
+		{
+			keyReader = sessionKeyReader;
+			return true;
+		}
+
+		if (!Console.IsInputRedirected && !Console.IsOutputRedirected && !ReplSessionIO.IsSessionActive)
+		{
+			keyReader = new ConsoleKeyReader();
+			return true;
+		}
+
+		keyReader = null;
+		return false;
+	}
+
+	private static bool IsPagedHumanFormat(string format) =>
+		string.Equals(format, "human", StringComparison.OrdinalIgnoreCase)
+		|| string.Equals(format, "spectre", StringComparison.OrdinalIgnoreCase);
 
 	private string TryColorizeStructuredPayload(string payload, string format, bool isInteractive)
 	{

--- a/src/Repl.Core/CoreReplApp.Execution.cs
+++ b/src/Repl.Core/CoreReplApp.Execution.cs
@@ -757,14 +757,45 @@ public sealed partial class CoreReplApp
 				out var pagerMode,
 				out var ansiEnabled))
 		{
-			if (!string.IsNullOrEmpty(payload))
-			{
-				await ReplSessionIO.Output.WriteLineAsync(payload).ConfigureAwait(false);
-			}
-
-			return true;
+			return await WritePageSourcePayloadAsync(payload).ConfigureAwait(false);
 		}
 
+		return await RenderPageSourcePagerAsync(
+				source,
+				transformer,
+				isInteractive,
+				request,
+				page,
+				keyReader,
+				visibleRows,
+				pagerMode,
+				ansiEnabled,
+				cancellationToken)
+			.ConfigureAwait(false);
+	}
+
+	private static async ValueTask<bool> WritePageSourcePayloadAsync(string payload)
+	{
+		if (!string.IsNullOrEmpty(payload))
+		{
+			await ReplSessionIO.Output.WriteLineAsync(payload).ConfigureAwait(false);
+		}
+
+		return true;
+	}
+
+	private async ValueTask<bool> RenderPageSourcePagerAsync(
+		IReplPageSource source,
+		IOutputTransformer transformer,
+		bool isInteractive,
+		ReplPageRequest request,
+		IReplPage page,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		ReplPagerMode pagerMode,
+		bool ansiEnabled,
+		CancellationToken cancellationToken)
+	{
 		var nextCursor = page.PageInfo.NextCursor;
 		var pagerPayload = await TransformPagerPageAsync(transformer, page, ResultFlowPageRenderMode.Initial, cancellationToken)
 			.ConfigureAwait(false);
@@ -798,7 +829,10 @@ public sealed partial class CoreReplApp
 			var nextPayload = await TransformPagerPageAsync(transformer, nextPage, ResultFlowPageRenderMode.Continuation, token)
 				.ConfigureAwait(false);
 			nextPayload = TryColorizeStructuredPayload(nextPayload, transformer.Name, isInteractive);
-			return new ResultFlowPagerPage(nextPayload, nextPage.PageInfo.HasMore);
+			return new ResultFlowPagerPage(
+				nextPayload,
+				nextPage.PageInfo.HasMore,
+				ContainsPresentationChrome: false);
 		}
 	}
 

--- a/src/Repl.Core/CoreReplApp.Execution.cs
+++ b/src/Repl.Core/CoreReplApp.Execution.cs
@@ -63,6 +63,23 @@ public sealed partial class CoreReplApp
 		try
 		{
 			var globalOptions = GlobalOptionParser.Parse(args, _options.Output, _options.Parsing);
+			if (await TryHandleGlobalDiagnosticsAsync(globalOptions, cancellationToken).ConfigureAwait(false) is { } globalDiagnosticsExitCode) return globalDiagnosticsExitCode;
+
+			return await ExecuteParsedCoreAsync(globalOptions, serviceProvider, isSubInvocation, cancellationToken)
+				.ConfigureAwait(false);
+		}
+		finally
+		{
+			_options.Interaction.SetObserver(observer: null);
+		}
+	}
+
+	private async ValueTask<int> ExecuteParsedCoreAsync(
+		GlobalInvocationOptions globalOptions,
+		IServiceProvider serviceProvider,
+		bool isSubInvocation,
+		CancellationToken cancellationToken)
+	{
 			_globalOptionsSnapshot.Update(globalOptions.CustomGlobalNamedOptions); // volatile ref swap — safe under concurrent sub-invocations
 			if (!isSubInvocation)
 			{
@@ -71,14 +88,14 @@ public sealed partial class CoreReplApp
 			using var runtimeStateScope = PushRuntimeState(serviceProvider, isInteractiveSession: false);
 			var prefixResolution = ResolveUniquePrefixes(globalOptions.RemainingTokens);
 			var resolvedGlobalOptions = globalOptions with { RemainingTokens = prefixResolution.Tokens };
-				var ambiguousExitCode = await TryHandleAmbiguousPrefixAsync(
+			var ambiguousExitCode = await TryHandleAmbiguousPrefixAsync(
 						prefixResolution,
 						globalOptions,
 						resolvedGlobalOptions,
 						serviceProvider,
 						cancellationToken)
 					.ConfigureAwait(false);
-				if (ambiguousExitCode is not null) return ambiguousExitCode.Value;
+			if (ambiguousExitCode is not null) return ambiguousExitCode.Value;
 
 			var preResolvedRouteResolution = TryPreResolveRouteForBanner(resolvedGlobalOptions);
 			if (!ShouldSuppressGlobalBanner(resolvedGlobalOptions, preResolvedRouteResolution?.Match))
@@ -86,26 +103,26 @@ public sealed partial class CoreReplApp
 				await TryRenderBannerAsync(resolvedGlobalOptions, serviceProvider, cancellationToken).ConfigureAwait(false);
 			}
 
-				var preExecutionExitCode = await TryHandlePreExecutionAsync(
+			var preExecutionExitCode = await TryHandlePreExecutionAsync(
 						resolvedGlobalOptions,
 						serviceProvider,
 						cancellationToken)
 					.ConfigureAwait(false);
-				if (preExecutionExitCode is not null) return preExecutionExitCode.Value;
+			if (preExecutionExitCode is not null) return preExecutionExitCode.Value;
 
 			var resolution = preResolvedRouteResolution
 				?? ResolveWithDiagnostics(resolvedGlobalOptions.RemainingTokens);
 			var match = resolution.Match;
-				if (match is null)
-				{
-					return await TryHandleContextDeeplinkAsync(
+			if (match is null)
+			{
+				return await TryHandleContextDeeplinkAsync(
 							resolvedGlobalOptions,
 							serviceProvider,
 							cancellationToken,
 							constraintFailure: resolution.ConstraintFailure,
 							missingArgumentsFailure: resolution.MissingArgumentsFailure)
 						.ConfigureAwait(false);
-				}
+			}
 
 			return await ExecuteMatchedCommandAndMaybeEnterInteractiveAsync(
 					match,
@@ -113,11 +130,6 @@ public sealed partial class CoreReplApp
 					serviceProvider,
 					cancellationToken)
 				.ConfigureAwait(false);
-		}
-		finally
-		{
-			_options.Interaction.SetObserver(observer: null);
-		}
 	}
 
 	private async ValueTask<int?> TryHandleAmbiguousPrefixAsync(
@@ -787,6 +799,25 @@ public sealed partial class CoreReplApp
 			nextPayload = TryColorizeStructuredPayload(nextPayload, transformer.Name, isInteractive);
 			return new ResultFlowPagerPage(nextPayload, nextPage.PageInfo.HasMore);
 		}
+	}
+
+	private async ValueTask<int?> TryHandleGlobalDiagnosticsAsync(
+		GlobalInvocationOptions globalOptions,
+		CancellationToken cancellationToken)
+	{
+		if (!globalOptions.HasErrors)
+		{
+			return null;
+		}
+
+		var firstError = globalOptions.Diagnostics
+			.First(diagnostic => diagnostic.Severity == ParseDiagnosticSeverity.Error);
+		_ = await RenderOutputAsync(
+				Results.Validation(firstError.Message),
+				globalOptions.OutputFormat,
+				cancellationToken)
+			.ConfigureAwait(false);
+		return 1;
 	}
 
 	private static ValueTask<string> TransformPagerPageAsync(

--- a/src/Repl.Core/CoreReplApp.Execution.cs
+++ b/src/Repl.Core/CoreReplApp.Execution.cs
@@ -754,7 +754,7 @@ public sealed partial class CoreReplApp
 		}
 
 		var nextCursor = page.PageInfo.NextCursor;
-		var pagerPayload = await transformer.TransformAsync(CreatePagerDisplayPage(page), cancellationToken)
+		var pagerPayload = await TransformPagerPageAsync(transformer, page, ResultFlowPageRenderMode.Initial, cancellationToken)
 			.ConfigureAwait(false);
 		pagerPayload = TryColorizeStructuredPayload(pagerPayload, transformer.Name, isInteractive);
 		await ResultFlowPager.WriteAsync(
@@ -782,11 +782,23 @@ public sealed partial class CoreReplApp
 			var nextRequest = request with { Cursor = nextCursor };
 			var nextPage = await FetchPageSourceAsync(source, nextRequest, token).ConfigureAwait(false);
 			nextCursor = nextPage.PageInfo.NextCursor;
-			var nextPayload = await transformer.TransformAsync(CreatePagerDisplayPage(nextPage), token)
+			var nextPayload = await TransformPagerPageAsync(transformer, nextPage, ResultFlowPageRenderMode.Continuation, token)
 				.ConfigureAwait(false);
 			nextPayload = TryColorizeStructuredPayload(nextPayload, transformer.Name, isInteractive);
 			return new ResultFlowPagerPage(nextPayload, nextPage.PageInfo.HasMore);
 		}
+	}
+
+	private static ValueTask<string> TransformPagerPageAsync(
+		IOutputTransformer transformer,
+		IReplPage page,
+		ResultFlowPageRenderMode mode,
+		CancellationToken cancellationToken)
+	{
+		var displayPage = CreatePagerDisplayPage(page);
+		return transformer is IResultFlowOutputTransformer resultFlowTransformer
+			? resultFlowTransformer.TransformPageAsync(displayPage, mode, cancellationToken)
+			: transformer.TransformAsync(displayPage, cancellationToken);
 	}
 
 	private async ValueTask WritePayloadAsync(

--- a/src/Repl.Core/CoreReplApp.Execution.cs
+++ b/src/Repl.Core/CoreReplApp.Execution.cs
@@ -702,6 +702,18 @@ public sealed partial class CoreReplApp
 			return false;
 		}
 
+		if (result is IReplPageSource pageSource)
+		{
+			return await RenderPageSourceAsync(
+					pageSource,
+					transformer,
+					format,
+					isInteractive,
+					resultFlow,
+					cancellationToken)
+				.ConfigureAwait(false);
+		}
+
 		var payload = await transformer.TransformAsync(result, cancellationToken).ConfigureAwait(false);
 		payload = TryColorizeStructuredPayload(payload, format, isInteractive);
 		if (!string.IsNullOrEmpty(payload))
@@ -710,6 +722,67 @@ public sealed partial class CoreReplApp
 		}
 
 		return true;
+	}
+
+	private async ValueTask<bool> RenderPageSourceAsync(
+		IReplPageSource source,
+		IOutputTransformer transformer,
+		string format,
+		bool isInteractive,
+		ResultFlowInvocationOptions? resultFlow,
+		CancellationToken cancellationToken)
+	{
+		var request = CreatePageSourceRequest(resultFlow);
+		var page = await FetchPageSourceAsync(source, request, cancellationToken).ConfigureAwait(false);
+		var payload = await transformer.TransformAsync(page, cancellationToken).ConfigureAwait(false);
+		payload = TryColorizeStructuredPayload(payload, format, isInteractive);
+
+		if (!TryCreatePager(
+				payload,
+				format,
+				resultFlow,
+				page.PageInfo.HasMore,
+				out var keyReader,
+				out var visibleRows))
+		{
+			if (!string.IsNullOrEmpty(payload))
+			{
+				await WritePayloadAsync(payload, format, resultFlow, cancellationToken).ConfigureAwait(false);
+			}
+
+			return true;
+		}
+
+		var nextCursor = page.PageInfo.NextCursor;
+		var pagerPayload = await transformer.TransformAsync(CreatePagerDisplayPage(page), cancellationToken)
+			.ConfigureAwait(false);
+		pagerPayload = TryColorizeStructuredPayload(pagerPayload, format, isInteractive);
+		await ResultFlowPager.WriteAsync(
+				pagerPayload,
+				ReplSessionIO.Output,
+				keyReader,
+				visibleRows,
+				page.PageInfo.HasMore,
+				FetchNextPayloadAsync,
+				cancellationToken)
+			.ConfigureAwait(false);
+		return true;
+
+		async ValueTask<ResultFlowPagerPage?> FetchNextPayloadAsync(CancellationToken token)
+		{
+			if (string.IsNullOrWhiteSpace(nextCursor))
+			{
+				return null;
+			}
+
+			var nextRequest = request with { Cursor = nextCursor };
+			var nextPage = await FetchPageSourceAsync(source, nextRequest, token).ConfigureAwait(false);
+			nextCursor = nextPage.PageInfo.NextCursor;
+			var nextPayload = await transformer.TransformAsync(CreatePagerDisplayPage(nextPage), token)
+				.ConfigureAwait(false);
+			nextPayload = TryColorizeStructuredPayload(nextPayload, format, isInteractive);
+			return new ResultFlowPagerPage(nextPayload, nextPage.PageInfo.HasMore);
+		}
 	}
 
 	private async ValueTask WritePayloadAsync(
@@ -739,6 +812,21 @@ public sealed partial class CoreReplApp
 		ResultFlowInvocationOptions? resultFlow,
 		[NotNullWhen(true)] out IReplKeyReader? keyReader,
 		out int visibleRows)
+		=> TryCreatePager(
+			payload,
+			format,
+			resultFlow,
+			hasMorePayload: false,
+			out keyReader,
+			out visibleRows);
+
+	private bool TryCreatePager(
+		string payload,
+		string format,
+		ResultFlowInvocationOptions? resultFlow,
+		bool hasMorePayload,
+		[NotNullWhen(true)] out IReplKeyReader? keyReader,
+		out int visibleRows)
 	{
 		keyReader = null;
 		visibleRows = 0;
@@ -753,7 +841,7 @@ public sealed partial class CoreReplApp
 		}
 
 		if (!TryResolvePagerVisibleRows(out visibleRows)
-			|| ResultFlowPager.CountLines(payload) <= visibleRows
+			|| (!hasMorePayload && ResultFlowPager.CountLines(payload) <= visibleRows)
 			|| !TryResolvePagerKeyReader(out keyReader))
 		{
 			return false;
@@ -793,6 +881,38 @@ public sealed partial class CoreReplApp
 	private static bool IsPagedHumanFormat(string format) =>
 		string.Equals(format, "human", StringComparison.OrdinalIgnoreCase)
 		|| string.Equals(format, "spectre", StringComparison.OrdinalIgnoreCase);
+
+	private ReplPageRequest CreatePageSourceRequest(ResultFlowInvocationOptions? resultFlow)
+	{
+		var surface = ResolveResultSurface();
+		return new ReplPagingContext(
+				_options.Output.ResultFlow,
+				resultFlow ?? new ResultFlowInvocationOptions(),
+				surface,
+				ResolveVisibleRowCapacityHint(surface))
+			.CreateRequest();
+	}
+
+	private static IReplPage CreatePagerDisplayPage(IReplPage page)
+	{
+		if (!page.PageInfo.HasMore)
+		{
+			return page;
+		}
+
+		var pageInfo = page.PageInfo with
+		{
+			NextCursor = null,
+			HasMore = false,
+		};
+		return new ReplPageDisplaySnapshot(page, pageInfo);
+	}
+
+	private static ValueTask<IReplPage> FetchPageSourceAsync(
+		IReplPageSource source,
+		ReplPageRequest request,
+		CancellationToken cancellationToken) =>
+		source.FetchPageAsync(request, cancellationToken);
 
 	private string TryColorizeStructuredPayload(string payload, string format, bool isInteractive)
 	{

--- a/src/Repl.Core/CoreReplApp.Execution.cs
+++ b/src/Repl.Core/CoreReplApp.Execution.cs
@@ -1138,7 +1138,19 @@ public sealed partial class CoreReplApp
 			var height = Console.WindowHeight;
 			return height > 0 ? height : null;
 		}
-		catch
+		catch (IOException)
+		{
+			return null;
+		}
+		catch (PlatformNotSupportedException)
+		{
+			return null;
+		}
+		catch (InvalidOperationException)
+		{
+			return null;
+		}
+		catch (System.Security.SecurityException)
 		{
 			return null;
 		}

--- a/src/Repl.Core/CoreReplApp.Execution.cs
+++ b/src/Repl.Core/CoreReplApp.Execution.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 
 namespace Repl;
 
-public sealed partial class CoreReplApp
+public sealed partial class CoreReplApp : ISubInvocableReplApp
 {
 	/// <summary>
 	/// Runs the app in synchronous mode.
@@ -52,6 +52,12 @@ public sealed partial class CoreReplApp
 		IServiceProvider serviceProvider,
 		CancellationToken cancellationToken = default) =>
 		ExecuteCoreAsync(args, serviceProvider, isSubInvocation: true, cancellationToken);
+
+	ValueTask<int> ISubInvocableReplApp.RunSubInvocationAsync(
+		string[] args,
+		IServiceProvider serviceProvider,
+		CancellationToken cancellationToken) =>
+		RunSubInvocationAsync(args, serviceProvider, cancellationToken);
 
 	private async ValueTask<int> ExecuteCoreAsync(
 		IReadOnlyList<string> args,
@@ -1054,7 +1060,8 @@ public sealed partial class CoreReplApp
 	private IReplResultFlowDiagnostics? ResolveResultFlowDiagnostics()
 	{
 		var serviceProvider = _runtimeState.Value?.ServiceProvider ?? _services;
-		return serviceProvider.GetService(typeof(IReplResultFlowDiagnostics)) as IReplResultFlowDiagnostics;
+		return serviceProvider.GetService(typeof(IReplResultFlowDiagnostics)) as IReplResultFlowDiagnostics
+			?? _services.GetService(typeof(IReplResultFlowDiagnostics)) as IReplResultFlowDiagnostics;
 	}
 
 	private string TryColorizeStructuredPayload(string payload, string format, bool isInteractive)

--- a/src/Repl.Core/CoreReplApp.Execution.cs
+++ b/src/Repl.Core/CoreReplApp.Execution.cs
@@ -804,14 +804,17 @@ public sealed partial class CoreReplApp
 				pagerPayload,
 				ReplSessionIO.Output,
 				keyReader,
-				visibleRows,
-				ResolvePagerVisibleRows,
-				pagerMode,
-				ansiEnabled,
-				page.PageInfo.HasMore,
-				FetchNextPayloadAsync,
-				_options.Output.ResultFlow.PagerRenderers,
-				_options.Output.ResultFlow.MaxBufferedLines,
+				new ResultFlowPagerOptions
+				{
+					VisibleRows = visibleRows,
+					VisibleRowsProvider = ResolvePagerVisibleRows,
+					PagerMode = pagerMode,
+					AnsiEnabled = ansiEnabled,
+					HasMorePayload = page.PageInfo.HasMore,
+					FetchNextPayload = FetchNextPayloadAsync,
+					PagerRenderers = _options.Output.ResultFlow.PagerRenderers,
+					MaxBufferedLines = _options.Output.ResultFlow.MaxBufferedLines,
+				},
 				cancellationToken)
 			.ConfigureAwait(false);
 		return true;
@@ -886,14 +889,14 @@ public sealed partial class CoreReplApp
 					payload,
 					ReplSessionIO.Output,
 					keyReader,
-					visibleRows,
-					visibleRowsProvider: null,
-					pagerMode,
-					ansiEnabled,
-					hasMorePayload: false,
-					fetchNextPayload: null,
-					_options.Output.ResultFlow.PagerRenderers,
-					_options.Output.ResultFlow.MaxBufferedLines,
+					new ResultFlowPagerOptions
+					{
+						VisibleRows = visibleRows,
+						PagerMode = pagerMode,
+						AnsiEnabled = ansiEnabled,
+						PagerRenderers = _options.Output.ResultFlow.PagerRenderers,
+						MaxBufferedLines = _options.Output.ResultFlow.MaxBufferedLines,
+					},
 					cancellationToken)
 				.ConfigureAwait(false);
 			return;

--- a/src/Repl.Core/CoreReplApp.Execution.cs
+++ b/src/Repl.Core/CoreReplApp.Execution.cs
@@ -780,6 +780,7 @@ public sealed partial class CoreReplApp
 				page.PageInfo.HasMore,
 				FetchNextPayloadAsync,
 				_options.Output.ResultFlow.PagerRenderers,
+				_options.Output.ResultFlow.MaxBufferedLines,
 				cancellationToken)
 			.ConfigureAwait(false);
 		return true;
@@ -858,6 +859,7 @@ public sealed partial class CoreReplApp
 					hasMorePayload: false,
 					fetchNextPayload: null,
 					_options.Output.ResultFlow.PagerRenderers,
+					_options.Output.ResultFlow.MaxBufferedLines,
 					cancellationToken)
 				.ConfigureAwait(false);
 			return;
@@ -976,11 +978,47 @@ public sealed partial class CoreReplApp
 		return new ReplPageDisplaySnapshot(page, pageInfo);
 	}
 
-	private static ValueTask<IReplPage> FetchPageSourceAsync(
+	private async ValueTask<IReplPage> FetchPageSourceAsync(
 		IReplPageSource source,
 		ReplPageRequest request,
-		CancellationToken cancellationToken) =>
-		source.FetchPageAsync(request, cancellationToken);
+		CancellationToken cancellationToken)
+	{
+		var diagnostics = ResolveResultFlowDiagnostics();
+		diagnostics?.OnDiagnostic(new ReplResultFlowDiagnostic(
+			ReplResultFlowDiagnosticKind.PageFetchStarting,
+			request.Cursor,
+			request.PageSize));
+
+		try
+		{
+			var page = await source.FetchPageAsync(request, cancellationToken).ConfigureAwait(false);
+			diagnostics?.OnDiagnostic(new ReplResultFlowDiagnostic(
+				ReplResultFlowDiagnosticKind.PageFetchSucceeded,
+				request.Cursor,
+				request.PageSize,
+				page.UntypedItems.Count));
+			return page;
+		}
+		catch (OperationCanceledException)
+		{
+			throw;
+		}
+		catch (Exception ex)
+		{
+			diagnostics?.OnDiagnostic(new ReplResultFlowDiagnostic(
+				ReplResultFlowDiagnosticKind.PageFetchFailed,
+				request.Cursor,
+				request.PageSize,
+				Exception: ex));
+			throw;
+		}
+	}
+
+	private IReplResultFlowDiagnostics? ResolveResultFlowDiagnostics()
+	{
+		var serviceProvider = _runtimeState.Value?.ServiceProvider ?? _services;
+		return serviceProvider.GetService(typeof(IReplResultFlowDiagnostics)) as IReplResultFlowDiagnostics;
+	}
 
 	private string TryColorizeStructuredPayload(string payload, string format, bool isInteractive)
 	{

--- a/src/Repl.Core/CoreReplApp.Execution.cs
+++ b/src/Repl.Core/CoreReplApp.Execution.cs
@@ -831,6 +831,7 @@ public sealed partial class CoreReplApp
 		CancellationToken cancellationToken)
 	{
 		var contextValues = BuildContextHierarchyValues(match.Route.Template, matchedPathTokens, contexts);
+		contextValues.Add(CreatePagingContext(globalOptions));
 		var mergedNamedOptions = MergeNamedOptions(
 			parsedOptions.NamedOptions,
 			globalOptions.CustomGlobalNamedOptions);
@@ -846,6 +847,69 @@ public sealed partial class CoreReplApp
 			_options.Interaction,
 			_implicitServiceParameters,
 			cancellationToken);
+	}
+
+	private ReplPagingContext CreatePagingContext(GlobalInvocationOptions globalOptions)
+	{
+		var surface = ResolveResultSurface();
+		var visibleRows = ResolveVisibleRowCapacityHint(surface);
+		return new ReplPagingContext(
+			_options.Output.ResultFlow,
+			globalOptions.ResultFlow,
+			surface,
+			visibleRows);
+	}
+
+	private ReplResultSurface ResolveResultSurface()
+	{
+		if (ReplSessionIO.IsProgrammatic)
+		{
+			return ReplResultSurface.Programmatic;
+		}
+
+		if (_runtimeState.Value?.IsInteractiveSession == true)
+		{
+			return ReplResultSurface.Interactive;
+		}
+
+		if (ReplSessionIO.IsHostedSession)
+		{
+			return ReplResultSurface.Hosted;
+		}
+
+		return Console.IsOutputRedirected
+			? ReplResultSurface.Redirected
+			: ReplResultSurface.Console;
+	}
+
+	private int? ResolveVisibleRowCapacityHint(ReplResultSurface surface)
+	{
+		if (surface is ReplResultSurface.Redirected or ReplResultSurface.Programmatic)
+		{
+			return null;
+		}
+
+		var height = ReplSessionIO.WindowSize?.Height ?? TryGetConsoleWindowHeight();
+		if (height is not > 0)
+		{
+			return null;
+		}
+
+		var reservedRows = Math.Max(0, _options.Output.ResultFlow.ReservedVisibleRows);
+		return Math.Max(1, height.Value - reservedRows);
+	}
+
+	private static int? TryGetConsoleWindowHeight()
+	{
+		try
+		{
+			var height = Console.WindowHeight;
+			return height > 0 ? height : null;
+		}
+		catch
+		{
+			return null;
+		}
 	}
 
 	private static bool TryFindGlobalCommandOptionCollision(

--- a/src/Repl.Core/Documentation/DocumentationEngine.cs
+++ b/src/Repl.Core/Documentation/DocumentationEngine.cs
@@ -15,51 +15,8 @@ internal sealed class DocumentationEngine(CoreReplApp app)
 	/// </summary>
 	public ReplDocumentationModel CreateDocumentationModel(string? targetPath = null)
 	{
-		var activeGraph = app.ResolveActiveRoutingGraph();
-		var normalizedTargetPath = NormalizePath(targetPath);
-		var targetTokens = string.IsNullOrWhiteSpace(normalizedTargetPath)
-			? []
-			: normalizedTargetPath
-				.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-		var discoverableRoutes = app.ResolveDiscoverableRoutes(
-			activeGraph.Routes,
-			activeGraph.Contexts,
-			targetTokens,
-			StringComparison.OrdinalIgnoreCase);
-		var discoverableContexts = app.ResolveDiscoverableContexts(
-			activeGraph.Contexts,
-			targetTokens,
-			StringComparison.OrdinalIgnoreCase);
-		var commands = SelectDocumentationCommands(
-			normalizedTargetPath,
-			discoverableRoutes,
-			discoverableContexts,
-			out _);
-
-		var contexts = SelectDocumentationContexts(normalizedTargetPath, commands, discoverableContexts);
-		var commandDocs = commands.Select(BuildDocumentationCommand).ToArray();
-		var contextDocs = contexts
-			.Select(context => new ReplDocContext(
-				Path: context.Template.Template,
-				Description: context.Description,
-				IsDynamic: context.Template.Segments.Any(segment => segment is DynamicRouteSegment),
-				IsHidden: context.IsHidden,
-				Details: context.Details))
-			.ToArray();
-		var resourceDocs = commandDocs
-			.Where(cmd => cmd.IsResource || cmd.Annotations?.ReadOnly == true)
-			.Select(cmd => new ReplDocResource(
-				Path: cmd.Path,
-				Description: cmd.Description,
-				Details: cmd.Details,
-				Arguments: cmd.Arguments,
-				Options: cmd.Options))
-			.ToArray();
-		return new ReplDocumentationModel(
-			App: BuildDocumentationApp(),
-			Contexts: contextDocs,
-			Commands: commandDocs,
-			Resources: resourceDocs);
+		var (model, _) = CreateDocumentationModelCore(targetPath);
+		return model;
 	}
 
 	/// <summary>
@@ -79,6 +36,12 @@ internal sealed class DocumentationEngine(CoreReplApp app)
 	/// Internal documentation model creation that supports not-found result for help rendering.
 	/// </summary>
 	public object CreateDocumentationModelInternal(string? targetPath)
+	{
+		var (model, notFoundResult) = CreateDocumentationModelCore(targetPath);
+		return notFoundResult is null ? model : notFoundResult;
+	}
+
+	private (ReplDocumentationModel Model, IReplResult? NotFoundResult) CreateDocumentationModelCore(string? targetPath)
 	{
 		var activeGraph = app.ResolveActiveRoutingGraph();
 		var normalizedTargetPath = NormalizePath(targetPath);
@@ -100,10 +63,6 @@ internal sealed class DocumentationEngine(CoreReplApp app)
 			discoverableRoutes,
 			discoverableContexts,
 			out var notFoundResult);
-		if (notFoundResult is not null)
-		{
-			return notFoundResult;
-		}
 
 		var contexts = SelectDocumentationContexts(normalizedTargetPath, commands, discoverableContexts);
 		var commandDocs = commands.Select(BuildDocumentationCommand).ToArray();
@@ -124,11 +83,12 @@ internal sealed class DocumentationEngine(CoreReplApp app)
 				Arguments: cmd.Arguments,
 				Options: cmd.Options))
 			.ToArray();
-		return new ReplDocumentationModel(
+		var model = new ReplDocumentationModel(
 			App: BuildDocumentationApp(),
 			Contexts: contextDocs,
 			Commands: commandDocs,
 			Resources: resourceDocs);
+		return (model, notFoundResult);
 	}
 
 	private static RouteDefinition[] SelectDocumentationCommands(

--- a/src/Repl.Core/Documentation/DocumentationEngine.cs
+++ b/src/Repl.Core/Documentation/DocumentationEngine.cs
@@ -220,19 +220,34 @@ internal sealed class DocumentationEngine(CoreReplApp app)
 			.Select(segment => segment.Name)
 			.ToHashSet(StringComparer.OrdinalIgnoreCase);
 		var handlerParams = route.Command.Handler.Method.GetParameters();
-		var arguments = dynamicSegments
-			.Select(segment =>
-			{
-				var paramInfo = handlerParams.FirstOrDefault(p =>
-					string.Equals(p.Name, segment.Name, StringComparison.OrdinalIgnoreCase));
-				var description = paramInfo?.GetCustomAttribute<DescriptionAttribute>()?.Description;
-				return new ReplDocArgument(
-					Name: segment.Name,
-					Type: GetConstraintTypeName(segment.ConstraintKind),
-					Required: !segment.IsOptional,
-					Description: description);
-			})
-			.ToArray();
+		var arguments = BuildDocumentationArguments(dynamicSegments, handlerParams);
+		var options = BuildDocumentationOptions(route, routeParameterNames, handlerParams);
+		var answers = BuildDocumentationAnswers(route.Command);
+		var acceptsPagingInput = handlerParams.Any(static parameter => parameter.ParameterType == typeof(IReplPagingContext));
+		var emitsPagedResult = IsPagedReturnType(route.Command.Handler.Method.ReturnType);
+
+		return new ReplDocCommand(
+			Path: route.Template.Template,
+			Description: route.Command.Description,
+			Aliases: route.Command.Aliases,
+			IsHidden: route.Command.IsHidden,
+			Arguments: arguments,
+			Options: options,
+			Details: route.Command.Details,
+			Annotations: route.Command.Annotations,
+			Metadata: route.Command.Metadata.Count > 0 ? route.Command.Metadata : null,
+			Answers: answers.Length > 0 ? answers : null,
+			IsResource: route.Command.IsResource,
+			IsPrompt: route.Command.IsPrompt,
+			AcceptsPagingInput: acceptsPagingInput,
+			EmitsPagedResult: emitsPagedResult);
+	}
+
+	private ReplDocOption[] BuildDocumentationOptions(
+		RouteDefinition route,
+		HashSet<string> routeParameterNames,
+		ParameterInfo[] handlerParams)
+	{
 		var regularOptions = handlerParams
 			.Where(parameter =>
 				!string.IsNullOrWhiteSpace(parameter.Name)
@@ -252,24 +267,25 @@ internal sealed class DocumentationEngine(CoreReplApp app)
 					.Where(prop => prop.CanWrite)
 					.Select(prop => BuildDocumentationOptionFromProperty(route.OptionSchema, prop, defaultInstance));
 			});
-		var options = regularOptions.Concat(groupOptions).ToArray();
-
-		var answers = BuildDocumentationAnswers(route.Command);
-
-		return new ReplDocCommand(
-			Path: route.Template.Template,
-			Description: route.Command.Description,
-			Aliases: route.Command.Aliases,
-			IsHidden: route.Command.IsHidden,
-			Arguments: arguments,
-			Options: options,
-			Details: route.Command.Details,
-			Annotations: route.Command.Annotations,
-			Metadata: route.Command.Metadata.Count > 0 ? route.Command.Metadata : null,
-			Answers: answers.Length > 0 ? answers : null,
-			IsResource: route.Command.IsResource,
-			IsPrompt: route.Command.IsPrompt);
+		return regularOptions.Concat(groupOptions).ToArray();
 	}
+
+	private static ReplDocArgument[] BuildDocumentationArguments(
+		DynamicRouteSegment[] dynamicSegments,
+		ParameterInfo[] handlerParams) =>
+		dynamicSegments
+			.Select(segment =>
+			{
+				var paramInfo = handlerParams.FirstOrDefault(p =>
+					string.Equals(p.Name, segment.Name, StringComparison.OrdinalIgnoreCase));
+				var description = paramInfo?.GetCustomAttribute<DescriptionAttribute>()?.Description;
+				return new ReplDocArgument(
+					Name: segment.Name,
+					Type: GetConstraintTypeName(segment.ConstraintKind),
+					Required: !segment.IsOptional,
+					Description: description);
+			})
+			.ToArray();
 
 	private static ReplDocAnswer[] BuildDocumentationAnswers(CommandBuilder command)
 	{
@@ -283,6 +299,26 @@ internal sealed class DocumentationEngine(CoreReplApp app)
 			.GroupBy(a => a.Name, StringComparer.OrdinalIgnoreCase)
 			.Select(g => g.First())
 			.ToArray();
+	}
+
+	private static bool IsPagedReturnType(Type returnType)
+	{
+		var effectiveType = UnwrapAsyncReturnType(returnType);
+		return typeof(IReplPage).IsAssignableFrom(effectiveType)
+			|| typeof(IReplPageSource).IsAssignableFrom(effectiveType);
+	}
+
+	private static Type UnwrapAsyncReturnType(Type returnType)
+	{
+		if (!returnType.IsGenericType)
+		{
+			return returnType;
+		}
+
+		var definition = returnType.GetGenericTypeDefinition();
+		return definition == typeof(Task<>) || definition == typeof(ValueTask<>)
+			? returnType.GetGenericArguments()[0]
+			: returnType;
 	}
 
 	internal ReplDocApp BuildDocumentationApp()

--- a/src/Repl.Core/Documentation/ReplDocCommand.cs
+++ b/src/Repl.Core/Documentation/ReplDocCommand.cs
@@ -15,4 +15,6 @@ public sealed record ReplDocCommand(
 	IReadOnlyDictionary<string, object>? Metadata = null,
 	IReadOnlyList<ReplDocAnswer>? Answers = null,
 	bool IsResource = false,
-	bool IsPrompt = false);
+	bool IsPrompt = false,
+	bool AcceptsPagingInput = false,
+	bool EmitsPagedResult = false);

--- a/src/Repl.Core/Help/HelpRenderCommand.cs
+++ b/src/Repl.Core/Help/HelpRenderCommand.cs
@@ -7,4 +7,5 @@ internal sealed record HelpRenderCommand(
 	IReadOnlyList<string> Aliases,
 	IReadOnlyList<HelpRenderEntry> Arguments,
 	IReadOnlyList<HelpRenderEntry> Options,
+	IReadOnlyList<HelpRenderEntry> ResultFlow,
 	IReadOnlyList<HelpRenderEntry> Answers);

--- a/src/Repl.Core/Help/HelpTextBuilder.Rendering.cs
+++ b/src/Repl.Core/Help/HelpTextBuilder.Rendering.cs
@@ -12,7 +12,7 @@ internal static partial class HelpTextBuilder
 		new("--result:page-size <n>", "Request a page size for paged handlers."),
 		new("--result:cursor <value>", "Continue from a cursor returned by a previous page."),
 		new("--result:all", "Request all rows when the handler supports it."),
-		new("--result:pager=auto|off|more|scroll|external", "Control the integrated pager for human output."),
+		new("--result:pager=auto|off|more|inline|full", "Control the integrated pager for human output."),
 	];
 
 	private static string BuildCommandHelp(RouteDefinition[] routes, bool useAnsi, AnsiPalette palette)

--- a/src/Repl.Core/Help/HelpTextBuilder.Rendering.cs
+++ b/src/Repl.Core/Help/HelpTextBuilder.Rendering.cs
@@ -7,6 +7,14 @@ namespace Repl;
 
 internal static partial class HelpTextBuilder
 {
+	private static readonly HelpRenderEntry[] ResultFlowRows =
+	[
+		new("--result:page-size <n>", "Request a page size for paged handlers."),
+		new("--result:cursor <value>", "Continue from a cursor returned by a previous page."),
+		new("--result:all", "Request all rows when the handler supports it."),
+		new("--result:pager=auto|off|more|scroll|external", "Control the integrated pager for human output."),
+	];
+
 	private static string BuildCommandHelp(RouteDefinition[] routes, bool useAnsi, AnsiPalette palette)
 	{
 		if (routes.Length == 1)
@@ -47,10 +55,11 @@ internal static partial class HelpTextBuilder
 			: $"{Environment.NewLine}Aliases: {string.Join(", ", route.Command.Aliases)}";
 		var argumentSection = BuildArgumentSection(route, useAnsi, palette);
 		var optionSection = BuildOptionSection(route, useAnsi, palette);
+		var resultFlowSection = BuildResultFlowSection(route, useAnsi, palette);
 		var answerSection = BuildAnswerSection(route, useAnsi, palette);
 		if (!useAnsi)
 		{
-			return $"Usage: {displayTemplate}{Environment.NewLine}Description: {description}{aliases}{argumentSection}{optionSection}{answerSection}";
+			return $"Usage: {displayTemplate}{Environment.NewLine}Description: {description}{aliases}{argumentSection}{optionSection}{resultFlowSection}{answerSection}";
 		}
 
 		var usage = $"{AnsiText.Apply("Usage:", palette.SectionStyle)} {AnsiText.Apply(displayTemplate, palette.CommandStyle)}";
@@ -58,7 +67,7 @@ internal static partial class HelpTextBuilder
 		var aliasText = route.Command.Aliases.Count == 0
 			? string.Empty
 			: $"{Environment.NewLine}{AnsiText.Apply("Aliases:", palette.SectionStyle)} {AnsiText.Apply(string.Join(", ", route.Command.Aliases), palette.CommandStyle)}";
-		return $"{usage}{Environment.NewLine}{desc}{aliasText}{argumentSection}{optionSection}{answerSection}";
+		return $"{usage}{Environment.NewLine}{desc}{aliasText}{argumentSection}{optionSection}{resultFlowSection}{answerSection}";
 	}
 
 	private static string BuildArgumentSection(RouteDefinition route, bool useAnsi, AnsiPalette palette)
@@ -99,6 +108,29 @@ internal static partial class HelpTextBuilder
 			? AnsiText.Apply("Answers:", palette.SectionStyle)
 			: "Answers:");
 		foreach (var row in rows)
+		{
+			builder.AppendLine();
+			builder.Append(useAnsi
+				? $"  {AnsiText.Apply(row.Name, palette.CommandStyle)}  {AnsiText.Apply(row.Description, palette.DescriptionStyle)}"
+				: $"  {row.Name}  {row.Description}");
+		}
+
+		return builder.ToString();
+	}
+
+	private static string BuildResultFlowSection(RouteDefinition route, bool useAnsi, AnsiPalette palette)
+	{
+		if (!UsesResultFlow(route))
+		{
+			return string.Empty;
+		}
+
+		var builder = new StringBuilder();
+		builder.AppendLine();
+		builder.Append(useAnsi
+			? AnsiText.Apply("Result Flow:", palette.SectionStyle)
+			: "Result Flow:");
+		foreach (var row in ResultFlowRows)
 		{
 			builder.AppendLine();
 			builder.Append(useAnsi
@@ -255,6 +287,31 @@ internal static partial class HelpTextBuilder
 			.Where(row => row is not null)
 			.Select(row => new HelpRenderEntry(row![0], row[1]))
 			.ToArray();
+	}
+
+	private static bool UsesResultFlow(RouteDefinition route) =>
+		route.Command.Handler.Method.GetParameters()
+			.Any(static parameter => parameter.ParameterType == typeof(IReplPagingContext))
+		|| IsPagedReturnType(route.Command.Handler.Method.ReturnType);
+
+	private static bool IsPagedReturnType(Type returnType)
+	{
+		var effectiveType = UnwrapAsyncReturnType(returnType);
+		return typeof(IReplPage).IsAssignableFrom(effectiveType)
+			|| typeof(IReplPageSource).IsAssignableFrom(effectiveType);
+	}
+
+	private static Type UnwrapAsyncReturnType(Type returnType)
+	{
+		if (!returnType.IsGenericType)
+		{
+			return returnType;
+		}
+
+		var definition = returnType.GetGenericTypeDefinition();
+		return definition == typeof(Task<>) || definition == typeof(ValueTask<>)
+			? returnType.GetGenericArguments()[0]
+			: returnType;
 	}
 
 	private static bool IsDefaultForType(object value, Type type)

--- a/src/Repl.Core/Help/HelpTextBuilder.Rendering.cs
+++ b/src/Repl.Core/Help/HelpTextBuilder.Rendering.cs
@@ -9,10 +9,10 @@ internal static partial class HelpTextBuilder
 {
 	private static readonly HelpRenderEntry[] ResultFlowRows =
 	[
-		new("--result:page-size <n>", "Request a page size for paged handlers."),
-		new("--result:cursor <value>", "Continue from a cursor returned by a previous page."),
-		new("--result:all", "Request all rows when the handler supports it."),
-		new("--result:pager=auto|off|more|inline|full", "Control the integrated pager for human output."),
+		new($"{ReplResultFlowOptionNames.PageSize} <n>", "Request a page size for paged handlers."),
+		new($"{ReplResultFlowOptionNames.Cursor} <value>", "Continue from a cursor returned by a previous page."),
+		new(ReplResultFlowOptionNames.All, "Request all rows when the handler supports it."),
+		new($"{ReplResultFlowOptionNames.Pager}=auto|off|more|inline|full", "Control the integrated pager for human output."),
 	];
 
 	private static string BuildCommandHelp(RouteDefinition[] routes, bool useAnsi, AnsiPalette palette)

--- a/src/Repl.Core/Help/HelpTextBuilder.cs
+++ b/src/Repl.Core/Help/HelpTextBuilder.cs
@@ -268,6 +268,7 @@ internal static partial class HelpTextBuilder
 			Aliases: route.Command.Aliases.ToArray(),
 			Arguments: BuildArgumentRows(route),
 			Options: BuildOptionRows(route),
+			ResultFlow: UsesResultFlow(route) ? ResultFlowRows : [],
 			Answers: BuildAnswerRows(route));
 	}
 
@@ -310,6 +311,7 @@ internal static partial class HelpTextBuilder
 					Aliases: aliases,
 					Arguments: [],
 					Options: [],
+					ResultFlow: [],
 					Answers: []);
 			})
 			.Where(command => command is not null)

--- a/src/Repl.Core/IOutputTransformer.cs
+++ b/src/Repl.Core/IOutputTransformer.cs
@@ -11,6 +11,11 @@ public interface IOutputTransformer
 	string Name { get; }
 
 	/// <summary>
+	/// Gets a value indicating whether this transformer can be displayed by the interactive result pager.
+	/// </summary>
+	bool SupportsInteractivePaging => false;
+
+	/// <summary>
 	/// Transforms a value to the target representation.
 	/// </summary>
 	/// <param name="value">Input value.</param>

--- a/src/Repl.Core/IReplKeyReader.cs
+++ b/src/Repl.Core/IReplKeyReader.cs
@@ -4,6 +4,9 @@ namespace Repl;
 /// Injectable service for handlers that need raw key input (watch/top pattern).
 /// When a handler declares this parameter, it owns the console input and decides
 /// what each key means.
+/// Custom <see cref="IReplPagerRenderer"/> implementations can also use this
+/// service through <see cref="ReplPagerRenderContext"/> to drive interactive
+/// navigation without depending directly on <see cref="Console"/>.
 /// </summary>
 public interface IReplKeyReader
 {

--- a/src/Repl.Core/IResultFlowOutputTransformer.cs
+++ b/src/Repl.Core/IResultFlowOutputTransformer.cs
@@ -1,0 +1,9 @@
+namespace Repl;
+
+internal interface IResultFlowOutputTransformer : IOutputTransformer
+{
+	ValueTask<string> TransformPageAsync(
+		IReplPage page,
+		ResultFlowPageRenderMode mode,
+		CancellationToken cancellationToken = default);
+}

--- a/src/Repl.Core/ISubInvocableReplApp.cs
+++ b/src/Repl.Core/ISubInvocableReplApp.cs
@@ -1,0 +1,9 @@
+namespace Repl;
+
+internal interface ISubInvocableReplApp
+{
+	ValueTask<int> RunSubInvocationAsync(
+		string[] args,
+		IServiceProvider serviceProvider,
+		CancellationToken cancellationToken = default);
+}

--- a/src/Repl.Core/Output/HumanOutputTransformer.cs
+++ b/src/Repl.Core/Output/HumanOutputTransformer.cs
@@ -23,6 +23,8 @@ internal sealed class HumanOutputTransformer : IOutputTransformer
 
 	public string Name => "human";
 
+	public bool SupportsInteractivePaging => true;
+
 	public ValueTask<string> TransformAsync(object? value, CancellationToken cancellationToken = default)
 	{
 		cancellationToken.ThrowIfCancellationRequested();

--- a/src/Repl.Core/Output/HumanOutputTransformer.cs
+++ b/src/Repl.Core/Output/HumanOutputTransformer.cs
@@ -33,6 +33,11 @@ internal sealed class HumanOutputTransformer : IOutputTransformer
 			return ValueTask.FromResult(string.Empty);
 		}
 
+		if (value is IReplPage page)
+		{
+			return ValueTask.FromResult(RenderPage(page, settings));
+		}
+
 		if (value is IReplResult replResult)
 		{
 			return ValueTask.FromResult(RenderReplResult(replResult, settings));
@@ -78,6 +83,37 @@ internal sealed class HumanOutputTransformer : IOutputTransformer
 
 		return ValueTask.FromResult(
 			Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty);
+	}
+
+	private static string RenderPage(IReplPage page, HumanRenderSettings settings)
+	{
+		var body = page.UntypedItems.Count == 0
+			? "No results."
+			: RenderCollection(page.UntypedItems, depth: 0, settings);
+		var footer = RenderPageFooter(page);
+		return string.IsNullOrWhiteSpace(footer)
+			? body
+			: string.Concat(body, Environment.NewLine, footer);
+	}
+
+	private static string RenderPageFooter(IReplPage page)
+	{
+		var info = page.PageInfo;
+		var count = page.UntypedItems.Count;
+		if (info.TotalCount is { } total)
+		{
+			var prefix = $"Showing {count.ToString(CultureInfo.InvariantCulture)} of {total.ToString(CultureInfo.InvariantCulture)}.";
+			return info.HasMore
+				? $"{prefix} Continue with --result:cursor {info.NextCursor}."
+				: prefix;
+		}
+
+		if (!info.HasMore)
+		{
+			return string.Empty;
+		}
+
+		return $"Showing {count.ToString(CultureInfo.InvariantCulture)} result(s). Continue with --result:cursor {info.NextCursor}.";
 	}
 
 	private static bool TryRenderObject(object value, HumanRenderSettings settings, out string text)
@@ -361,6 +397,11 @@ internal sealed class HumanOutputTransformer : IOutputTransformer
 		if (result.Details is null)
 		{
 			return message;
+		}
+
+		if (result.Details is IReplPage page)
+		{
+			return $"{message}{Environment.NewLine}{RenderPage(page, settings)}";
 		}
 
 		if (TryRenderDictionary(result.Details, settings, out var dictionaryText))

--- a/src/Repl.Core/Output/HumanOutputTransformer.cs
+++ b/src/Repl.Core/Output/HumanOutputTransformer.cs
@@ -130,7 +130,7 @@ internal sealed class HumanOutputTransformer : IResultFlowOutputTransformer
 		{
 			var prefix = $"Showing {count.ToString(CultureInfo.InvariantCulture)} of {total.ToString(CultureInfo.InvariantCulture)}.";
 			return info.HasMore
-				? $"{prefix} Next data page: rerun with --result:cursor {info.NextCursor}."
+				? $"{prefix} Next data page: rerun with {ResultFlowCursorPolicy.FormatCliContinuation(info.NextCursor)}."
 				: prefix;
 		}
 
@@ -139,7 +139,7 @@ internal sealed class HumanOutputTransformer : IResultFlowOutputTransformer
 			return string.Empty;
 		}
 
-		return $"Showing {count.ToString(CultureInfo.InvariantCulture)} result(s). Next data page: rerun with --result:cursor {info.NextCursor}.";
+		return $"Showing {count.ToString(CultureInfo.InvariantCulture)} result(s). Next data page: rerun with {ResultFlowCursorPolicy.FormatCliContinuation(info.NextCursor)}.";
 	}
 
 	private static bool TryRenderObject(object value, HumanRenderSettings settings, out string text)

--- a/src/Repl.Core/Output/HumanOutputTransformer.cs
+++ b/src/Repl.Core/Output/HumanOutputTransformer.cs
@@ -116,30 +116,10 @@ internal sealed class HumanOutputTransformer : IResultFlowOutputTransformer
 				depth: 0,
 				settings,
 				includeTableHeader: mode == ResultFlowPageRenderMode.Initial);
-		var footer = includeFooter ? RenderPageFooter(page) : string.Empty;
+		var footer = includeFooter ? ResultFlowPageFooterBuilder.RenderHuman(page) : string.Empty;
 		return string.IsNullOrWhiteSpace(footer)
 			? body
 			: string.Concat(body, Environment.NewLine, footer);
-	}
-
-	private static string RenderPageFooter(IReplPage page)
-	{
-		var info = page.PageInfo;
-		var count = page.UntypedItems.Count;
-		if (info.TotalCount is { } total)
-		{
-			var prefix = $"Showing {count.ToString(CultureInfo.InvariantCulture)} of {total.ToString(CultureInfo.InvariantCulture)}.";
-			return info.HasMore
-				? $"{prefix} Next data page: rerun with {ResultFlowCursorPolicy.FormatCliContinuation(info.NextCursor)}."
-				: prefix;
-		}
-
-		if (!info.HasMore)
-		{
-			return string.Empty;
-		}
-
-		return $"Showing {count.ToString(CultureInfo.InvariantCulture)} result(s). Next data page: rerun with {ResultFlowCursorPolicy.FormatCliContinuation(info.NextCursor)}.";
 	}
 
 	private static bool TryRenderObject(object value, HumanRenderSettings settings, out string text)

--- a/src/Repl.Core/Output/HumanOutputTransformer.cs
+++ b/src/Repl.Core/Output/HumanOutputTransformer.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Repl;
 
-internal sealed class HumanOutputTransformer : IOutputTransformer
+internal sealed class HumanOutputTransformer : IResultFlowOutputTransformer
 {
 	private readonly Func<HumanRenderSettings> _resolveRenderSettings;
 
@@ -60,7 +60,7 @@ internal sealed class HumanOutputTransformer : IOutputTransformer
 				return ValueTask.FromResult("No results.");
 			}
 
-			if (TryRenderTable(lines, settings, out var tableText))
+			if (TryRenderTable(lines, settings, includeHeader: true, out var tableText))
 			{
 				return ValueTask.FromResult(tableText);
 			}
@@ -87,12 +87,36 @@ internal sealed class HumanOutputTransformer : IOutputTransformer
 			Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty);
 	}
 
-	private static string RenderPage(IReplPage page, HumanRenderSettings settings)
+	public ValueTask<string> TransformPageAsync(
+		IReplPage page,
+		ResultFlowPageRenderMode mode,
+		CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(page);
+		cancellationToken.ThrowIfCancellationRequested();
+		return ValueTask.FromResult(RenderPage(page, _resolveRenderSettings(), mode));
+	}
+
+	private static string RenderPage(IReplPage page, HumanRenderSettings settings) =>
+		RenderPage(page, settings, ResultFlowPageRenderMode.Initial, includeFooter: true);
+
+	private static string RenderPage(IReplPage page, HumanRenderSettings settings, ResultFlowPageRenderMode mode) =>
+		RenderPage(page, settings, mode, includeFooter: false);
+
+	private static string RenderPage(
+		IReplPage page,
+		HumanRenderSettings settings,
+		ResultFlowPageRenderMode mode,
+		bool includeFooter)
 	{
 		var body = page.UntypedItems.Count == 0
 			? "No results."
-			: RenderCollection(page.UntypedItems, depth: 0, settings);
-		var footer = RenderPageFooter(page);
+			: RenderCollection(
+				page.UntypedItems,
+				depth: 0,
+				settings,
+				includeTableHeader: mode == ResultFlowPageRenderMode.Initial);
+		var footer = includeFooter ? RenderPageFooter(page) : string.Empty;
 		return string.IsNullOrWhiteSpace(footer)
 			? body
 			: string.Concat(body, Environment.NewLine, footer);
@@ -164,7 +188,11 @@ internal sealed class HumanOutputTransformer : IOutputTransformer
 		return true;
 	}
 
-	private static string RenderCollection(System.Collections.IEnumerable collection, int depth, HumanRenderSettings settings)
+	private static string RenderCollection(
+		System.Collections.IEnumerable collection,
+		int depth,
+		HumanRenderSettings settings,
+		bool includeTableHeader = true)
 	{
 		var values = collection.Cast<object?>().ToArray();
 		if (values.Length == 0)
@@ -172,7 +200,7 @@ internal sealed class HumanOutputTransformer : IOutputTransformer
 			return string.Empty;
 		}
 
-		if (TryRenderTable(values, settings, out var tableText))
+		if (TryRenderTable(values, settings, includeTableHeader, out var tableText))
 		{
 			return tableText;
 		}
@@ -182,7 +210,11 @@ internal sealed class HumanOutputTransformer : IOutputTransformer
 			values.Select(value => $"- {RenderScalar(value, member: null, depth, compactCollection: false, settings.Width, settings)}"));
 	}
 
-	private static bool TryRenderTable(object?[] values, HumanRenderSettings settings, out string text)
+	private static bool TryRenderTable(
+		object?[] values,
+		HumanRenderSettings settings,
+		bool includeHeader,
+		out string text)
 	{
 		var firstNonNull = values.FirstOrDefault(value => value is not null);
 		if (firstNonNull is null)
@@ -206,24 +238,30 @@ internal sealed class HumanOutputTransformer : IOutputTransformer
 			return false;
 		}
 
-		var rows = BuildTableRows(values, members, settings);
-		var style = settings.UseAnsi
+		var rows = BuildTableRows(values, members, settings, includeHeader);
+		var style = includeHeader && settings.UseAnsi
 			? TextTableStyle.ForHeader(settings.Palette.TableHeaderStyle)
 			: TextTableStyle.None;
 		text = TextTableFormatter.FormatRows(
 			rows,
 			settings.Width,
-			includeHeaderSeparator: !settings.UseAnsi,
+			includeHeaderSeparator: includeHeader && !settings.UseAnsi,
 			style);
 		return true;
 	}
 
-	private static List<string[]> BuildTableRows(object?[] values, DisplayMember[] members, HumanRenderSettings settings)
+	private static List<string[]> BuildTableRows(
+		object?[] values,
+		DisplayMember[] members,
+		HumanRenderSettings settings,
+		bool includeHeader)
 	{
-		var rows = new List<string[]>(values.Length + 1)
+		var rows = new List<string[]>(values.Length + (includeHeader ? 1 : 0));
+		if (includeHeader)
 		{
-			members.Select(member => member.Label).ToArray(),
-		};
+			rows.Add(members.Select(member => member.Label).ToArray());
+		}
+
 		foreach (var item in values)
 		{
 			if (item is null)

--- a/src/Repl.Core/Output/HumanOutputTransformer.cs
+++ b/src/Repl.Core/Output/HumanOutputTransformer.cs
@@ -104,7 +104,7 @@ internal sealed class HumanOutputTransformer : IOutputTransformer
 		{
 			var prefix = $"Showing {count.ToString(CultureInfo.InvariantCulture)} of {total.ToString(CultureInfo.InvariantCulture)}.";
 			return info.HasMore
-				? $"{prefix} Continue with --result:cursor {info.NextCursor}."
+				? $"{prefix} Next data page: rerun with --result:cursor {info.NextCursor}."
 				: prefix;
 		}
 
@@ -113,7 +113,7 @@ internal sealed class HumanOutputTransformer : IOutputTransformer
 			return string.Empty;
 		}
 
-		return $"Showing {count.ToString(CultureInfo.InvariantCulture)} result(s). Continue with --result:cursor {info.NextCursor}.";
+		return $"Showing {count.ToString(CultureInfo.InvariantCulture)} result(s). Next data page: rerun with --result:cursor {info.NextCursor}.";
 	}
 
 	private static bool TryRenderObject(object value, HumanRenderSettings settings, out string text)

--- a/src/Repl.Core/Output/JsonOutputTransformer.cs
+++ b/src/Repl.Core/Output/JsonOutputTransformer.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Repl;
 
@@ -9,9 +10,23 @@ internal sealed class JsonOutputTransformer(JsonSerializerOptions serializerOpti
 	public ValueTask<string> TransformAsync(object? value, CancellationToken cancellationToken = default)
 	{
 		cancellationToken.ThrowIfCancellationRequested();
+		if (value is IReplPage page)
+		{
+#pragma warning disable IL2026 // JSON object serialization is an explicit extensibility behavior in v1.
+			return ValueTask.FromResult(JsonSerializer.Serialize(
+				new ReplPageJsonResult("page", page.UntypedItems, page.PageInfo),
+				serializerOptions));
+#pragma warning restore IL2026
+		}
+
 #pragma warning disable IL2026 // JSON object serialization is an explicit extensibility behavior in v1.
 		var payload = JsonSerializer.Serialize(value, serializerOptions);
 #pragma warning restore IL2026
 		return ValueTask.FromResult(payload);
 	}
+
+	private sealed record ReplPageJsonResult(
+		[property: JsonPropertyName("$type")] string Type,
+		IReadOnlyList<object?> Items,
+		ReplPageInfo PageInfo);
 }

--- a/src/Repl.Core/Output/MarkdownOutputTransformer.cs
+++ b/src/Repl.Core/Output/MarkdownOutputTransformer.cs
@@ -31,6 +31,11 @@ internal sealed class MarkdownOutputTransformer : IOutputTransformer
 			return ValueTask.FromResult(text);
 		}
 
+		if (value is IReplPage page)
+		{
+			return ValueTask.FromResult(RenderPage(page));
+		}
+
 		if (value is IReplResult result)
 		{
 			return ValueTask.FromResult(RenderReplResult(result));
@@ -68,6 +73,8 @@ internal sealed class MarkdownOutputTransformer : IOutputTransformer
 
 		var details = result.Details is string detailsText
 			? detailsText
+			: result.Details is IReplPage page
+				? RenderPage(page)
 			: result.Details is System.Collections.IEnumerable enumerable && result.Details is not string
 				? RenderEnumerable(enumerable)
 				: RenderObject(result.Details);
@@ -78,6 +85,37 @@ internal sealed class MarkdownOutputTransformer : IOutputTransformer
 		}
 
 		return string.Concat(message, Environment.NewLine, Environment.NewLine, details);
+	}
+
+	private static string RenderPage(IReplPage page)
+	{
+		var body = page.UntypedItems.Count == 0
+			? "No results."
+			: RenderEnumerable(page.UntypedItems);
+		var footer = RenderPageFooter(page);
+		return string.IsNullOrWhiteSpace(footer)
+			? body
+			: string.Concat(body, Environment.NewLine, Environment.NewLine, footer);
+	}
+
+	private static string RenderPageFooter(IReplPage page)
+	{
+		var info = page.PageInfo;
+		var count = page.UntypedItems.Count;
+		if (info.TotalCount is { } total)
+		{
+			var prefix = $"Showing {count} of {total}.";
+			return info.HasMore
+				? $"{prefix} Continue with `--result:cursor {info.NextCursor}`."
+				: prefix;
+		}
+
+		if (!info.HasMore)
+		{
+			return string.Empty;
+		}
+
+		return $"Showing {count} result(s). Continue with `--result:cursor {info.NextCursor}`.";
 	}
 
 	private static string RenderEnumerable(System.Collections.IEnumerable enumerable)

--- a/src/Repl.Core/Output/MarkdownOutputTransformer.cs
+++ b/src/Repl.Core/Output/MarkdownOutputTransformer.cs
@@ -125,7 +125,7 @@ internal sealed class MarkdownOutputTransformer : IOutputTransformer
 
 	private static string RenderEnumerable(System.Collections.IEnumerable enumerable)
 	{
-		var items = enumerable.Cast<object?>().ToArray();
+		var items = ToObjectArray(enumerable);
 		if (items.Length == 0)
 		{
 			return "No results.";
@@ -226,7 +226,7 @@ internal sealed class MarkdownOutputTransformer : IOutputTransformer
 
 		if (value is System.Collections.IEnumerable enumerable)
 		{
-			var count = enumerable.Cast<object?>().Count();
+			var count = CountEnumerable(enumerable);
 			return count.ToString(System.Globalization.CultureInfo.InvariantCulture);
 		}
 
@@ -254,6 +254,36 @@ internal sealed class MarkdownOutputTransformer : IOutputTransformer
 
 	private static string EscapeCell(string value) =>
 		value.Replace("|", "\\|", StringComparison.Ordinal);
+
+	private static object?[] ToObjectArray(System.Collections.IEnumerable enumerable)
+	{
+		if (enumerable is object?[] array)
+		{
+			return array;
+		}
+
+		if (enumerable is IReplPage page)
+		{
+			return page.UntypedItems as object?[] ?? [.. page.UntypedItems];
+		}
+
+		return enumerable.Cast<object?>().ToArray();
+	}
+
+	private static int CountEnumerable(System.Collections.IEnumerable enumerable)
+	{
+		if (enumerable is System.Collections.ICollection collection)
+		{
+			return collection.Count;
+		}
+
+		if (enumerable is IReadOnlyCollection<object?> readonlyCollection)
+		{
+			return readonlyCollection.Count;
+		}
+
+		return enumerable.Cast<object?>().Count();
+	}
 
 	private static string RenderHelp(HelpRenderDocument help)
 	{

--- a/src/Repl.Core/Output/MarkdownOutputTransformer.cs
+++ b/src/Repl.Core/Output/MarkdownOutputTransformer.cs
@@ -152,6 +152,8 @@ internal sealed class MarkdownOutputTransformer : IOutputTransformer
 				items.Select(item => $"- {item?.ToString() ?? string.Empty}"));
 		}
 
+		var emptyRow = new string[members.Length];
+		Array.Fill(emptyRow, string.Empty);
 		var rows = new List<string[]>(items.Length + 1)
 		{
 			members.Select(member => EscapeCell(member.Label)).ToArray(),
@@ -161,7 +163,7 @@ internal sealed class MarkdownOutputTransformer : IOutputTransformer
 		{
 			if (item is null)
 			{
-				rows.Add(members.Select(_ => string.Empty).ToArray());
+				rows.Add(emptyRow);
 				continue;
 			}
 

--- a/src/Repl.Core/Output/MarkdownOutputTransformer.cs
+++ b/src/Repl.Core/Output/MarkdownOutputTransformer.cs
@@ -111,7 +111,7 @@ internal sealed class MarkdownOutputTransformer : IOutputTransformer
 		{
 			var prefix = $"Showing {count} of {total}.";
 			return info.HasMore
-				? $"{prefix} Continue with `--result:cursor {info.NextCursor}`."
+				? $"{prefix} Continue with `{ResultFlowCursorPolicy.FormatCliContinuation(info.NextCursor)}`."
 				: prefix;
 		}
 
@@ -120,7 +120,7 @@ internal sealed class MarkdownOutputTransformer : IOutputTransformer
 			return string.Empty;
 		}
 
-		return $"Showing {count} result(s). Continue with `--result:cursor {info.NextCursor}`.";
+		return $"Showing {count} result(s). Continue with `{ResultFlowCursorPolicy.FormatCliContinuation(info.NextCursor)}`.";
 	}
 
 	private static string RenderEnumerable(System.Collections.IEnumerable enumerable)

--- a/src/Repl.Core/Output/MarkdownOutputTransformer.cs
+++ b/src/Repl.Core/Output/MarkdownOutputTransformer.cs
@@ -26,6 +26,11 @@ internal sealed class MarkdownOutputTransformer : IOutputTransformer
 			return ValueTask.FromResult(RenderDocumentation(documentation));
 		}
 
+		if (value is HelpRenderDocument help)
+		{
+			return ValueTask.FromResult(RenderHelp(help));
+		}
+
 		if (value is string text)
 		{
 			return ValueTask.FromResult(text);
@@ -248,6 +253,90 @@ internal sealed class MarkdownOutputTransformer : IOutputTransformer
 		|| type == typeof(TimeSpan);
 
 	private static string EscapeCell(string value) =>
+		value.Replace("|", "\\|", StringComparison.Ordinal);
+
+	private static string RenderHelp(HelpRenderDocument help)
+	{
+		var builder = new StringBuilder();
+		if (help.IsCommandHelp)
+		{
+			if (help.Commands.Count == 1)
+			{
+				RenderCommandHelp(builder, help.Commands[0]);
+			}
+			else
+			{
+				AppendEntrySection(builder, "Commands", help.Commands.Select(CommandEntry).ToArray());
+			}
+
+			return builder.ToString().TrimEnd();
+		}
+
+		builder.AppendLine($"# Help: {EscapeMarkdown(help.Scope)}");
+		AppendCommandSection(builder, help.Commands);
+		AppendEntrySection(builder, "Scopes", help.Scopes);
+		AppendEntrySection(builder, "Global Options", help.GlobalOptions);
+		AppendEntrySection(builder, "Global Commands", help.GlobalCommands);
+		return builder.ToString().TrimEnd();
+	}
+
+	private static void RenderCommandHelp(StringBuilder builder, HelpRenderCommand command)
+	{
+		builder.AppendLine($"# `{EscapeMarkdown(command.Usage)}`");
+		builder.AppendLine();
+		builder.AppendLine($"- **Usage**: `{EscapeMarkdown(command.Usage)}`");
+		builder.AppendLine($"- **Description**: {EscapeMarkdown(command.Description)}");
+		if (command.Aliases.Count > 0)
+		{
+			builder.AppendLine($"- **Aliases**: {EscapeMarkdown(string.Join(", ", command.Aliases))}");
+		}
+
+		AppendEntrySection(builder, "Arguments", command.Arguments);
+		AppendEntrySection(builder, "Options", command.Options);
+		AppendEntrySection(builder, "Result Flow", command.ResultFlow);
+		AppendEntrySection(builder, "Answers", command.Answers);
+	}
+
+	private static void AppendCommandSection(StringBuilder builder, IReadOnlyList<HelpRenderCommand> commands)
+	{
+		if (commands.Count == 0)
+		{
+			return;
+		}
+
+		AppendEntrySection(builder, "Commands", commands.Select(CommandEntry).ToArray());
+	}
+
+	private static HelpRenderEntry CommandEntry(HelpRenderCommand command) =>
+		new(command.Name, command.Description);
+
+	private static void AppendEntrySection(
+		StringBuilder builder,
+		string title,
+		IReadOnlyList<HelpRenderEntry> entries)
+	{
+		if (entries.Count == 0)
+		{
+			return;
+		}
+
+		builder.AppendLine();
+		builder.AppendLine($"## {title}");
+		builder.AppendLine();
+		builder.AppendLine("| Name | Description |");
+		builder.AppendLine("| --- | --- |");
+		foreach (var entry in entries)
+		{
+			builder
+				.Append("| `")
+				.Append(EscapeCell(entry.Name))
+				.Append("` | ")
+				.Append(EscapeCell(entry.Description))
+				.AppendLine(" |");
+		}
+	}
+
+	private static string EscapeMarkdown(string value) =>
 		value.Replace("|", "\\|", StringComparison.Ordinal);
 
 	[UnconditionalSuppressMessage(

--- a/src/Repl.Core/Output/MarkdownOutputTransformer.cs
+++ b/src/Repl.Core/Output/MarkdownOutputTransformer.cs
@@ -97,30 +97,10 @@ internal sealed class MarkdownOutputTransformer : IOutputTransformer
 		var body = page.UntypedItems.Count == 0
 			? "No results."
 			: RenderEnumerable(page.UntypedItems);
-		var footer = RenderPageFooter(page);
+		var footer = ResultFlowPageFooterBuilder.RenderMarkdown(page);
 		return string.IsNullOrWhiteSpace(footer)
 			? body
 			: string.Concat(body, Environment.NewLine, Environment.NewLine, footer);
-	}
-
-	private static string RenderPageFooter(IReplPage page)
-	{
-		var info = page.PageInfo;
-		var count = page.UntypedItems.Count;
-		if (info.TotalCount is { } total)
-		{
-			var prefix = $"Showing {count} of {total}.";
-			return info.HasMore
-				? $"{prefix} Continue with `{ResultFlowCursorPolicy.FormatCliContinuation(info.NextCursor)}`."
-				: prefix;
-		}
-
-		if (!info.HasMore)
-		{
-			return string.Empty;
-		}
-
-		return $"Showing {count} result(s). Continue with `{ResultFlowCursorPolicy.FormatCliContinuation(info.NextCursor)}`.";
 	}
 
 	private static string RenderEnumerable(System.Collections.IEnumerable enumerable)

--- a/src/Repl.Core/Output/ResultFlowPageFooterBuilder.cs
+++ b/src/Repl.Core/Output/ResultFlowPageFooterBuilder.cs
@@ -1,0 +1,41 @@
+using System.Globalization;
+
+namespace Repl;
+
+internal static class ResultFlowPageFooterBuilder
+{
+	public static string RenderHuman(IReplPage page)
+	{
+		var info = page.PageInfo;
+		var count = page.UntypedItems.Count;
+		var countText = count.ToString(CultureInfo.InvariantCulture);
+		if (info.TotalCount is { } total)
+		{
+			var prefix = $"Showing {countText} of {total.ToString(CultureInfo.InvariantCulture)}.";
+			return info.HasMore
+				? $"{prefix} Next data page: rerun with {ResultFlowCursorPolicy.FormatCliContinuation(info.NextCursor)}."
+				: prefix;
+		}
+
+		return info.HasMore
+			? $"Showing {countText} result(s). Next data page: rerun with {ResultFlowCursorPolicy.FormatCliContinuation(info.NextCursor)}."
+			: string.Empty;
+	}
+
+	public static string RenderMarkdown(IReplPage page)
+	{
+		var info = page.PageInfo;
+		var count = page.UntypedItems.Count.ToString(CultureInfo.InvariantCulture);
+		if (info.TotalCount is { } total)
+		{
+			var prefix = $"Showing {count} of {total.ToString(CultureInfo.InvariantCulture)}.";
+			return info.HasMore
+				? $"{prefix} Continue with `{ResultFlowCursorPolicy.FormatCliContinuation(info.NextCursor)}`."
+				: prefix;
+		}
+
+		return info.HasMore
+			? $"Showing {count} result(s). Continue with `{ResultFlowCursorPolicy.FormatCliContinuation(info.NextCursor)}`."
+			: string.Empty;
+	}
+}

--- a/src/Repl.Core/OutputOptions.cs
+++ b/src/Repl.Core/OutputOptions.cs
@@ -30,6 +30,8 @@ public sealed class OutputOptions
 		_transformers["xml"] = new XmlOutputTransformer(JsonSerializerOptions);
 		_transformers["yaml"] = new YamlOutputTransformer(JsonSerializerOptions);
 		_transformers["markdown"] = new MarkdownOutputTransformer();
+		_helpOutputFactories["markdown"] = static (routes, contexts, scopeTokens, parsingOptions, ambientOptions) =>
+			HelpTextBuilder.BuildRenderModel(routes, contexts, scopeTokens, parsingOptions, ambientOptions);
 
 		_aliases["json"] = "json";
 		_aliases["xml"] = "xml";

--- a/src/Repl.Core/OutputOptions.cs
+++ b/src/Repl.Core/OutputOptions.cs
@@ -91,6 +91,11 @@ public sealed class OutputOptions
 	public int FallbackWidth { get; set; } = 120;
 
 	/// <summary>
+	/// Gets result-flow options for paging and large result sets.
+	/// </summary>
+	public ResultFlowOptions ResultFlow { get; } = new();
+
+	/// <summary>
 	/// Gets JSON serializer options used by the JSON transformer.
 	/// </summary>
 	public JsonSerializerOptions JsonSerializerOptions { get; }

--- a/src/Repl.Core/Parsing/GlobalInvocationOptions.cs
+++ b/src/Repl.Core/Parsing/GlobalInvocationOptions.cs
@@ -13,6 +13,8 @@ internal sealed record GlobalInvocationOptions(
 
 	public string? OutputFormat { get; init; }
 
+	public ResultFlowInvocationOptions ResultFlow { get; init; } = new();
+
 	public IReadOnlyDictionary<string, string> PromptAnswers { get; init; } =
 		new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/Repl.Core/Parsing/GlobalInvocationOptions.cs
+++ b/src/Repl.Core/Parsing/GlobalInvocationOptions.cs
@@ -20,4 +20,8 @@ internal sealed record GlobalInvocationOptions(
 
 	public IReadOnlyDictionary<string, IReadOnlyList<string>> CustomGlobalNamedOptions { get; init; } =
 		new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+
+	public IReadOnlyList<ParseDiagnostic> Diagnostics { get; init; } = [];
+
+	public bool HasErrors => Diagnostics.Any(static diagnostic => diagnostic.Severity == ParseDiagnosticSeverity.Error);
 }

--- a/src/Repl.Core/Parsing/GlobalOptionParser.cs
+++ b/src/Repl.Core/Parsing/GlobalOptionParser.cs
@@ -68,7 +68,14 @@ internal static class GlobalOptionParser
 				continue;
 			}
 
-			if (TryParseResultFlowOption(args, ref index, argument, optionComparison, options.ResultFlow, out var resultFlow))
+			if (TryParseResultFlowOption(
+					args,
+					ref index,
+					argument,
+					optionComparison,
+					options.ResultFlow,
+					outputOptions.ResultFlow.MaxPageSize,
+					out var resultFlow))
 			{
 				options = options with { ResultFlow = resultFlow };
 				continue;
@@ -155,6 +162,7 @@ internal static class GlobalOptionParser
 		string argument,
 		StringComparison comparison,
 		ResultFlowInvocationOptions current,
+		int maxPageSize,
 		out ResultFlowInvocationOptions resultFlow)
 	{
 		const string prefix = "--result:";
@@ -168,7 +176,7 @@ internal static class GlobalOptionParser
 		if (TrySplitToken(token, '=', out var name, out var inlineValue)
 			|| TrySplitToken(token, ':', out name, out inlineValue))
 		{
-			return ApplyResultFlowOption(name, inlineValue, current, out resultFlow);
+			return ApplyResultFlowOption(name, inlineValue, current, maxPageSize, out resultFlow);
 		}
 
 		if (string.Equals(token, "all", comparison))
@@ -182,16 +190,17 @@ internal static class GlobalOptionParser
 			&& !args[index + 1].StartsWith('-'))
 		{
 			index++;
-			return ApplyResultFlowOption(token, args[index], current, out resultFlow);
+			return ApplyResultFlowOption(token, args[index], current, maxPageSize, out resultFlow);
 		}
 
-		return ApplyResultFlowOption(token, "true", current, out resultFlow);
+		return ApplyResultFlowOption(token, "true", current, maxPageSize, out resultFlow);
 	}
 
 	private static bool ApplyResultFlowOption(
 		string name,
 		string value,
 		ResultFlowInvocationOptions current,
+		int maxPageSize,
 		out ResultFlowInvocationOptions resultFlow)
 	{
 		resultFlow = current;
@@ -203,7 +212,7 @@ internal static class GlobalOptionParser
 				System.Globalization.CultureInfo.InvariantCulture,
 				out var pageSize))
 			{
-				resultFlow = current with { PageSize = pageSize };
+				resultFlow = current with { PageSize = ClampPageSize(pageSize, maxPageSize) };
 			}
 
 			return true;
@@ -238,6 +247,9 @@ internal static class GlobalOptionParser
 		string.Equals(token, "page-size", comparison)
 		|| string.Equals(token, "cursor", comparison)
 		|| string.Equals(token, "pager", comparison);
+
+	private static int ClampPageSize(int pageSize, int maxPageSize) =>
+		Math.Clamp(pageSize, 1, Math.Max(1, maxPageSize));
 
 	private static Dictionary<string, string> BuildCustomTokenMap(
 		IReadOnlyDictionary<string, GlobalOptionDefinition> definitions,

--- a/src/Repl.Core/Parsing/GlobalOptionParser.cs
+++ b/src/Repl.Core/Parsing/GlobalOptionParser.cs
@@ -68,6 +68,12 @@ internal static class GlobalOptionParser
 				continue;
 			}
 
+			if (TryParseResultFlowOption(args, ref index, argument, optionComparison, options.ResultFlow, out var resultFlow))
+			{
+				options = options with { ResultFlow = resultFlow };
+				continue;
+			}
+
 			if (TryParsePromptAnswer(argument, promptAnswers))
 			{
 				continue;
@@ -142,6 +148,96 @@ internal static class GlobalOptionParser
 
 		return true;
 	}
+
+	private static bool TryParseResultFlowOption(
+		IReadOnlyList<string> args,
+		ref int index,
+		string argument,
+		StringComparison comparison,
+		ResultFlowInvocationOptions current,
+		out ResultFlowInvocationOptions resultFlow)
+	{
+		const string prefix = "--result:";
+		resultFlow = current;
+		if (!argument.StartsWith(prefix, comparison))
+		{
+			return false;
+		}
+
+		var token = argument[prefix.Length..];
+		if (TrySplitToken(token, '=', out var name, out var inlineValue)
+			|| TrySplitToken(token, ':', out name, out inlineValue))
+		{
+			return ApplyResultFlowOption(name, inlineValue, current, out resultFlow);
+		}
+
+		if (string.Equals(token, "all", comparison))
+		{
+			resultFlow = current with { AllRequested = true };
+			return true;
+		}
+
+		if (RequiresResultFlowValue(token, comparison)
+			&& index + 1 < args.Count
+			&& !args[index + 1].StartsWith('-'))
+		{
+			index++;
+			return ApplyResultFlowOption(token, args[index], current, out resultFlow);
+		}
+
+		return ApplyResultFlowOption(token, "true", current, out resultFlow);
+	}
+
+	private static bool ApplyResultFlowOption(
+		string name,
+		string value,
+		ResultFlowInvocationOptions current,
+		out ResultFlowInvocationOptions resultFlow)
+	{
+		resultFlow = current;
+		if (string.Equals(name, "page-size", StringComparison.OrdinalIgnoreCase))
+		{
+			if (int.TryParse(
+				value,
+				System.Globalization.NumberStyles.Integer,
+				System.Globalization.CultureInfo.InvariantCulture,
+				out var pageSize))
+			{
+				resultFlow = current with { PageSize = pageSize };
+			}
+
+			return true;
+		}
+
+		if (string.Equals(name, "cursor", StringComparison.OrdinalIgnoreCase))
+		{
+			resultFlow = current with { Cursor = value };
+			return true;
+		}
+
+		if (string.Equals(name, "pager", StringComparison.OrdinalIgnoreCase))
+		{
+			if (Enum.TryParse<ReplPagerMode>(value, ignoreCase: true, out var mode))
+			{
+				resultFlow = current with { PagerMode = mode };
+			}
+
+			return true;
+		}
+
+		if (string.Equals(name, "all", StringComparison.OrdinalIgnoreCase))
+		{
+			resultFlow = current with { AllRequested = !string.Equals(value, "false", StringComparison.OrdinalIgnoreCase) };
+			return true;
+		}
+
+		return false;
+	}
+
+	private static bool RequiresResultFlowValue(string token, StringComparison comparison) =>
+		string.Equals(token, "page-size", comparison)
+		|| string.Equals(token, "cursor", comparison)
+		|| string.Equals(token, "pager", comparison);
 
 	private static Dictionary<string, string> BuildCustomTokenMap(
 		IReadOnlyDictionary<string, GlobalOptionDefinition> definitions,

--- a/src/Repl.Core/Parsing/GlobalOptionParser.cs
+++ b/src/Repl.Core/Parsing/GlobalOptionParser.cs
@@ -23,6 +23,7 @@ internal static class GlobalOptionParser
 		var remaining = new List<string>(args.Count);
 		var promptAnswers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 		var customGlobalValues = new Dictionary<string, List<string>>(tokenComparer);
+		var diagnostics = new List<ParseDiagnostic>();
 		var customTokenMap = BuildCustomTokenMap(parsingOptions.GlobalOptions, tokenComparer);
 		var options = new GlobalInvocationOptions(remaining);
 		var optionComparison = parsingOptions.OptionCaseSensitivity == ReplCaseSensitivity.CaseInsensitive
@@ -75,6 +76,7 @@ internal static class GlobalOptionParser
 					optionComparison,
 					options.ResultFlow,
 					outputOptions.ResultFlow.MaxPageSize,
+					diagnostics,
 					out var resultFlow))
 			{
 				options = options with { ResultFlow = resultFlow };
@@ -108,6 +110,7 @@ internal static class GlobalOptionParser
 		{
 			PromptAnswers = promptAnswers,
 			CustomGlobalNamedOptions = readonlyCustomGlobalValues,
+			Diagnostics = diagnostics,
 		};
 	}
 
@@ -163,6 +166,7 @@ internal static class GlobalOptionParser
 		StringComparison comparison,
 		ResultFlowInvocationOptions current,
 		int maxPageSize,
+		List<ParseDiagnostic> diagnostics,
 		out ResultFlowInvocationOptions resultFlow)
 	{
 		const string prefix = "--result:";
@@ -176,7 +180,7 @@ internal static class GlobalOptionParser
 		if (TrySplitToken(token, '=', out var name, out var inlineValue)
 			|| TrySplitToken(token, ':', out name, out inlineValue))
 		{
-			return ApplyResultFlowOption(name, inlineValue, current, maxPageSize, out resultFlow);
+			return ApplyResultFlowOption(name, inlineValue, current, maxPageSize, diagnostics, out resultFlow);
 		}
 
 		if (string.Equals(token, "all", comparison))
@@ -190,10 +194,16 @@ internal static class GlobalOptionParser
 			&& !args[index + 1].StartsWith('-'))
 		{
 			index++;
-			return ApplyResultFlowOption(token, args[index], current, maxPageSize, out resultFlow);
+			return ApplyResultFlowOption(token, args[index], current, maxPageSize, diagnostics, out resultFlow);
 		}
 
-		return ApplyResultFlowOption(token, "true", current, maxPageSize, out resultFlow);
+		if (RequiresResultFlowValue(token, comparison))
+		{
+			AddResultFlowDiagnostic(diagnostics, $"The result-flow option '--result:{token}' requires a value.");
+			return true;
+		}
+
+		return ApplyResultFlowOption(token, "true", current, maxPageSize, diagnostics, out resultFlow);
 	}
 
 	private static bool ApplyResultFlowOption(
@@ -201,6 +211,7 @@ internal static class GlobalOptionParser
 		string value,
 		ResultFlowInvocationOptions current,
 		int maxPageSize,
+		List<ParseDiagnostic> diagnostics,
 		out ResultFlowInvocationOptions resultFlow)
 	{
 		resultFlow = current;
@@ -220,6 +231,12 @@ internal static class GlobalOptionParser
 
 		if (string.Equals(name, "cursor", StringComparison.OrdinalIgnoreCase))
 		{
+			if (!ResultFlowCursorPolicy.TryValidate(value, out var error))
+			{
+				AddResultFlowDiagnostic(diagnostics, error);
+				return true;
+			}
+
 			resultFlow = current with { Cursor = value };
 			return true;
 		}
@@ -250,6 +267,9 @@ internal static class GlobalOptionParser
 
 	private static int ClampPageSize(int pageSize, int maxPageSize) =>
 		Math.Clamp(pageSize, 1, Math.Max(1, maxPageSize));
+
+	private static void AddResultFlowDiagnostic(List<ParseDiagnostic> diagnostics, string message) =>
+		diagnostics.Add(new ParseDiagnostic(ParseDiagnosticSeverity.Error, message));
 
 	private static Dictionary<string, string> BuildCustomTokenMap(
 		IReadOnlyDictionary<string, GlobalOptionDefinition> definitions,

--- a/src/Repl.Core/Parsing/ImplicitServiceParameterRegistry.cs
+++ b/src/Repl.Core/Parsing/ImplicitServiceParameterRegistry.cs
@@ -60,6 +60,7 @@ internal sealed class ImplicitServiceParameterRegistry
 		|| parameterType == typeof(IReplInteractionChannel)
 		|| parameterType == typeof(IReplIoContext)
 		|| parameterType == typeof(IReplKeyReader)
+		|| parameterType == typeof(IReplPagingContext)
 		|| string.Equals(parameterType.FullName, "Repl.Mcp.IMcpClientRoots", StringComparison.Ordinal)
 		|| string.Equals(parameterType.FullName, "Repl.Mcp.IMcpSampling", StringComparison.Ordinal)
 		|| string.Equals(parameterType.FullName, "Repl.Mcp.IMcpElicitation", StringComparison.Ordinal)

--- a/src/Repl.Core/ResultFlow/IReplPage.cs
+++ b/src/Repl.Core/ResultFlow/IReplPage.cs
@@ -1,0 +1,22 @@
+namespace Repl;
+
+/// <summary>
+/// Represents a typed page using an untyped view for the output pipeline.
+/// </summary>
+public interface IReplPage
+{
+	/// <summary>
+	/// Gets the runtime item type declared by the page.
+	/// </summary>
+	Type ItemType { get; }
+
+	/// <summary>
+	/// Gets page metadata.
+	/// </summary>
+	ReplPageInfo PageInfo { get; }
+
+	/// <summary>
+	/// Gets the current page items as an untyped list.
+	/// </summary>
+	IReadOnlyList<object?> UntypedItems { get; }
+}

--- a/src/Repl.Core/ResultFlow/IReplPage.cs
+++ b/src/Repl.Core/ResultFlow/IReplPage.cs
@@ -3,6 +3,10 @@ namespace Repl;
 /// <summary>
 /// Represents a typed page using an untyped view for the output pipeline.
 /// </summary>
+/// <remarks>
+/// Prefer returning <see cref="ReplPage{T}"/> or one of the page-source helpers instead of implementing
+/// this interface directly; it is primarily a framework contract between result-flow components.
+/// </remarks>
 public interface IReplPage
 {
 	/// <summary>

--- a/src/Repl.Core/ResultFlow/IReplPageSource.cs
+++ b/src/Repl.Core/ResultFlow/IReplPageSource.cs
@@ -1,0 +1,18 @@
+namespace Repl;
+
+/// <summary>
+/// Fetches pages of a result set on demand.
+/// </summary>
+/// <typeparam name="T">Item type.</typeparam>
+public interface IReplPageSource<T>
+{
+	/// <summary>
+	/// Fetches a page for the supplied request.
+	/// </summary>
+	/// <param name="request">Page request.</param>
+	/// <param name="cancellationToken">Cancellation token.</param>
+	/// <returns>The fetched page.</returns>
+	ValueTask<ReplPage<T>> FetchAsync(
+		ReplPageRequest request,
+		CancellationToken cancellationToken = default);
+}

--- a/src/Repl.Core/ResultFlow/IReplPageSource.cs
+++ b/src/Repl.Core/ResultFlow/IReplPageSource.cs
@@ -1,10 +1,26 @@
 namespace Repl;
 
 /// <summary>
+/// Fetches result-flow pages on demand.
+/// </summary>
+public interface IReplPageSource
+{
+	/// <summary>
+	/// Fetches a page for the supplied request.
+	/// </summary>
+	/// <param name="request">Page request.</param>
+	/// <param name="cancellationToken">Cancellation token.</param>
+	/// <returns>The fetched page.</returns>
+	ValueTask<IReplPage> FetchPageAsync(
+		ReplPageRequest request,
+		CancellationToken cancellationToken = default);
+}
+
+/// <summary>
 /// Fetches pages of a result set on demand.
 /// </summary>
 /// <typeparam name="T">Item type.</typeparam>
-public interface IReplPageSource<T>
+public interface IReplPageSource<T> : IReplPageSource
 {
 	/// <summary>
 	/// Fetches a page for the supplied request.
@@ -15,4 +31,11 @@ public interface IReplPageSource<T>
 	ValueTask<ReplPage<T>> FetchAsync(
 		ReplPageRequest request,
 		CancellationToken cancellationToken = default);
+
+	async ValueTask<IReplPage> IReplPageSource.FetchPageAsync(
+		ReplPageRequest request,
+		CancellationToken cancellationToken)
+	{
+		return await FetchAsync(request, cancellationToken).ConfigureAwait(false);
+	}
 }

--- a/src/Repl.Core/ResultFlow/IReplPagerRenderer.cs
+++ b/src/Repl.Core/ResultFlow/IReplPagerRenderer.cs
@@ -1,0 +1,20 @@
+namespace Repl;
+
+/// <summary>
+/// Renders result-flow payloads in an interactive human terminal pager.
+/// </summary>
+public interface IReplPagerRenderer
+{
+	/// <summary>
+	/// Gets the pager mode handled by this renderer.
+	/// </summary>
+	ReplPagerMode Mode { get; }
+
+	/// <summary>
+	/// Renders the pager session.
+	/// </summary>
+	/// <param name="context">Pager render context.</param>
+	/// <param name="cancellationToken">Cancellation token.</param>
+	/// <returns>A value task that completes when the pager session exits.</returns>
+	ValueTask RenderAsync(ReplPagerRenderContext context, CancellationToken cancellationToken = default);
+}

--- a/src/Repl.Core/ResultFlow/IReplPagingContext.cs
+++ b/src/Repl.Core/ResultFlow/IReplPagingContext.cs
@@ -40,25 +40,4 @@ public interface IReplPagingContext
 	/// </summary>
 	ReplResultSurface Surface { get; }
 
-	/// <summary>
-	/// Creates a paged result from an already fetched page.
-	/// </summary>
-	/// <typeparam name="T">Item type.</typeparam>
-	/// <param name="items">Items in the current page.</param>
-	/// <param name="nextCursor">Cursor for the next page, when one exists.</param>
-	/// <param name="totalCount">Total item count, when known without expensive enumeration.</param>
-	/// <returns>A result page consumable by Repl renderers.</returns>
-	ReplPage<T> Page<T>(
-		IReadOnlyList<T> items,
-		string? nextCursor = null,
-		long? totalCount = null);
-
-	/// <summary>
-	/// Creates a lazy page source that can fetch additional pages on demand.
-	/// </summary>
-	/// <typeparam name="T">Item type.</typeparam>
-	/// <param name="fetch">Page fetch delegate.</param>
-	/// <returns>A page source consumable by interactive renderers.</returns>
-	IReplPageSource<T> CreateSource<T>(
-		Func<ReplPageRequest, CancellationToken, ValueTask<ReplPage<T>>> fetch);
 }

--- a/src/Repl.Core/ResultFlow/IReplPagingContext.cs
+++ b/src/Repl.Core/ResultFlow/IReplPagingContext.cs
@@ -1,0 +1,64 @@
+namespace Repl;
+
+/// <summary>
+/// Provides paging intent and output-capacity hints to command handlers.
+/// </summary>
+/// <remarks>
+/// Handlers can use this context to avoid loading or returning unbounded result sets.
+/// The visible-row hint is best-effort: terminal, hosted, and MCP surfaces can expose
+/// different capacities, and redirected output usually has no visible screen.
+/// </remarks>
+public interface IReplPagingContext
+{
+	/// <summary>
+	/// Gets a best-effort hint for the number of data rows the current output surface can show.
+	/// </summary>
+	int? VisibleRowCapacityHint { get; }
+
+	/// <summary>
+	/// Gets the page size suggested for the current invocation.
+	/// </summary>
+	int SuggestedPageSize { get; }
+
+	/// <summary>
+	/// Gets the maximum page size allowed by the current application configuration.
+	/// </summary>
+	int MaxPageSize { get; }
+
+	/// <summary>
+	/// Gets the opaque cursor supplied by the caller, when continuing a paged result.
+	/// </summary>
+	string? Cursor { get; }
+
+	/// <summary>
+	/// Gets a value indicating whether the caller explicitly requested all available rows.
+	/// </summary>
+	bool AllRequested { get; }
+
+	/// <summary>
+	/// Gets the kind of output surface driving this invocation.
+	/// </summary>
+	ReplResultSurface Surface { get; }
+
+	/// <summary>
+	/// Creates a paged result from an already fetched page.
+	/// </summary>
+	/// <typeparam name="T">Item type.</typeparam>
+	/// <param name="items">Items in the current page.</param>
+	/// <param name="nextCursor">Cursor for the next page, when one exists.</param>
+	/// <param name="totalCount">Total item count, when known without expensive enumeration.</param>
+	/// <returns>A result page consumable by Repl renderers.</returns>
+	ReplPage<T> Page<T>(
+		IReadOnlyList<T> items,
+		string? nextCursor = null,
+		long? totalCount = null);
+
+	/// <summary>
+	/// Creates a lazy page source that can fetch additional pages on demand.
+	/// </summary>
+	/// <typeparam name="T">Item type.</typeparam>
+	/// <param name="fetch">Page fetch delegate.</param>
+	/// <returns>A page source consumable by interactive renderers.</returns>
+	IReplPageSource<T> CreateSource<T>(
+		Func<ReplPageRequest, CancellationToken, ValueTask<ReplPage<T>>> fetch);
+}

--- a/src/Repl.Core/ResultFlow/IReplResultFlowDiagnostics.cs
+++ b/src/Repl.Core/ResultFlow/IReplResultFlowDiagnostics.cs
@@ -1,0 +1,13 @@
+namespace Repl;
+
+/// <summary>
+/// Receives structured diagnostics for result-flow paging operations.
+/// </summary>
+public interface IReplResultFlowDiagnostics
+{
+	/// <summary>
+	/// Observes a result-flow diagnostic event.
+	/// </summary>
+	/// <param name="diagnostic">Diagnostic payload.</param>
+	void OnDiagnostic(ReplResultFlowDiagnostic diagnostic);
+}

--- a/src/Repl.Core/ResultFlow/PagerHeader.cs
+++ b/src/Repl.Core/ResultFlow/PagerHeader.cs
@@ -1,0 +1,6 @@
+namespace Repl;
+
+internal sealed record PagerHeader(IReadOnlyList<string> Lines, IReadOnlySet<string> NormalizedLines)
+{
+	public static PagerHeader Empty { get; } = new([], new HashSet<string>(StringComparer.Ordinal));
+}

--- a/src/Repl.Core/ResultFlow/PagerPayloadParser.cs
+++ b/src/Repl.Core/ResultFlow/PagerPayloadParser.cs
@@ -1,6 +1,7 @@
 namespace Repl;
 
 using System.Buffers;
+using Repl.Terminal;
 
 internal static class PagerPayloadParser
 {
@@ -57,15 +58,15 @@ internal static class PagerPayloadParser
 
 	private static bool IsPlainTableSeparator(string line)
 	{
-		var text = line.Trim();
+		var text = line.AsSpan().Trim();
 		return text.Length > 0
-			&& text.AsSpan().IndexOfAnyExcept(PlainTableSeparatorChars) < 0
-			&& text.Contains('-', StringComparison.Ordinal);
+			&& text.IndexOfAnyExcept(PlainTableSeparatorChars) < 0
+			&& text.Contains('-');
 	}
 
 	private static bool IsPlainHumanTableHeader(string line)
 	{
-		var text = line.TrimStart();
+		var text = line.AsSpan().TrimStart();
 		return text.StartsWith("# ", StringComparison.Ordinal)
 			&& text.Contains("  ", StringComparison.Ordinal);
 	}
@@ -105,33 +106,6 @@ internal static class PagerPayloadParser
 			return line.Trim();
 		}
 
-		var builder = new System.Text.StringBuilder(line.Length);
-		for (var i = 0; i < line.Length; i++)
-		{
-			if (line[i] == '\u001b')
-			{
-				if (i + 1 >= line.Length)
-				{
-					continue;
-				}
-
-				if (line[i + 1] != '[')
-				{
-					continue;
-				}
-
-				i += 2;
-				while (i < line.Length && (line[i] < '@' || line[i] > '~'))
-				{
-					i++;
-				}
-
-				continue;
-			}
-
-			builder.Append(line[i]);
-		}
-
-		return builder.ToString().Trim();
+		return AnsiTextMetrics.StripControlSequences(line).Trim();
 	}
 }

--- a/src/Repl.Core/ResultFlow/PagerPayloadParser.cs
+++ b/src/Repl.Core/ResultFlow/PagerPayloadParser.cs
@@ -1,0 +1,123 @@
+namespace Repl;
+
+internal static class PagerPayloadParser
+{
+	public static ParsedPagerPayload Parse(string payload, PagerHeader? header, bool stripPresentationChrome = true)
+	{
+		var lines = SplitLines(payload);
+		var payloadHeader = DetectHeader(lines);
+		var resolvedHeader = header ?? payloadHeader;
+		var headerLineCount = payloadHeader.Lines.Count;
+		var content = new List<string>();
+		for (var i = headerLineCount; i < lines.Length; i++)
+		{
+			var normalized = NormalizeLine(lines[i]);
+			if (resolvedHeader.NormalizedLines.Contains(normalized)
+				|| (stripPresentationChrome && IsPageFooterLine(lines[i])))
+			{
+				continue;
+			}
+
+			content.Add(lines[i]);
+		}
+
+		return new ParsedPagerPayload(resolvedHeader, content);
+	}
+
+	private static PagerHeader DetectHeader(string[] lines)
+	{
+		if (lines.Length == 0)
+		{
+			return PagerHeader.Empty;
+		}
+
+		if (lines.Length > 1 && IsPlainTableSeparator(lines[1]))
+		{
+			return CreateHeader(lines.Take(2).ToArray());
+		}
+
+		if (IsPlainHumanTableHeader(lines[0]))
+		{
+			return CreateHeader([lines[0]]);
+		}
+
+		return lines[0].Contains("\u001b[1m", StringComparison.Ordinal)
+			? CreateHeader([lines[0]])
+			: PagerHeader.Empty;
+	}
+
+	private static PagerHeader CreateHeader(string[] lines) =>
+		new(
+			lines,
+			lines.Select(NormalizeLine).ToHashSet(StringComparer.Ordinal));
+
+	private static bool IsPlainTableSeparator(string line)
+	{
+		var text = line.Trim();
+		return text.Length > 0
+			&& text.All(ch => ch is '-' or ' ' or '\t')
+			&& text.Contains('-', StringComparison.Ordinal);
+	}
+
+	private static bool IsPlainHumanTableHeader(string line)
+	{
+		var text = line.TrimStart();
+		return text.StartsWith("# ", StringComparison.Ordinal)
+			&& text.Contains("  ", StringComparison.Ordinal);
+	}
+
+	private static bool IsPageFooterLine(string line) =>
+		line.StartsWith("Showing ", StringComparison.Ordinal)
+		&& (line.Contains(" of ", StringComparison.Ordinal)
+			|| line.Contains(" result(s).", StringComparison.Ordinal))
+		&& (line.EndsWith('.')
+			|| line.Contains("Next data page: rerun with --result:cursor ", StringComparison.Ordinal));
+
+	private static string[] SplitLines(string payload)
+	{
+		if (string.IsNullOrEmpty(payload))
+		{
+			return [];
+		}
+
+		var lines = new List<string>();
+		foreach (var line in payload.AsSpan().EnumerateLines())
+		{
+			lines.Add(line.ToString());
+		}
+
+		if (lines.Count > 0 && lines[^1].Length == 0)
+		{
+			lines.RemoveAt(lines.Count - 1);
+		}
+
+		return [.. lines];
+	}
+
+	private static string NormalizeLine(string line)
+	{
+		if (!line.Contains('\u001b', StringComparison.Ordinal))
+		{
+			return line.Trim();
+		}
+
+		var builder = new System.Text.StringBuilder(line.Length);
+		for (var i = 0; i < line.Length; i++)
+		{
+			if (line[i] == '\u001b' && i + 1 < line.Length && line[i + 1] == '[')
+			{
+				i += 2;
+				while (i < line.Length && (line[i] < '@' || line[i] > '~'))
+				{
+					i++;
+				}
+
+				continue;
+			}
+
+			builder.Append(line[i]);
+		}
+
+		return builder.ToString().Trim();
+	}
+}

--- a/src/Repl.Core/ResultFlow/PagerPayloadParser.cs
+++ b/src/Repl.Core/ResultFlow/PagerPayloadParser.cs
@@ -1,7 +1,11 @@
 namespace Repl;
 
+using System.Buffers;
+
 internal static class PagerPayloadParser
 {
+	private static readonly SearchValues<char> PlainTableSeparatorChars = SearchValues.Create("- \t");
+
 	public static ParsedPagerPayload Parse(string payload, PagerHeader? header, bool stripPresentationChrome = true)
 	{
 		var lines = SplitLines(payload);
@@ -9,7 +13,7 @@ internal static class PagerPayloadParser
 		var resolvedHeader = header ?? payloadHeader;
 		var headerLineCount = payloadHeader.Lines.Count;
 		var content = new List<string>();
-		for (var i = headerLineCount; i < lines.Length; i++)
+		for (var i = headerLineCount; i < lines.Count; i++)
 		{
 			var normalized = NormalizeLine(lines[i]);
 			if (resolvedHeader.NormalizedLines.Contains(normalized)
@@ -24,16 +28,16 @@ internal static class PagerPayloadParser
 		return new ParsedPagerPayload(resolvedHeader, content);
 	}
 
-	private static PagerHeader DetectHeader(string[] lines)
+	private static PagerHeader DetectHeader(List<string> lines)
 	{
-		if (lines.Length == 0)
+		if (lines.Count == 0)
 		{
 			return PagerHeader.Empty;
 		}
 
-		if (lines.Length > 1 && IsPlainTableSeparator(lines[1]))
+		if (lines.Count > 1 && IsPlainTableSeparator(lines[1]))
 		{
-			return CreateHeader(lines.Take(2).ToArray());
+			return CreateHeader([lines[0], lines[1]]);
 		}
 
 		if (IsPlainHumanTableHeader(lines[0]))
@@ -55,7 +59,7 @@ internal static class PagerPayloadParser
 	{
 		var text = line.Trim();
 		return text.Length > 0
-			&& text.All(ch => ch is '-' or ' ' or '\t')
+			&& text.AsSpan().IndexOfAnyExcept(PlainTableSeparatorChars) < 0
 			&& text.Contains('-', StringComparison.Ordinal);
 	}
 
@@ -71,9 +75,9 @@ internal static class PagerPayloadParser
 		&& (line.Contains(" of ", StringComparison.Ordinal)
 			|| line.Contains(" result(s).", StringComparison.Ordinal))
 		&& (line.EndsWith('.')
-			|| line.Contains("Next data page: rerun with --result:cursor ", StringComparison.Ordinal));
+			|| line.Contains($"Next data page: rerun with {ReplResultFlowOptionNames.Cursor} ", StringComparison.Ordinal));
 
-	private static string[] SplitLines(string payload)
+	private static List<string> SplitLines(string payload)
 	{
 		if (string.IsNullOrEmpty(payload))
 		{
@@ -91,7 +95,7 @@ internal static class PagerPayloadParser
 			lines.RemoveAt(lines.Count - 1);
 		}
 
-		return [.. lines];
+		return lines;
 	}
 
 	private static string NormalizeLine(string line)
@@ -104,8 +108,18 @@ internal static class PagerPayloadParser
 		var builder = new System.Text.StringBuilder(line.Length);
 		for (var i = 0; i < line.Length; i++)
 		{
-			if (line[i] == '\u001b' && i + 1 < line.Length && line[i + 1] == '[')
+			if (line[i] == '\u001b')
 			{
+				if (i + 1 >= line.Length)
+				{
+					continue;
+				}
+
+				if (line[i + 1] != '[')
+				{
+					continue;
+				}
+
 				i += 2;
 				while (i < line.Length && (line[i] < '@' || line[i] > '~'))
 				{

--- a/src/Repl.Core/ResultFlow/PagerSession.cs
+++ b/src/Repl.Core/ResultFlow/PagerSession.cs
@@ -1,0 +1,58 @@
+namespace Repl;
+
+internal sealed class PagerSession
+{
+	private readonly PagerHeader _header;
+	private readonly int _maxBufferedLines;
+
+	public PagerSession(string initialPayload, bool hasMorePayload, int maxBufferedLines)
+	{
+		_maxBufferedLines = Math.Max(1, maxBufferedLines);
+		var parsed = PagerPayloadParser.Parse(initialPayload, header: null);
+		_header = parsed.Header;
+		Lines = [];
+		AppendContent(parsed.ContentLines, hasMorePayload);
+		PageSize = 1;
+		NextWindow = 1;
+	}
+
+	public IReadOnlyList<string> HeaderLines => _header.Lines;
+
+	public List<string> Lines { get; }
+
+	public int PageSize { get; set; }
+
+	public int NextWindow { get; set; }
+
+	public int Index { get; set; }
+
+	public bool HasMorePayload { get; set; }
+
+	public bool BufferLimitReached { get; private set; }
+
+	public void Append(string payload, bool hasMorePayload, bool containsPresentationChrome = true)
+	{
+		var parsed = PagerPayloadParser.Parse(payload, _header, containsPresentationChrome);
+		AppendContent(parsed.ContentLines, hasMorePayload);
+	}
+
+	private void AppendContent(IReadOnlyList<string> contentLines, bool hasMorePayload)
+	{
+		var available = _maxBufferedLines - Lines.Count;
+		if (available <= 0)
+		{
+			BufferLimitReached = true;
+			HasMorePayload = false;
+			return;
+		}
+
+		var take = Math.Min(available, contentLines.Count);
+		for (var i = 0; i < take; i++)
+		{
+			Lines.Add(contentLines[i]);
+		}
+
+		BufferLimitReached = take < contentLines.Count;
+		HasMorePayload = !BufferLimitReached && hasMorePayload;
+	}
+}

--- a/src/Repl.Core/ResultFlow/PagerSession.cs
+++ b/src/Repl.Core/ResultFlow/PagerSession.cs
@@ -4,21 +4,23 @@ internal sealed class PagerSession
 {
 	private readonly PagerHeader _header;
 	private readonly int _maxBufferedLines;
+	private readonly List<string> _lines = [];
+	private readonly IReadOnlyList<string> _readOnlyLines;
 
 	public PagerSession(string initialPayload, bool hasMorePayload, int maxBufferedLines)
 	{
 		_maxBufferedLines = Math.Max(1, maxBufferedLines);
+		_readOnlyLines = _lines.AsReadOnly();
 		var parsed = PagerPayloadParser.Parse(initialPayload, header: null);
-		_header = parsed.Header;
-		Lines = [];
-		AppendContent(parsed.ContentLines, hasMorePayload);
-		PageSize = 1;
-		NextWindow = 1;
+			_header = parsed.Header;
+			AppendContent(parsed.ContentLines, hasMorePayload);
+			PageSize = 1;
+			NextWindow = 1;
 	}
 
 	public IReadOnlyList<string> HeaderLines => _header.Lines;
 
-	public List<string> Lines { get; }
+	public IReadOnlyList<string> Lines => _readOnlyLines;
 
 	public int PageSize { get; set; }
 
@@ -38,7 +40,7 @@ internal sealed class PagerSession
 
 	private void AppendContent(IReadOnlyList<string> contentLines, bool hasMorePayload)
 	{
-		var available = _maxBufferedLines - Lines.Count;
+		var available = _maxBufferedLines - _lines.Count;
 		if (available <= 0)
 		{
 			BufferLimitReached = true;
@@ -49,7 +51,7 @@ internal sealed class PagerSession
 		var take = Math.Min(available, contentLines.Count);
 		for (var i = 0; i < take; i++)
 		{
-			Lines.Add(contentLines[i]);
+			_lines.Add(contentLines[i]);
 		}
 
 		BufferLimitReached = take < contentLines.Count;

--- a/src/Repl.Core/ResultFlow/PagerSession.cs
+++ b/src/Repl.Core/ResultFlow/PagerSession.cs
@@ -32,6 +32,8 @@ internal sealed class PagerSession
 
 	public bool BufferLimitReached { get; private set; }
 
+	public bool SourceReturnedNoData { get; set; }
+
 	public void Append(string payload, bool hasMorePayload, bool containsPresentationChrome = true)
 	{
 		var parsed = PagerPayloadParser.Parse(payload, _header, containsPresentationChrome);
@@ -55,6 +57,6 @@ internal sealed class PagerSession
 		}
 
 		BufferLimitReached = take < contentLines.Count;
-		HasMorePayload = !BufferLimitReached && hasMorePayload;
+		HasMorePayload = hasMorePayload && !BufferLimitReached;
 	}
 }

--- a/src/Repl.Core/ResultFlow/ParsedPagerPayload.cs
+++ b/src/Repl.Core/ResultFlow/ParsedPagerPayload.cs
@@ -1,0 +1,6 @@
+namespace Repl;
+
+internal sealed record ParsedPagerPayload(PagerHeader Header, IReadOnlyList<string> ContentLines)
+{
+	public int TotalLineCount => Header.Lines.Count + ContentLines.Count;
+}

--- a/src/Repl.Core/ResultFlow/ReplPage.cs
+++ b/src/Repl.Core/ResultFlow/ReplPage.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Repl;
 
 /// <summary>
@@ -25,11 +27,13 @@ public sealed class ReplPage<T> : IReplPage
 	public IReadOnlyList<T> Items { get; }
 
 	/// <inheritdoc />
+	[JsonIgnore]
 	public Type ItemType => typeof(T);
 
 	/// <inheritdoc />
 	public ReplPageInfo PageInfo { get; }
 
 	/// <inheritdoc />
+	[JsonIgnore]
 	public IReadOnlyList<object?> UntypedItems => _untypedItems ??= Items.Cast<object?>().ToArray();
 }

--- a/src/Repl.Core/ResultFlow/ReplPage.cs
+++ b/src/Repl.Core/ResultFlow/ReplPage.cs
@@ -8,7 +8,7 @@ namespace Repl;
 /// <typeparam name="T">Item type.</typeparam>
 public sealed record ReplPage<T> : IReplPage
 {
-	private object?[]? _untypedItems;
+	private IReadOnlyList<object?>? _untypedItems;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ReplPage{T}"/> record.
@@ -38,5 +38,10 @@ public sealed record ReplPage<T> : IReplPage
 
 	/// <inheritdoc />
 	[JsonIgnore]
-	public IReadOnlyList<object?> UntypedItems => _untypedItems ??= Items.Cast<object?>().ToArray();
+	public IReadOnlyList<object?> UntypedItems => _untypedItems ??= Items switch
+	{
+		object?[] array => array,
+		IReadOnlyList<object?> list => list,
+		_ => Items.Cast<object?>().ToArray(),
+	};
 }

--- a/src/Repl.Core/ResultFlow/ReplPage.cs
+++ b/src/Repl.Core/ResultFlow/ReplPage.cs
@@ -6,32 +6,35 @@ namespace Repl;
 /// Represents one page of a larger result set.
 /// </summary>
 /// <typeparam name="T">Item type.</typeparam>
-public sealed class ReplPage<T> : IReplPage
+public sealed record ReplPage<T> : IReplPage
 {
 	private object?[]? _untypedItems;
 
 	/// <summary>
-	/// Initializes a new instance of the <see cref="ReplPage{T}"/> class.
+	/// Initializes a new instance of the <see cref="ReplPage{T}"/> record.
 	/// </summary>
 	/// <param name="items">Items in the page.</param>
 	/// <param name="pageInfo">Page metadata.</param>
 	public ReplPage(IReadOnlyList<T> items, ReplPageInfo pageInfo)
 	{
-		Items = items ?? throw new ArgumentNullException(nameof(items));
-		PageInfo = pageInfo ?? throw new ArgumentNullException(nameof(pageInfo));
+		ArgumentNullException.ThrowIfNull(items);
+		ArgumentNullException.ThrowIfNull(pageInfo);
+
+		Items = items;
+		PageInfo = pageInfo;
 	}
 
 	/// <summary>
 	/// Gets the typed items in the page.
 	/// </summary>
-	public IReadOnlyList<T> Items { get; }
+	public IReadOnlyList<T> Items { get; init; }
 
 	/// <inheritdoc />
 	[JsonIgnore]
 	public Type ItemType => typeof(T);
 
 	/// <inheritdoc />
-	public ReplPageInfo PageInfo { get; }
+	public ReplPageInfo PageInfo { get; init; }
 
 	/// <inheritdoc />
 	[JsonIgnore]

--- a/src/Repl.Core/ResultFlow/ReplPage.cs
+++ b/src/Repl.Core/ResultFlow/ReplPage.cs
@@ -1,0 +1,35 @@
+namespace Repl;
+
+/// <summary>
+/// Represents one page of a larger result set.
+/// </summary>
+/// <typeparam name="T">Item type.</typeparam>
+public sealed class ReplPage<T> : IReplPage
+{
+	private object?[]? _untypedItems;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ReplPage{T}"/> class.
+	/// </summary>
+	/// <param name="items">Items in the page.</param>
+	/// <param name="pageInfo">Page metadata.</param>
+	public ReplPage(IReadOnlyList<T> items, ReplPageInfo pageInfo)
+	{
+		Items = items ?? throw new ArgumentNullException(nameof(items));
+		PageInfo = pageInfo ?? throw new ArgumentNullException(nameof(pageInfo));
+	}
+
+	/// <summary>
+	/// Gets the typed items in the page.
+	/// </summary>
+	public IReadOnlyList<T> Items { get; }
+
+	/// <inheritdoc />
+	public Type ItemType => typeof(T);
+
+	/// <inheritdoc />
+	public ReplPageInfo PageInfo { get; }
+
+	/// <inheritdoc />
+	public IReadOnlyList<object?> UntypedItems => _untypedItems ??= Items.Cast<object?>().ToArray();
+}

--- a/src/Repl.Core/ResultFlow/ReplPageDisplaySnapshot.cs
+++ b/src/Repl.Core/ResultFlow/ReplPageDisplaySnapshot.cs
@@ -1,0 +1,18 @@
+namespace Repl;
+
+internal sealed class ReplPageDisplaySnapshot : IReplPage
+{
+	private readonly IReplPage _page;
+
+	public ReplPageDisplaySnapshot(IReplPage page, ReplPageInfo pageInfo)
+	{
+		_page = page ?? throw new ArgumentNullException(nameof(page));
+		PageInfo = pageInfo ?? throw new ArgumentNullException(nameof(pageInfo));
+	}
+
+	public Type ItemType => _page.ItemType;
+
+	public ReplPageInfo PageInfo { get; }
+
+	public IReadOnlyList<object?> UntypedItems => _page.UntypedItems;
+}

--- a/src/Repl.Core/ResultFlow/ReplPageInfo.cs
+++ b/src/Repl.Core/ResultFlow/ReplPageInfo.cs
@@ -7,10 +7,14 @@ namespace Repl;
 /// <param name="NextCursor">Cursor that fetches the next page, when available.</param>
 /// <param name="TotalCount">Total result count, when known.</param>
 /// <param name="PageSize">Requested or effective page size.</param>
-/// <param name="HasMore">Whether another page is available.</param>
 public sealed record ReplPageInfo(
 	string? Cursor,
 	string? NextCursor,
 	long? TotalCount,
-	int PageSize,
-	bool HasMore);
+	int PageSize)
+{
+	/// <summary>
+	/// Gets a value indicating whether another page is available.
+	/// </summary>
+	public bool HasMore => !string.IsNullOrWhiteSpace(NextCursor);
+}

--- a/src/Repl.Core/ResultFlow/ReplPageInfo.cs
+++ b/src/Repl.Core/ResultFlow/ReplPageInfo.cs
@@ -1,0 +1,16 @@
+namespace Repl;
+
+/// <summary>
+/// Metadata describing one page of a result set.
+/// </summary>
+/// <param name="Cursor">Cursor used to fetch the current page.</param>
+/// <param name="NextCursor">Cursor that fetches the next page, when available.</param>
+/// <param name="TotalCount">Total result count, when known.</param>
+/// <param name="PageSize">Requested or effective page size.</param>
+/// <param name="HasMore">Whether another page is available.</param>
+public sealed record ReplPageInfo(
+	string? Cursor,
+	string? NextCursor,
+	long? TotalCount,
+	int PageSize,
+	bool HasMore);

--- a/src/Repl.Core/ResultFlow/ReplPageRequest.cs
+++ b/src/Repl.Core/ResultFlow/ReplPageRequest.cs
@@ -1,0 +1,16 @@
+namespace Repl;
+
+/// <summary>
+/// Request sent to a page source.
+/// </summary>
+/// <param name="PageSize">Requested page size.</param>
+/// <param name="Cursor">Opaque cursor for continuation.</param>
+/// <param name="VisibleRowCapacityHint">Best-effort visible row capacity for the output surface.</param>
+/// <param name="AllRequested">Whether the caller requested all available rows.</param>
+/// <param name="Surface">Output surface requesting the page.</param>
+public sealed record ReplPageRequest(
+	int PageSize,
+	string? Cursor,
+	int? VisibleRowCapacityHint,
+	bool AllRequested,
+	ReplResultSurface Surface);

--- a/src/Repl.Core/ResultFlow/ReplPageRequestExtensions.cs
+++ b/src/Repl.Core/ResultFlow/ReplPageRequestExtensions.cs
@@ -29,7 +29,6 @@ public static class ReplPageRequestExtensions
 				Cursor: request.Cursor,
 				NextCursor: nextCursor,
 				TotalCount: totalCount,
-				PageSize: request.PageSize,
-				HasMore: !string.IsNullOrWhiteSpace(nextCursor)));
+				PageSize: request.PageSize));
 	}
 }

--- a/src/Repl.Core/ResultFlow/ReplPageRequestExtensions.cs
+++ b/src/Repl.Core/ResultFlow/ReplPageRequestExtensions.cs
@@ -1,0 +1,35 @@
+namespace Repl;
+
+/// <summary>
+/// Convenience helpers for creating result-flow pages from page-source requests.
+/// </summary>
+public static class ReplPageRequestExtensions
+{
+	/// <summary>
+	/// Creates a typed result page for the supplied request.
+	/// </summary>
+	/// <typeparam name="T">Item type.</typeparam>
+	/// <param name="request">The page-source request being handled.</param>
+	/// <param name="items">Items in the current page.</param>
+	/// <param name="nextCursor">Cursor for the next page, when one exists.</param>
+	/// <param name="totalCount">Total item count, when known without expensive enumeration.</param>
+	/// <returns>A result page consumable by Repl renderers.</returns>
+	public static ReplPage<T> Page<T>(
+		this ReplPageRequest request,
+		IReadOnlyList<T> items,
+		string? nextCursor = null,
+		long? totalCount = null)
+	{
+		ArgumentNullException.ThrowIfNull(request);
+		ArgumentNullException.ThrowIfNull(items);
+
+		return new ReplPage<T>(
+			items,
+			new ReplPageInfo(
+				Cursor: request.Cursor,
+				NextCursor: nextCursor,
+				TotalCount: totalCount,
+				PageSize: request.PageSize,
+				HasMore: !string.IsNullOrWhiteSpace(nextCursor)));
+	}
+}

--- a/src/Repl.Core/ResultFlow/ReplPageSource.cs
+++ b/src/Repl.Core/ResultFlow/ReplPageSource.cs
@@ -137,6 +137,12 @@ public static class ReplPageSource
 	/// mutable files, channels, network cursors, or shared enumerator instances. For
 	/// those sources, use <see cref="Create{T}(Func{ReplPageRequest, CancellationToken, ValueTask{ReplPage{T}}})"/>
 	/// with an opaque cursor owned by the source.
+	/// <para>
+	/// <b>Performance note:</b> fetching page N re-streams from the beginning and skips
+	/// <c>(N-1) × pageSize</c> items; cost is O(offset) per page. For large or expensive
+	/// sources prefer <see cref="Create{T}(Func{ReplPageRequest, CancellationToken, ValueTask{ReplPage{T}}})"/>
+	/// with a source-native cursor so each page starts directly at the right position.
+	/// </para>
 	/// </remarks>
 	public static IReplPageSource<T> FromAsyncEnumerable<T>(
 		Func<CancellationToken, IAsyncEnumerable<T>> createItems,
@@ -165,6 +171,12 @@ public static class ReplPageSource
 	/// mutable files, channels, network cursors, or shared enumerator instances. For
 	/// those sources, use <see cref="Create{T,TState}(TState, Func{TState, ReplPageRequest, CancellationToken, ValueTask{ReplPage{T}}})"/>
 	/// with an opaque cursor owned by the source.
+	/// <para>
+	/// <b>Performance note:</b> fetching page N re-streams from the beginning and skips
+	/// <c>(N-1) × pageSize</c> items; cost is O(offset) per page. For large or expensive
+	/// sources prefer the stateful <see cref="Create{T,TState}"/> overload with a
+	/// source-native cursor so each page starts directly at the right position.
+	/// </para>
 	/// </remarks>
 	public static IReplPageSource<T> FromAsyncEnumerable<T, TState>(
 		TState state,

--- a/src/Repl.Core/ResultFlow/ReplPageSource.cs
+++ b/src/Repl.Core/ResultFlow/ReplPageSource.cs
@@ -7,7 +7,7 @@ namespace Repl;
 /// </summary>
 public static class ReplPageSource
 {
-	private const int DefaultMaxSourceItemsToScan = 10000;
+	private const int DefaultMaxSourceItemsToScan = 10_000;
 
 	/// <summary>
 	/// Creates a page source from a fetch delegate.

--- a/src/Repl.Core/ResultFlow/ReplPageSource.cs
+++ b/src/Repl.Core/ResultFlow/ReplPageSource.cs
@@ -1,0 +1,372 @@
+using System.Globalization;
+
+namespace Repl;
+
+/// <summary>
+/// Convenience factories for result-flow page sources.
+/// </summary>
+public static class ReplPageSource
+{
+	private const int DefaultMaxSourceItemsToScan = 10000;
+
+	/// <summary>
+	/// Creates a page source from a fetch delegate.
+	/// </summary>
+	/// <typeparam name="T">Item type.</typeparam>
+	/// <param name="fetch">Delegate that fetches one page for each request.</param>
+	/// <returns>A page source consumable by Repl renderers.</returns>
+	public static IReplPageSource<T> Create<T>(
+		Func<ReplPageRequest, CancellationToken, ValueTask<ReplPage<T>>> fetch)
+	{
+		ArgumentNullException.ThrowIfNull(fetch);
+		return new DelegateReplPageSource<T>(fetch);
+	}
+
+	/// <summary>
+	/// Creates a page source from a fetch delegate and explicit state.
+	/// </summary>
+	/// <typeparam name="T">Item type.</typeparam>
+	/// <typeparam name="TState">State type.</typeparam>
+	/// <param name="state">State passed to the fetch delegate.</param>
+	/// <param name="fetch">Delegate that fetches one page for each request.</param>
+	/// <returns>A page source consumable by Repl renderers.</returns>
+	public static IReplPageSource<T> Create<T, TState>(
+		TState state,
+		Func<TState, ReplPageRequest, CancellationToken, ValueTask<ReplPage<T>>> fetch)
+	{
+		ArgumentNullException.ThrowIfNull(fetch);
+		return Create<T>((request, cancellationToken) => fetch(state, request, cancellationToken));
+	}
+
+	/// <summary>
+	/// Creates an offset-cursor page source over an in-memory list.
+	/// </summary>
+	/// <typeparam name="T">Item type.</typeparam>
+	/// <param name="items">Items to expose as pages.</param>
+	/// <param name="filter">Optional client-side filter applied before final paging.</param>
+	/// <returns>A page source consumable by Repl renderers.</returns>
+	public static IReplPageSource<T> FromItems<T>(
+		IReadOnlyList<T> items,
+		Func<T, bool>? filter = null)
+	{
+		ArgumentNullException.ThrowIfNull(items);
+
+		return Create<T>((request, cancellationToken) =>
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			return ValueTask.FromResult(CreateItemsPage(items, request, filter));
+		});
+	}
+
+	/// <summary>
+	/// Creates an offset-cursor page source over an in-memory list and explicit state.
+	/// </summary>
+	/// <typeparam name="T">Item type.</typeparam>
+	/// <typeparam name="TState">State type.</typeparam>
+	/// <param name="items">Items to expose as pages.</param>
+	/// <param name="state">State passed to the filter delegate.</param>
+	/// <param name="filter">Optional client-side filter applied before final paging.</param>
+	/// <returns>A page source consumable by Repl renderers.</returns>
+	public static IReplPageSource<T> FromItems<T, TState>(
+		IReadOnlyList<T> items,
+		TState state,
+		Func<TState, T, bool>? filter = null)
+	{
+		ArgumentNullException.ThrowIfNull(items);
+		return FromItems(items, filter is null ? null : item => filter(state, item));
+	}
+
+	/// <summary>
+	/// Creates an offset-cursor page source over a store that can fetch by offset and take.
+	/// </summary>
+	/// <typeparam name="T">Item type.</typeparam>
+	/// <param name="fetch">Delegate called with offset, take, and cancellation token.</param>
+	/// <param name="totalCount">Total item count, when known without expensive enumeration.</param>
+	/// <param name="filter">Optional client-side filter applied after source fetches and before final paging.</param>
+	/// <param name="maxSourceItemsToScan">Maximum source rows to scan while filling one filtered page.</param>
+	/// <returns>A page source consumable by Repl renderers.</returns>
+	public static IReplPageSource<T> FromOffset<T>(
+		Func<int, int, CancellationToken, ValueTask<IReadOnlyList<T>>> fetch,
+		long? totalCount = null,
+		Func<T, bool>? filter = null,
+		int? maxSourceItemsToScan = null)
+	{
+		ArgumentNullException.ThrowIfNull(fetch);
+		return Create<T>((request, cancellationToken) =>
+			CreateOffsetPageAsync(fetch, request, totalCount, filter, maxSourceItemsToScan, cancellationToken));
+	}
+
+	/// <summary>
+	/// Creates an offset-cursor page source over a store that can fetch by offset and take, with explicit state.
+	/// </summary>
+	/// <typeparam name="T">Item type.</typeparam>
+	/// <typeparam name="TState">State type.</typeparam>
+	/// <param name="state">State passed to the fetch and filter delegates.</param>
+	/// <param name="fetch">Delegate called with state, offset, take, and cancellation token.</param>
+	/// <param name="totalCount">Total item count, when known without expensive enumeration.</param>
+	/// <param name="filter">Optional client-side filter applied after source fetches and before final paging.</param>
+	/// <param name="maxSourceItemsToScan">Maximum source rows to scan while filling one filtered page.</param>
+	/// <returns>A page source consumable by Repl renderers.</returns>
+	public static IReplPageSource<T> FromOffset<T, TState>(
+		TState state,
+		Func<TState, int, int, CancellationToken, ValueTask<IReadOnlyList<T>>> fetch,
+		long? totalCount = null,
+		Func<TState, T, bool>? filter = null,
+		int? maxSourceItemsToScan = null)
+	{
+		ArgumentNullException.ThrowIfNull(fetch);
+		return FromOffset<T>(
+			(offset, take, cancellationToken) => fetch(state, offset, take, cancellationToken),
+			totalCount,
+			filter is null ? null : item => filter(state, item),
+			maxSourceItemsToScan);
+	}
+
+	/// <summary>
+	/// Creates an offset-cursor page source over an async stream factory.
+	/// </summary>
+	/// <typeparam name="T">Item type.</typeparam>
+	/// <param name="createItems">Factory that creates the async stream for each page request.</param>
+	/// <param name="filter">Optional client-side filter applied before final paging.</param>
+	/// <param name="maxSourceItemsToScan">Maximum source rows to scan while filling one filtered page.</param>
+	/// <returns>A page source consumable by Repl renderers.</returns>
+	public static IReplPageSource<T> FromAsyncEnumerable<T>(
+		Func<CancellationToken, IAsyncEnumerable<T>> createItems,
+		Func<T, bool>? filter = null,
+		int? maxSourceItemsToScan = null)
+	{
+		ArgumentNullException.ThrowIfNull(createItems);
+		return Create<T>((request, cancellationToken) =>
+			CreateAsyncEnumerablePageAsync(createItems, request, filter, maxSourceItemsToScan, cancellationToken));
+	}
+
+	/// <summary>
+	/// Creates an offset-cursor page source over an async stream factory, with explicit state.
+	/// </summary>
+	/// <typeparam name="T">Item type.</typeparam>
+	/// <typeparam name="TState">State type.</typeparam>
+	/// <param name="state">State passed to the stream factory and filter delegate.</param>
+	/// <param name="createItems">Factory that creates the async stream for each page request.</param>
+	/// <param name="filter">Optional client-side filter applied before final paging.</param>
+	/// <param name="maxSourceItemsToScan">Maximum source rows to scan while filling one filtered page.</param>
+	/// <returns>A page source consumable by Repl renderers.</returns>
+	public static IReplPageSource<T> FromAsyncEnumerable<T, TState>(
+		TState state,
+		Func<TState, CancellationToken, IAsyncEnumerable<T>> createItems,
+		Func<TState, T, bool>? filter = null,
+		int? maxSourceItemsToScan = null)
+	{
+		ArgumentNullException.ThrowIfNull(createItems);
+		return FromAsyncEnumerable<T>(
+			cancellationToken => createItems(state, cancellationToken),
+			filter is null ? null : item => filter(state, item),
+			maxSourceItemsToScan);
+	}
+
+	private static ReplPage<T> CreateItemsPage<T>(
+		IReadOnlyList<T> items,
+		ReplPageRequest request,
+		Func<T, bool>? filter)
+	{
+		var offset = request.AllRequested ? 0 : ParseOffset(request.Cursor);
+		var filteredItems = filter is null
+			? items
+			: items.Where(filter).ToArray();
+		var pageItems = request.AllRequested
+			? filteredItems
+			: filteredItems.Skip(offset).Take(request.PageSize).ToArray();
+		var nextOffset = offset + pageItems.Count;
+		var nextCursor = !request.AllRequested && nextOffset < filteredItems.Count
+			? nextOffset.ToString(CultureInfo.InvariantCulture)
+			: null;
+
+		return request.Page(pageItems, nextCursor, filteredItems.Count);
+	}
+
+	private static async ValueTask<ReplPage<T>> CreateOffsetPageAsync<T>(
+		Func<int, int, CancellationToken, ValueTask<IReadOnlyList<T>>> fetch,
+		ReplPageRequest request,
+		long? totalCount,
+		Func<T, bool>? filter,
+		int? maxSourceItemsToScan,
+		CancellationToken cancellationToken)
+	{
+		ThrowIfAllRequestedForUnboundedSource(request);
+		var offset = request.AllRequested ? 0 : ParseOffset(request.Cursor);
+		var take = GetProbeSize(request.PageSize);
+		if (filter is not null)
+		{
+			return await CreateFilteredOffsetPageAsync(
+					fetch,
+					request,
+					offset,
+					take,
+					totalCount,
+					filter,
+					ResolveMaxSourceItemsToScan(maxSourceItemsToScan),
+					cancellationToken)
+				.ConfigureAwait(false);
+		}
+
+		var items = await fetch(offset, take, cancellationToken).ConfigureAwait(false)
+			?? throw new InvalidOperationException("The offset page source returned null.");
+		return CreateOffsetProbePage(request, offset, items, totalCount);
+	}
+
+	private static async ValueTask<ReplPage<T>> CreateAsyncEnumerablePageAsync<T>(
+		Func<CancellationToken, IAsyncEnumerable<T>> createItems,
+		ReplPageRequest request,
+		Func<T, bool>? filter,
+		int? maxSourceItemsToScan,
+		CancellationToken cancellationToken)
+	{
+		ThrowIfAllRequestedForUnboundedSource(request);
+		var offset = request.AllRequested ? 0 : ParseOffset(request.Cursor);
+		var pageItems = new List<T>(request.PageSize + 1);
+		var scanned = 0;
+		var index = 0;
+		int? nextOffsetAfterVisible = null;
+		var maxScan = ResolveMaxSourceItemsToScan(maxSourceItemsToScan);
+		await foreach (var item in CreateStreamAsync(createItems, cancellationToken)
+			.WithCancellation(cancellationToken)
+			.ConfigureAwait(false))
+		{
+			ThrowIfScanLimitExceeded(scanned++, maxScan);
+			if (index++ < offset)
+			{
+				continue;
+			}
+
+			if (filter is not null && !filter(item))
+			{
+				continue;
+			}
+
+			if (pageItems.Count == request.PageSize)
+			{
+				return request.Page(
+					pageItems,
+					nextOffsetAfterVisible?.ToString(CultureInfo.InvariantCulture));
+			}
+
+			pageItems.Add(item);
+			nextOffsetAfterVisible = index;
+		}
+
+		return request.Page(pageItems);
+	}
+
+	private static ReplPage<T> CreateOffsetProbePage<T>(
+		ReplPageRequest request,
+		int offset,
+		IReadOnlyList<T> items,
+		long? totalCount)
+	{
+		var hasMore = items.Count > request.PageSize;
+		var visibleItems = hasMore
+			? items.Take(request.PageSize).ToArray()
+			: items;
+		var nextCursor = hasMore
+			? (offset + visibleItems.Count).ToString(CultureInfo.InvariantCulture)
+			: null;
+		return request.Page(visibleItems, nextCursor, totalCount);
+	}
+
+	private static async ValueTask<ReplPage<T>> CreateFilteredOffsetPageAsync<T>(
+		Func<int, int, CancellationToken, ValueTask<IReadOnlyList<T>>> fetch,
+		ReplPageRequest request,
+		int offset,
+		int take,
+		long? totalCount,
+		Func<T, bool> filter,
+		int maxSourceItemsToScan,
+		CancellationToken cancellationToken)
+	{
+		var pageItems = new List<T>(request.PageSize);
+		var currentOffset = offset;
+		var scanned = 0;
+		int? nextOffset = null;
+
+		while (true)
+		{
+			ThrowIfScanLimitExceeded(scanned, maxSourceItemsToScan);
+			var items = await fetch(currentOffset, take, cancellationToken).ConfigureAwait(false)
+				?? throw new InvalidOperationException("The offset page source returned null.");
+			if (items.Count == 0)
+			{
+				return request.Page(pageItems, totalCount: totalCount);
+			}
+
+			for (var index = 0; index < items.Count; index++)
+			{
+				ThrowIfScanLimitExceeded(scanned++, maxSourceItemsToScan);
+				var item = items[index];
+				if (!filter(item))
+				{
+					continue;
+				}
+
+				var sourceOffsetAfterItem = currentOffset + index + 1;
+				if (pageItems.Count == request.PageSize)
+				{
+					var cursor = nextOffset ?? sourceOffsetAfterItem;
+					return request.Page(pageItems, cursor.ToString(CultureInfo.InvariantCulture), totalCount);
+				}
+
+				pageItems.Add(item);
+				nextOffset = sourceOffsetAfterItem;
+			}
+
+			if (items.Count < take)
+			{
+				return request.Page(pageItems, totalCount: totalCount);
+			}
+
+			currentOffset += items.Count;
+		}
+	}
+
+	private static int GetProbeSize(int pageSize) =>
+		pageSize == int.MaxValue ? pageSize : pageSize + 1;
+
+	private static IAsyncEnumerable<T> CreateStreamAsync<T>(
+		Func<CancellationToken, IAsyncEnumerable<T>> createItems,
+		CancellationToken cancellationToken) =>
+		createItems(cancellationToken)
+		?? throw new InvalidOperationException("The async enumerable page source returned null.");
+
+	private static int ParseOffset(string? cursor) =>
+		int.TryParse(cursor, NumberStyles.None, CultureInfo.InvariantCulture, out var offset) && offset >= 0
+			? offset
+			: 0;
+
+	private static int ResolveMaxSourceItemsToScan(int? value) =>
+		value is > 0 ? value.Value : DefaultMaxSourceItemsToScan;
+
+	private static void ThrowIfAllRequestedForUnboundedSource(ReplPageRequest request)
+	{
+		if (request.AllRequested)
+		{
+			throw new InvalidOperationException(
+				"--result:all is not supported by this page source because it could read an unbounded result set.");
+		}
+	}
+
+	private static void ThrowIfScanLimitExceeded(int scanned, int maxSourceItemsToScan)
+	{
+		if (scanned >= maxSourceItemsToScan)
+		{
+			throw new InvalidOperationException(
+				"The client-side filter scan limit was reached before a complete page could be produced.");
+		}
+	}
+
+	private sealed class DelegateReplPageSource<T>(
+		Func<ReplPageRequest, CancellationToken, ValueTask<ReplPage<T>>> fetch) : IReplPageSource<T>
+	{
+		public ValueTask<ReplPage<T>> FetchAsync(
+			ReplPageRequest request,
+			CancellationToken cancellationToken = default) =>
+			fetch(request, cancellationToken);
+	}
+}

--- a/src/Repl.Core/ResultFlow/ReplPageSource.cs
+++ b/src/Repl.Core/ResultFlow/ReplPageSource.cs
@@ -375,8 +375,11 @@ public static class ReplPageSource
 		}
 
 		throw new InvalidOperationException(
-			$"The result cursor '{cursor}' is not a valid non-negative offset cursor for this page source.");
+			$"The result cursor '{AbbreviateCursor(cursor)}' is not a valid non-negative offset cursor for this page source.");
 	}
+
+	private static string AbbreviateCursor(string cursor) =>
+		cursor.Length <= 40 ? cursor : string.Concat(cursor.AsSpan(0, 40), "...");
 
 	private static int ResolveMaxSourceItemsToScan(int? value) =>
 		value is > 0 ? value.Value : DefaultMaxSourceItemsToScan;

--- a/src/Repl.Core/ResultFlow/ReplPageSource.cs
+++ b/src/Repl.Core/ResultFlow/ReplPageSource.cs
@@ -362,10 +362,21 @@ public static class ReplPageSource
 		createItems(cancellationToken)
 		?? throw new InvalidOperationException("The async enumerable page source returned null.");
 
-	private static int ParseOffset(string? cursor) =>
-		int.TryParse(cursor, NumberStyles.None, CultureInfo.InvariantCulture, out var offset) && offset >= 0
-			? offset
-			: 0;
+	private static int ParseOffset(string? cursor)
+	{
+		if (string.IsNullOrEmpty(cursor))
+		{
+			return 0;
+		}
+
+		if (int.TryParse(cursor, NumberStyles.None, CultureInfo.InvariantCulture, out var offset) && offset >= 0)
+		{
+			return offset;
+		}
+
+		throw new InvalidOperationException(
+			$"The result cursor '{cursor}' is not a valid non-negative offset cursor for this page source.");
+	}
 
 	private static int ResolveMaxSourceItemsToScan(int? value) =>
 		value is > 0 ? value.Value : DefaultMaxSourceItemsToScan;
@@ -384,7 +395,7 @@ public static class ReplPageSource
 		if (scanned >= maxSourceItemsToScan)
 		{
 			throw new InvalidOperationException(
-				"The client-side filter scan limit was reached before a complete page could be produced.");
+				$"The client-side filter scan limit was reached before a complete page could be produced. Scanned {scanned.ToString(CultureInfo.InvariantCulture)} item(s); limit is {maxSourceItemsToScan.ToString(CultureInfo.InvariantCulture)}.");
 		}
 	}
 

--- a/src/Repl.Core/ResultFlow/ReplPageSource.cs
+++ b/src/Repl.Core/ResultFlow/ReplPageSource.cs
@@ -130,6 +130,13 @@ public static class ReplPageSource
 	/// <param name="filter">Optional client-side filter applied before final paging.</param>
 	/// <param name="maxSourceItemsToScan">Maximum source rows to scan while filling one filtered page.</param>
 	/// <returns>A page source consumable by Repl renderers.</returns>
+	/// <remarks>
+	/// The factory must be replayable and idempotent for the same underlying result set:
+	/// each page request reopens the stream and advances to the requested offset. Do not
+	/// use this helper for single-use streams such as channels, network cursors, or shared
+	/// enumerator instances. For those sources, use <see cref="Create{T}(Func{ReplPageRequest, CancellationToken, ValueTask{ReplPage{T}}})"/>
+	/// with an opaque cursor owned by the source.
+	/// </remarks>
 	public static IReplPageSource<T> FromAsyncEnumerable<T>(
 		Func<CancellationToken, IAsyncEnumerable<T>> createItems,
 		Func<T, bool>? filter = null,
@@ -150,6 +157,13 @@ public static class ReplPageSource
 	/// <param name="filter">Optional client-side filter applied before final paging.</param>
 	/// <param name="maxSourceItemsToScan">Maximum source rows to scan while filling one filtered page.</param>
 	/// <returns>A page source consumable by Repl renderers.</returns>
+	/// <remarks>
+	/// The factory must be replayable and idempotent for the same underlying result set:
+	/// each page request reopens the stream and advances to the requested offset. Do not
+	/// use this helper for single-use streams such as channels, network cursors, or shared
+	/// enumerator instances. For those sources, use <see cref="Create{T,TState}(TState, Func{TState, ReplPageRequest, CancellationToken, ValueTask{ReplPage{T}}})"/>
+	/// with an opaque cursor owned by the source.
+	/// </remarks>
 	public static IReplPageSource<T> FromAsyncEnumerable<T, TState>(
 		TState state,
 		Func<TState, CancellationToken, IAsyncEnumerable<T>> createItems,
@@ -289,7 +303,6 @@ public static class ReplPageSource
 
 		while (true)
 		{
-			ThrowIfScanLimitExceeded(scanned, maxSourceItemsToScan);
 			var items = await fetch(currentOffset, take, cancellationToken).ConfigureAwait(false)
 				?? throw new InvalidOperationException("The offset page source returned null.");
 			if (items.Count == 0)

--- a/src/Repl.Core/ResultFlow/ReplPageSource.cs
+++ b/src/Repl.Core/ResultFlow/ReplPageSource.cs
@@ -259,12 +259,12 @@ public static class ReplPageSource
 			.WithCancellation(cancellationToken)
 			.ConfigureAwait(false))
 		{
-			ThrowIfScanLimitExceeded(scanned++, maxScan);
 			if (index++ < offset)
 			{
 				continue;
 			}
 
+			ThrowIfScanLimitExceeded(scanned++, maxScan);
 			if (filter is not null && !filter(item))
 			{
 				continue;

--- a/src/Repl.Core/ResultFlow/ReplPageSource.cs
+++ b/src/Repl.Core/ResultFlow/ReplPageSource.cs
@@ -131,10 +131,11 @@ public static class ReplPageSource
 	/// <param name="maxSourceItemsToScan">Maximum source rows to scan while filling one filtered page.</param>
 	/// <returns>A page source consumable by Repl renderers.</returns>
 	/// <remarks>
-	/// The factory must be replayable and idempotent for the same underlying result set:
-	/// each page request reopens the stream and advances to the requested offset. Do not
-	/// use this helper for single-use streams such as channels, network cursors, or shared
-	/// enumerator instances. For those sources, use <see cref="Create{T}(Func{ReplPageRequest, CancellationToken, ValueTask{ReplPage{T}}})"/>
+	/// The factory must be replayable, idempotent, and deterministic for the same
+	/// underlying result set: each page request reopens the stream and advances to the
+	/// requested offset. Do not use this helper for single-use streams, live re-queries,
+	/// mutable files, channels, network cursors, or shared enumerator instances. For
+	/// those sources, use <see cref="Create{T}(Func{ReplPageRequest, CancellationToken, ValueTask{ReplPage{T}}})"/>
 	/// with an opaque cursor owned by the source.
 	/// </remarks>
 	public static IReplPageSource<T> FromAsyncEnumerable<T>(
@@ -158,10 +159,11 @@ public static class ReplPageSource
 	/// <param name="maxSourceItemsToScan">Maximum source rows to scan while filling one filtered page.</param>
 	/// <returns>A page source consumable by Repl renderers.</returns>
 	/// <remarks>
-	/// The factory must be replayable and idempotent for the same underlying result set:
-	/// each page request reopens the stream and advances to the requested offset. Do not
-	/// use this helper for single-use streams such as channels, network cursors, or shared
-	/// enumerator instances. For those sources, use <see cref="Create{T,TState}(TState, Func{TState, ReplPageRequest, CancellationToken, ValueTask{ReplPage{T}}})"/>
+	/// The factory must be replayable, idempotent, and deterministic for the same
+	/// underlying result set: each page request reopens the stream and advances to the
+	/// requested offset. Do not use this helper for single-use streams, live re-queries,
+	/// mutable files, channels, network cursors, or shared enumerator instances. For
+	/// those sources, use <see cref="Create{T,TState}(TState, Func{TState, ReplPageRequest, CancellationToken, ValueTask{ReplPage{T}}})"/>
 	/// with an opaque cursor owned by the source.
 	/// </remarks>
 	public static IReplPageSource<T> FromAsyncEnumerable<T, TState>(

--- a/src/Repl.Core/ResultFlow/ReplPagerMode.cs
+++ b/src/Repl.Core/ResultFlow/ReplPagerMode.cs
@@ -21,12 +21,12 @@ public enum ReplPagerMode
 	More,
 
 	/// <summary>
-	/// Use an interactive scrolling pager.
+	/// Use an inline pager that redraws in the main terminal buffer.
 	/// </summary>
-	Scroll,
+	Inline,
 
 	/// <summary>
-	/// Use an external pager process when available.
+	/// Use a full-screen alternate-buffer pager.
 	/// </summary>
-	External,
+	Full,
 }

--- a/src/Repl.Core/ResultFlow/ReplPagerMode.cs
+++ b/src/Repl.Core/ResultFlow/ReplPagerMode.cs
@@ -1,0 +1,32 @@
+namespace Repl;
+
+/// <summary>
+/// Controls how human-readable large results are paged.
+/// </summary>
+public enum ReplPagerMode
+{
+	/// <summary>
+	/// Let Repl choose the best pager for the active output surface.
+	/// </summary>
+	Auto,
+
+	/// <summary>
+	/// Disable Repl-owned paging.
+	/// </summary>
+	Off,
+
+	/// <summary>
+	/// Use a simple more-style pager.
+	/// </summary>
+	More,
+
+	/// <summary>
+	/// Use an interactive scrolling pager.
+	/// </summary>
+	Scroll,
+
+	/// <summary>
+	/// Use an external pager process when available.
+	/// </summary>
+	External,
+}

--- a/src/Repl.Core/ResultFlow/ReplPagerPayload.cs
+++ b/src/Repl.Core/ResultFlow/ReplPagerPayload.cs
@@ -1,0 +1,8 @@
+namespace Repl;
+
+/// <summary>
+/// Represents a rendered result-flow payload supplied to a pager renderer.
+/// </summary>
+/// <param name="Payload">Rendered payload text.</param>
+/// <param name="HasMore">Whether another result-flow payload can be fetched.</param>
+public sealed record ReplPagerPayload(string Payload, bool HasMore);

--- a/src/Repl.Core/ResultFlow/ReplPagerRenderContext.cs
+++ b/src/Repl.Core/ResultFlow/ReplPagerRenderContext.cs
@@ -1,0 +1,67 @@
+namespace Repl;
+
+/// <summary>
+/// Provides terminal, input, and payload state to a custom result-flow pager renderer.
+/// </summary>
+public sealed class ReplPagerRenderContext
+{
+	internal ReplPagerRenderContext(
+		string initialPayload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		Func<int>? visibleRowsProvider,
+		bool ansiEnabled,
+		bool hasMorePayload,
+		Func<CancellationToken, ValueTask<ReplPagerPayload?>>? fetchNextPayload)
+	{
+		InitialPayload = initialPayload;
+		Output = output;
+		KeyReader = keyReader;
+		VisibleRows = visibleRows;
+		VisibleRowsProvider = visibleRowsProvider;
+		AnsiEnabled = ansiEnabled;
+		HasMorePayload = hasMorePayload;
+		FetchNextPayload = fetchNextPayload;
+	}
+
+	/// <summary>
+	/// Gets the first rendered payload.
+	/// </summary>
+	public string InitialPayload { get; }
+
+	/// <summary>
+	/// Gets the output writer controlled by the pager.
+	/// </summary>
+	public TextWriter Output { get; }
+
+	/// <summary>
+	/// Gets the key reader used for interactive navigation.
+	/// </summary>
+	public IReplKeyReader KeyReader { get; }
+
+	/// <summary>
+	/// Gets the initial visible row count available to the pager.
+	/// </summary>
+	public int VisibleRows { get; }
+
+	/// <summary>
+	/// Gets the current visible row resolver when available.
+	/// </summary>
+	public Func<int>? VisibleRowsProvider { get; }
+
+	/// <summary>
+	/// Gets whether ANSI terminal control sequences can be used.
+	/// </summary>
+	public bool AnsiEnabled { get; }
+
+	/// <summary>
+	/// Gets whether another payload can initially be fetched.
+	/// </summary>
+	public bool HasMorePayload { get; }
+
+	/// <summary>
+	/// Gets the next payload fetcher when the result source can continue.
+	/// </summary>
+	public Func<CancellationToken, ValueTask<ReplPagerPayload?>>? FetchNextPayload { get; }
+}

--- a/src/Repl.Core/ResultFlow/ReplPagerRenderContext.cs
+++ b/src/Repl.Core/ResultFlow/ReplPagerRenderContext.cs
@@ -5,7 +5,12 @@ namespace Repl;
 /// </summary>
 public sealed class ReplPagerRenderContext
 {
-	internal ReplPagerRenderContext(
+	private readonly Func<CancellationToken, ValueTask<ReplPagerPayload?>>? _fetchNextPayload;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ReplPagerRenderContext"/> class.
+	/// </summary>
+	public ReplPagerRenderContext(
 		string initialPayload,
 		TextWriter output,
 		IReplKeyReader keyReader,
@@ -15,6 +20,10 @@ public sealed class ReplPagerRenderContext
 		bool hasMorePayload,
 		Func<CancellationToken, ValueTask<ReplPagerPayload?>>? fetchNextPayload)
 	{
+		ArgumentNullException.ThrowIfNull(initialPayload);
+		ArgumentNullException.ThrowIfNull(output);
+		ArgumentNullException.ThrowIfNull(keyReader);
+
 		InitialPayload = initialPayload;
 		Output = output;
 		KeyReader = keyReader;
@@ -22,7 +31,7 @@ public sealed class ReplPagerRenderContext
 		VisibleRowsProvider = visibleRowsProvider;
 		AnsiEnabled = ansiEnabled;
 		HasMorePayload = hasMorePayload;
-		FetchNextPayload = fetchNextPayload;
+		_fetchNextPayload = fetchNextPayload;
 	}
 
 	/// <summary>
@@ -61,7 +70,17 @@ public sealed class ReplPagerRenderContext
 	public bool HasMorePayload { get; }
 
 	/// <summary>
-	/// Gets the next payload fetcher when the result source can continue.
+	/// Gets a value indicating whether a next payload fetcher is available.
 	/// </summary>
-	public Func<CancellationToken, ValueTask<ReplPagerPayload?>>? FetchNextPayload { get; }
+	public bool CanFetchNextPayload => _fetchNextPayload is not null;
+
+	/// <summary>
+	/// Fetches the next rendered payload when the result source can continue.
+	/// </summary>
+	/// <param name="cancellationToken">Cancellation token.</param>
+	/// <returns>The next payload, or null when no fetcher is available or the source ended.</returns>
+	public ValueTask<ReplPagerPayload?> FetchNextPayloadAsync(CancellationToken cancellationToken = default) =>
+		_fetchNextPayload is null
+			? ValueTask.FromResult<ReplPagerPayload?>(null)
+			: _fetchNextPayload(cancellationToken);
 }

--- a/src/Repl.Core/ResultFlow/ReplPagingContext.cs
+++ b/src/Repl.Core/ResultFlow/ReplPagingContext.cs
@@ -45,8 +45,7 @@ internal sealed class ReplPagingContext : IReplPagingContext
 			Cursor,
 			nextCursor,
 			totalCount,
-			SuggestedPageSize,
-			HasMore: !string.IsNullOrWhiteSpace(nextCursor));
+			SuggestedPageSize);
 		return new ReplPage<T>(items, pageInfo);
 	}
 

--- a/src/Repl.Core/ResultFlow/ReplPagingContext.cs
+++ b/src/Repl.Core/ResultFlow/ReplPagingContext.cs
@@ -1,0 +1,74 @@
+namespace Repl;
+
+internal sealed class ReplPagingContext : IReplPagingContext
+{
+	public ReplPagingContext(
+		ResultFlowOptions options,
+		ResultFlowInvocationOptions invocation,
+		ReplResultSurface surface,
+		int? visibleRowCapacityHint)
+	{
+		ArgumentNullException.ThrowIfNull(options);
+		ArgumentNullException.ThrowIfNull(invocation);
+
+		MaxPageSize = Math.Max(1, options.MaxPageSize);
+		VisibleRowCapacityHint = visibleRowCapacityHint;
+		Cursor = invocation.Cursor;
+		AllRequested = invocation.AllRequested;
+		Surface = surface;
+		SuggestedPageSize = ClampPageSize(
+			invocation.PageSize
+				?? visibleRowCapacityHint
+				?? options.DefaultPageSize,
+			MaxPageSize);
+	}
+
+	public int? VisibleRowCapacityHint { get; }
+
+	public int SuggestedPageSize { get; }
+
+	public int MaxPageSize { get; }
+
+	public string? Cursor { get; }
+
+	public bool AllRequested { get; }
+
+	public ReplResultSurface Surface { get; }
+
+	public ReplPage<T> Page<T>(
+		IReadOnlyList<T> items,
+		string? nextCursor = null,
+		long? totalCount = null)
+	{
+		ArgumentNullException.ThrowIfNull(items);
+		var pageInfo = new ReplPageInfo(
+			Cursor,
+			nextCursor,
+			totalCount,
+			SuggestedPageSize,
+			HasMore: !string.IsNullOrWhiteSpace(nextCursor));
+		return new ReplPage<T>(items, pageInfo);
+	}
+
+	public IReplPageSource<T> CreateSource<T>(
+		Func<ReplPageRequest, CancellationToken, ValueTask<ReplPage<T>>> fetch)
+	{
+		ArgumentNullException.ThrowIfNull(fetch);
+		return new DelegateReplPageSource<T>(fetch);
+	}
+
+	internal ReplPageRequest CreateRequest() =>
+		new(SuggestedPageSize, Cursor, VisibleRowCapacityHint, AllRequested, Surface);
+
+	private static int ClampPageSize(int value, int maxPageSize) =>
+		Math.Clamp(value, 1, maxPageSize);
+
+	private sealed class DelegateReplPageSource<T>(
+		Func<ReplPageRequest, CancellationToken, ValueTask<ReplPage<T>>> fetch) : IReplPageSource<T>
+	{
+		public ValueTask<ReplPage<T>> FetchAsync(
+			ReplPageRequest request,
+			CancellationToken cancellationToken = default) =>
+			fetch(request, cancellationToken);
+	}
+}

--- a/src/Repl.Core/ResultFlow/ReplPagingContext.cs
+++ b/src/Repl.Core/ResultFlow/ReplPagingContext.cs
@@ -35,27 +35,6 @@ internal sealed class ReplPagingContext : IReplPagingContext
 
 	public ReplResultSurface Surface { get; }
 
-	public ReplPage<T> Page<T>(
-		IReadOnlyList<T> items,
-		string? nextCursor = null,
-		long? totalCount = null)
-	{
-		ArgumentNullException.ThrowIfNull(items);
-		var pageInfo = new ReplPageInfo(
-			Cursor,
-			nextCursor,
-			totalCount,
-			SuggestedPageSize);
-		return new ReplPage<T>(items, pageInfo);
-	}
-
-	public IReplPageSource<T> CreateSource<T>(
-		Func<ReplPageRequest, CancellationToken, ValueTask<ReplPage<T>>> fetch)
-	{
-		ArgumentNullException.ThrowIfNull(fetch);
-		return ReplPageSource.Create(fetch);
-	}
-
 	internal ReplPageRequest CreateRequest() =>
 		new(SuggestedPageSize, Cursor, VisibleRowCapacityHint, AllRequested, Surface);
 

--- a/src/Repl.Core/ResultFlow/ReplPagingContext.cs
+++ b/src/Repl.Core/ResultFlow/ReplPagingContext.cs
@@ -54,7 +54,7 @@ internal sealed class ReplPagingContext : IReplPagingContext
 		Func<ReplPageRequest, CancellationToken, ValueTask<ReplPage<T>>> fetch)
 	{
 		ArgumentNullException.ThrowIfNull(fetch);
-		return new DelegateReplPageSource<T>(fetch);
+		return ReplPageSource.Create(fetch);
 	}
 
 	internal ReplPageRequest CreateRequest() =>
@@ -62,13 +62,4 @@ internal sealed class ReplPagingContext : IReplPagingContext
 
 	private static int ClampPageSize(int value, int maxPageSize) =>
 		Math.Clamp(value, 1, maxPageSize);
-
-	private sealed class DelegateReplPageSource<T>(
-		Func<ReplPageRequest, CancellationToken, ValueTask<ReplPage<T>>> fetch) : IReplPageSource<T>
-	{
-		public ValueTask<ReplPage<T>> FetchAsync(
-			ReplPageRequest request,
-			CancellationToken cancellationToken = default) =>
-			fetch(request, cancellationToken);
-	}
 }

--- a/src/Repl.Core/ResultFlow/ReplPagingContextExtensions.cs
+++ b/src/Repl.Core/ResultFlow/ReplPagingContextExtensions.cs
@@ -1,0 +1,48 @@
+namespace Repl;
+
+/// <summary>
+/// Convenience helpers for creating result-flow pages from <see cref="IReplPagingContext"/>.
+/// </summary>
+public static class ReplPagingContextExtensions
+{
+	/// <summary>
+	/// Creates a paged result from an already fetched page.
+	/// </summary>
+	/// <typeparam name="T">Item type.</typeparam>
+	/// <param name="context">Paging context for the current invocation.</param>
+	/// <param name="items">Items in the current page.</param>
+	/// <param name="nextCursor">Cursor for the next page, when one exists.</param>
+	/// <param name="totalCount">Total item count, when known without expensive enumeration.</param>
+	/// <returns>A result page consumable by Repl renderers.</returns>
+	public static ReplPage<T> Page<T>(
+		this IReplPagingContext context,
+		IReadOnlyList<T> items,
+		string? nextCursor = null,
+		long? totalCount = null)
+	{
+		ArgumentNullException.ThrowIfNull(context);
+		ArgumentNullException.ThrowIfNull(items);
+		var pageInfo = new ReplPageInfo(
+			context.Cursor,
+			nextCursor,
+			totalCount,
+			context.SuggestedPageSize);
+		return new ReplPage<T>(items, pageInfo);
+	}
+
+	/// <summary>
+	/// Creates a lazy page source that can fetch additional pages on demand.
+	/// </summary>
+	/// <typeparam name="T">Item type.</typeparam>
+	/// <param name="context">Paging context for the current invocation.</param>
+	/// <param name="fetch">Page fetch delegate.</param>
+	/// <returns>A page source consumable by interactive renderers.</returns>
+	public static IReplPageSource<T> CreateSource<T>(
+		this IReplPagingContext context,
+		Func<ReplPageRequest, CancellationToken, ValueTask<ReplPage<T>>> fetch)
+	{
+		ArgumentNullException.ThrowIfNull(context);
+		ArgumentNullException.ThrowIfNull(fetch);
+		return ReplPageSource.Create(fetch);
+	}
+}

--- a/src/Repl.Core/ResultFlow/ReplResultFlowDiagnostic.cs
+++ b/src/Repl.Core/ResultFlow/ReplResultFlowDiagnostic.cs
@@ -1,0 +1,11 @@
+namespace Repl;
+
+/// <summary>
+/// Describes a result-flow paging diagnostic event.
+/// </summary>
+public sealed record ReplResultFlowDiagnostic(
+	ReplResultFlowDiagnosticKind Kind,
+	string? Cursor,
+	int PageSize,
+	int? ItemCount = null,
+	Exception? Exception = null);

--- a/src/Repl.Core/ResultFlow/ReplResultFlowDiagnosticKind.cs
+++ b/src/Repl.Core/ResultFlow/ReplResultFlowDiagnosticKind.cs
@@ -1,0 +1,22 @@
+namespace Repl;
+
+/// <summary>
+/// Classifies result-flow paging diagnostic events.
+/// </summary>
+public enum ReplResultFlowDiagnosticKind
+{
+	/// <summary>
+	/// A page source fetch is about to start.
+	/// </summary>
+	PageFetchStarting,
+
+	/// <summary>
+	/// A page source fetch completed successfully.
+	/// </summary>
+	PageFetchSucceeded,
+
+	/// <summary>
+	/// A page source fetch failed.
+	/// </summary>
+	PageFetchFailed,
+}

--- a/src/Repl.Core/ResultFlow/ReplResultFlowOptionNames.cs
+++ b/src/Repl.Core/ResultFlow/ReplResultFlowOptionNames.cs
@@ -1,0 +1,37 @@
+namespace Repl;
+
+/// <summary>
+/// Built-in result-flow option names reserved by Repl.
+/// </summary>
+public static class ReplResultFlowOptionNames
+{
+	/// <summary>
+	/// CLI option used to continue from a cursor returned by a previous page.
+	/// </summary>
+	public const string Cursor = "--result:cursor";
+
+	/// <summary>
+	/// CLI option used to request a page size.
+	/// </summary>
+	public const string PageSize = "--result:page-size";
+
+	/// <summary>
+	/// CLI option used to request all rows when supported.
+	/// </summary>
+	public const string All = "--result:all";
+
+	/// <summary>
+	/// CLI option used to control the integrated human-output pager.
+	/// </summary>
+	public const string Pager = "--result:pager";
+
+	/// <summary>
+	/// MCP argument used to continue from a cursor returned by a previous page.
+	/// </summary>
+	public const string McpCursor = "_replCursor";
+
+	/// <summary>
+	/// MCP argument used to request a page size.
+	/// </summary>
+	public const string McpPageSize = "_replPageSize";
+}

--- a/src/Repl.Core/ResultFlow/ReplResultSurface.cs
+++ b/src/Repl.Core/ResultFlow/ReplResultSurface.cs
@@ -1,0 +1,32 @@
+namespace Repl;
+
+/// <summary>
+/// Describes the output surface used for a command result.
+/// </summary>
+public enum ReplResultSurface
+{
+	/// <summary>
+	/// A local console or terminal.
+	/// </summary>
+	Console,
+
+	/// <summary>
+	/// An interactive REPL session.
+	/// </summary>
+	Interactive,
+
+	/// <summary>
+	/// Standard output is redirected to a pipe or file.
+	/// </summary>
+	Redirected,
+
+	/// <summary>
+	/// A hosted terminal session is active.
+	/// </summary>
+	Hosted,
+
+	/// <summary>
+	/// A programmatic client, such as MCP, is driving execution.
+	/// </summary>
+	Programmatic,
+}

--- a/src/Repl.Core/ResultFlow/ResultFlowCursorPolicy.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowCursorPolicy.cs
@@ -53,6 +53,6 @@ internal static class ResultFlowCursorPolicy
 
 	public static string FormatCliContinuation(string? cursor) =>
 		TryValidate(cursor, out _)
-			? $"--result:cursor {cursor}"
-			: "--result:cursor <cursor omitted>";
+			? $"{ReplResultFlowOptionNames.Cursor} {cursor}"
+			: $"{ReplResultFlowOptionNames.Cursor} <cursor omitted>";
 }

--- a/src/Repl.Core/ResultFlow/ResultFlowCursorPolicy.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowCursorPolicy.cs
@@ -1,0 +1,58 @@
+namespace Repl;
+
+internal static class ResultFlowCursorPolicy
+{
+	public const int MaxLength = 512;
+
+	public static bool TryValidate(string? cursor, [System.Diagnostics.CodeAnalysis.NotNullWhen(false)] out string? error)
+	{
+		if (string.IsNullOrEmpty(cursor))
+		{
+			error = "The result cursor must be provided with a non-empty value.";
+			return false;
+		}
+
+		if (cursor.Length > MaxLength)
+		{
+			error = $"The result cursor cannot exceed {MaxLength.ToString(System.Globalization.CultureInfo.InvariantCulture)} characters.";
+			return false;
+		}
+
+		if (cursor[0] == '-')
+		{
+			error = "The result cursor cannot start like a CLI option.";
+			return false;
+		}
+
+		foreach (var ch in cursor)
+		{
+			if (char.IsWhiteSpace(ch))
+			{
+				error = "The result cursor cannot contain whitespace.";
+				return false;
+			}
+
+			if (ch < 0x20 || ch == 0x7f)
+			{
+				error = "The result cursor cannot contain control characters.";
+				return false;
+			}
+		}
+
+		error = null;
+		return true;
+	}
+
+	public static void ValidateOrThrow(string? cursor)
+	{
+		if (!TryValidate(cursor, out var error))
+		{
+			throw new InvalidOperationException(error);
+		}
+	}
+
+	public static string FormatCliContinuation(string? cursor) =>
+		TryValidate(cursor, out _)
+			? $"--result:cursor {cursor}"
+			: "--result:cursor <cursor omitted>";
+}

--- a/src/Repl.Core/ResultFlow/ResultFlowCursorPolicy.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowCursorPolicy.cs
@@ -32,7 +32,7 @@ internal static class ResultFlowCursorPolicy
 				return false;
 			}
 
-			if (ch < 0x20 || ch == 0x7f)
+			if (ch < 0x20 || ch == 0x7f || ch is >= '\u0080' and <= '\u009f')
 			{
 				error = "The result cursor cannot contain control characters.";
 				return false;

--- a/src/Repl.Core/ResultFlow/ResultFlowInvocationOptions.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowInvocationOptions.cs
@@ -1,0 +1,7 @@
+namespace Repl;
+
+internal sealed record ResultFlowInvocationOptions(
+	int? PageSize = null,
+	string? Cursor = null,
+	bool AllRequested = false,
+	ReplPagerMode? PagerMode = null);

--- a/src/Repl.Core/ResultFlow/ResultFlowOptions.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowOptions.cs
@@ -26,6 +26,11 @@ public sealed class ResultFlowOptions
 	public ReplPagerMode DefaultPagerMode { get; set; } = ReplPagerMode.Auto;
 
 	/// <summary>
+	/// Gets custom pager renderers keyed by <see cref="IReplPagerRenderer.Mode"/>.
+	/// </summary>
+	public IList<IReplPagerRenderer> PagerRenderers { get; } = [];
+
+	/// <summary>
 	/// Gets or sets the maximum inline payload size for programmatic clients.
 	/// </summary>
 	public int ProgrammaticMaxInlineBytes { get; set; } = 64 * 1024;

--- a/src/Repl.Core/ResultFlow/ResultFlowOptions.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowOptions.cs
@@ -5,6 +5,8 @@ namespace Repl;
 /// </summary>
 public sealed class ResultFlowOptions
 {
+	internal const int DefaultMaxBufferedLines = 10_000;
+
 	private readonly List<IReplPagerRenderer> _pagerRenderers = [];
 	private int _defaultPageSize = 100;
 	private int _maxPageSize = 1000;
@@ -70,7 +72,7 @@ public sealed class ResultFlowOptions
 	/// <summary>
 	/// Gets or sets the maximum number of content lines an interactive pager buffers in memory.
 	/// </summary>
-	public int MaxBufferedLines { get; set; } = 10_000;
+	public int MaxBufferedLines { get; set; } = DefaultMaxBufferedLines;
 
 	/// <summary>
 	/// Gets or sets the maximum inline payload size for programmatic clients.

--- a/src/Repl.Core/ResultFlow/ResultFlowOptions.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowOptions.cs
@@ -5,6 +5,8 @@ namespace Repl;
 /// </summary>
 public sealed class ResultFlowOptions
 {
+	private readonly List<IReplPagerRenderer> _pagerRenderers = [];
+
 	/// <summary>
 	/// Gets or sets the default page size when no terminal-specific hint is available.
 	/// </summary>
@@ -28,10 +30,37 @@ public sealed class ResultFlowOptions
 	/// <summary>
 	/// Gets custom pager renderers keyed by <see cref="IReplPagerRenderer.Mode"/>.
 	/// </summary>
-	public IList<IReplPagerRenderer> PagerRenderers { get; } = [];
+	public IReadOnlyList<IReplPagerRenderer> PagerRenderers => _pagerRenderers;
 
 	/// <summary>
 	/// Gets or sets the maximum inline payload size for programmatic clients.
 	/// </summary>
 	public int ProgrammaticMaxInlineBytes { get; set; } = 64 * 1024;
+
+	/// <summary>
+	/// Registers or replaces the pager renderer for its configured mode.
+	/// </summary>
+	/// <param name="renderer">Renderer to register.</param>
+	/// <returns>This options instance.</returns>
+	public ResultFlowOptions UsePagerRenderer(IReplPagerRenderer renderer)
+	{
+		ArgumentNullException.ThrowIfNull(renderer);
+		_ = RemovePagerRenderer(renderer.Mode);
+		_pagerRenderers.Add(renderer);
+		return this;
+	}
+
+	/// <summary>
+	/// Removes the custom pager renderer registered for a mode.
+	/// </summary>
+	/// <param name="mode">Pager mode to remove.</param>
+	/// <returns>True when a renderer was removed.</returns>
+	public bool RemovePagerRenderer(ReplPagerMode mode) =>
+		_pagerRenderers.RemoveAll(renderer => renderer.Mode == mode) > 0;
+
+	/// <summary>
+	/// Removes all custom pager renderers.
+	/// </summary>
+	public void ClearPagerRenderers() =>
+		_pagerRenderers.Clear();
 }

--- a/src/Repl.Core/ResultFlow/ResultFlowOptions.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowOptions.cs
@@ -1,0 +1,32 @@
+namespace Repl;
+
+/// <summary>
+/// Configures Repl result-flow behavior for paging and large result sets.
+/// </summary>
+public sealed class ResultFlowOptions
+{
+	/// <summary>
+	/// Gets or sets the default page size when no terminal-specific hint is available.
+	/// </summary>
+	public int DefaultPageSize { get; set; } = 100;
+
+	/// <summary>
+	/// Gets or sets the maximum page size a caller can request.
+	/// </summary>
+	public int MaxPageSize { get; set; } = 1000;
+
+	/// <summary>
+	/// Gets or sets the number of non-data rows reserved in interactive pagers.
+	/// </summary>
+	public int ReservedVisibleRows { get; set; } = 2;
+
+	/// <summary>
+	/// Gets or sets the default pager mode for human output.
+	/// </summary>
+	public ReplPagerMode DefaultPagerMode { get; set; } = ReplPagerMode.Auto;
+
+	/// <summary>
+	/// Gets or sets the maximum inline payload size for programmatic clients.
+	/// </summary>
+	public int ProgrammaticMaxInlineBytes { get; set; } = 64 * 1024;
+}

--- a/src/Repl.Core/ResultFlow/ResultFlowOptions.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowOptions.cs
@@ -6,16 +6,51 @@ namespace Repl;
 public sealed class ResultFlowOptions
 {
 	private readonly List<IReplPagerRenderer> _pagerRenderers = [];
+	private int _defaultPageSize = 100;
+	private int _maxPageSize = 1000;
 
 	/// <summary>
 	/// Gets or sets the default page size when no terminal-specific hint is available.
 	/// </summary>
-	public int DefaultPageSize { get; set; } = 100;
+	public int DefaultPageSize
+	{
+		get => _defaultPageSize;
+		set
+		{
+			if (value < 1)
+			{
+				throw new ArgumentOutOfRangeException(nameof(value), "Default page size must be greater than zero.");
+			}
+
+			_defaultPageSize = value;
+			if (_maxPageSize < _defaultPageSize)
+			{
+				_maxPageSize = _defaultPageSize;
+			}
+		}
+	}
 
 	/// <summary>
 	/// Gets or sets the maximum page size a caller can request.
 	/// </summary>
-	public int MaxPageSize { get; set; } = 1000;
+	public int MaxPageSize
+	{
+		get => _maxPageSize;
+		set
+		{
+			if (value < 1)
+			{
+				throw new ArgumentOutOfRangeException(nameof(value), "Maximum page size must be greater than zero.");
+			}
+
+			if (value < _defaultPageSize)
+			{
+				throw new ArgumentOutOfRangeException(nameof(value), "Maximum page size must be greater than or equal to the default page size.");
+			}
+
+			_maxPageSize = value;
+		}
+	}
 
 	/// <summary>
 	/// Gets or sets the number of non-data rows reserved in interactive pagers.

--- a/src/Repl.Core/ResultFlow/ResultFlowOptions.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowOptions.cs
@@ -33,6 +33,11 @@ public sealed class ResultFlowOptions
 	public IReadOnlyList<IReplPagerRenderer> PagerRenderers => _pagerRenderers;
 
 	/// <summary>
+	/// Gets or sets the maximum number of content lines an interactive pager buffers in memory.
+	/// </summary>
+	public int MaxBufferedLines { get; set; } = 10_000;
+
+	/// <summary>
 	/// Gets or sets the maximum inline payload size for programmatic clients.
 	/// </summary>
 	public int ProgrammaticMaxInlineBytes { get; set; } = 64 * 1024;

--- a/src/Repl.Core/ResultFlow/ResultFlowOptions.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowOptions.cs
@@ -10,6 +10,8 @@ public sealed class ResultFlowOptions
 	private readonly List<IReplPagerRenderer> _pagerRenderers = [];
 	private int _defaultPageSize = 100;
 	private int _maxPageSize = 1000;
+	private int _maxBufferedLines = DefaultMaxBufferedLines;
+	private int _programmaticMaxInlineBytes = 64 * 1024;
 
 	/// <summary>
 	/// Gets or sets the default page size when no terminal-specific hint is available.
@@ -24,11 +26,12 @@ public sealed class ResultFlowOptions
 				throw new ArgumentOutOfRangeException(nameof(value), "Default page size must be greater than zero.");
 			}
 
-			_defaultPageSize = value;
-			if (_maxPageSize < _defaultPageSize)
+			if (value > _maxPageSize)
 			{
-				_maxPageSize = _defaultPageSize;
+				throw new ArgumentOutOfRangeException(nameof(value), "Default page size must be less than or equal to the maximum page size.");
 			}
+
+			_defaultPageSize = value;
 		}
 	}
 
@@ -72,12 +75,36 @@ public sealed class ResultFlowOptions
 	/// <summary>
 	/// Gets or sets the maximum number of content lines an interactive pager buffers in memory.
 	/// </summary>
-	public int MaxBufferedLines { get; set; } = DefaultMaxBufferedLines;
+	public int MaxBufferedLines
+	{
+		get => _maxBufferedLines;
+		set
+		{
+			if (value < 1)
+			{
+				throw new ArgumentOutOfRangeException(nameof(value), "Maximum buffered lines must be greater than zero.");
+			}
+
+			_maxBufferedLines = value;
+		}
+	}
 
 	/// <summary>
 	/// Gets or sets the maximum inline payload size for programmatic clients.
 	/// </summary>
-	public int ProgrammaticMaxInlineBytes { get; set; } = 64 * 1024;
+	public int ProgrammaticMaxInlineBytes
+	{
+		get => _programmaticMaxInlineBytes;
+		set
+		{
+			if (value < 1)
+			{
+				throw new ArgumentOutOfRangeException(nameof(value), "Programmatic maximum inline bytes must be greater than zero.");
+			}
+
+			_programmaticMaxInlineBytes = value;
+		}
+	}
 
 	/// <summary>
 	/// Registers or replaces the pager renderer for its configured mode.

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -9,6 +9,7 @@ internal static class ResultFlowPager
 	private const string ShowCursor = "\u001b[?25h";
 	private const string CursorHome = "\u001b[H";
 	private const string ClearToEndOfScreen = "\u001b[J";
+	private const string ClearLine = "\u001b[2K";
 
 	public static int CountLines(string payload) => SplitLines(payload).Length;
 
@@ -197,6 +198,8 @@ internal static class ResultFlowPager
 
 		await output.WriteAsync(EnterAlternateScreen).ConfigureAwait(false);
 		await output.WriteAsync(HideCursor).ConfigureAwait(false);
+		await output.WriteAsync(CursorHome).ConfigureAwait(false);
+		await output.WriteAsync(ClearToEndOfScreen).ConfigureAwait(false);
 		try
 		{
 			await EnsureScrollBufferAsync(state, fetchNextPayload, cancellationToken).ConfigureAwait(false);
@@ -204,22 +207,19 @@ internal static class ResultFlowPager
 			{
 				await RenderScrollAsync(state, output, cancellationToken).ConfigureAwait(false);
 				var key = await keyReader.ReadKeyAsync(cancellationToken).ConfigureAwait(false);
-				if (ApplyScrollKey(state, key))
+				var beforeTopLine = state.TopLine;
+				var action = ApplyScrollKey(state, key);
+				if (action == ScrollKeyAction.Quit)
 				{
 					return;
 				}
 
-				if (state.HasReachedBottom
-					&& state.Buffer.Count > state.ViewportHeight
+				if (ShouldFetchForScrollKey(state, action, beforeTopLine)
 					&& state.HasMorePayload
 					&& fetchNextPayload is not null)
 				{
-					var before = state.Buffer.Count;
 					await FetchIntoScrollBufferAsync(state, fetchNextPayload, cancellationToken).ConfigureAwait(false);
-					if (state.Buffer.Count > before)
-					{
-						state.TopLine = Math.Min(state.TopLine + state.ViewportHeight, state.MaxTopLine);
-					}
+					state.TopLine = Math.Min(beforeTopLine + GetScrollDelta(action, state.ViewportHeight), state.MaxTopLine);
 				}
 			}
 		}
@@ -357,15 +357,22 @@ internal static class ResultFlowPager
 		CancellationToken cancellationToken)
 	{
 		await output.WriteAsync(CursorHome).ConfigureAwait(false);
-		await output.WriteAsync(ClearToEndOfScreen).ConfigureAwait(false);
+		if (state.StickyHeader is { } header)
+		{
+			await output.WriteAsync(ClearLine).ConfigureAwait(false);
+			await output.WriteLineAsync(header).ConfigureAwait(false);
+		}
+
 		var take = Math.Min(state.ViewportHeight, Math.Max(0, state.Buffer.Count - state.TopLine));
 		for (var i = 0; i < take; i++)
 		{
+			await output.WriteAsync(ClearLine).ConfigureAwait(false);
 			await output.WriteLineAsync(state.Buffer[state.TopLine + i]).ConfigureAwait(false);
 		}
 
 		for (var i = take; i < state.ViewportHeight; i++)
 		{
+			await output.WriteAsync(ClearLine).ConfigureAwait(false);
 			await output.WriteLineAsync().ConfigureAwait(false);
 		}
 
@@ -375,43 +382,55 @@ internal static class ResultFlowPager
 		var status = state.Buffer.Count == 0
 			? "-- result-flow: loading --"
 			: $"-- result-flow {state.TopLine + 1}-{lastLine}/{state.Buffer.Count}{(state.HasMorePayload ? "+" : string.Empty)}  Space: next  Up/Down: scroll  q: quit --";
+		await output.WriteAsync(ClearLine).ConfigureAwait(false);
 		await output.WriteAsync(status).ConfigureAwait(false);
 		await output.FlushAsync(cancellationToken).ConfigureAwait(false);
 	}
 
-	private static bool ApplyScrollKey(ScrollPagerState state, ConsoleKeyInfo key)
+	private static ScrollKeyAction ApplyScrollKey(ScrollPagerState state, ConsoleKeyInfo key)
 	{
 		switch (key.Key)
 		{
 			case ConsoleKey.Q:
 			case ConsoleKey.Escape:
-				return true;
+				return ScrollKeyAction.Quit;
 			case ConsoleKey.Spacebar:
 			case ConsoleKey.PageDown:
 			case ConsoleKey.F:
 				state.TopLine = Math.Min(state.TopLine + state.ViewportHeight, state.MaxTopLine);
-				return false;
+				return ScrollKeyAction.PageDown;
 			case ConsoleKey.Enter:
 			case ConsoleKey.DownArrow:
 			case ConsoleKey.J:
 				state.TopLine = Math.Min(state.TopLine + 1, state.MaxTopLine);
-				return false;
+				return ScrollKeyAction.LineDown;
 			case ConsoleKey.UpArrow:
 			case ConsoleKey.K:
 				state.TopLine = Math.Max(0, state.TopLine - 1);
-				return false;
+				return ScrollKeyAction.Other;
 			case ConsoleKey.PageUp:
 			case ConsoleKey.B:
 				state.TopLine = Math.Max(0, state.TopLine - state.ViewportHeight);
-				return false;
+				return ScrollKeyAction.Other;
 			case ConsoleKey.Home:
 			case ConsoleKey.G when key.Modifiers.HasFlag(ConsoleModifiers.Shift):
 				state.TopLine = 0;
-				return false;
+				return ScrollKeyAction.Other;
 			default:
-				return false;
+				return ScrollKeyAction.Other;
 		}
 	}
+
+	private static bool ShouldFetchForScrollKey(ScrollPagerState state, ScrollKeyAction action, int beforeTopLine) =>
+		action switch
+		{
+			ScrollKeyAction.PageDown => state.HasReachedBottom && state.Buffer.Count > state.ViewportHeight,
+			ScrollKeyAction.LineDown => beforeTopLine == state.TopLine && state.HasReachedBottom,
+			_ => false,
+		};
+
+	private static int GetScrollDelta(ScrollKeyAction action, int viewportHeight) =>
+		action == ScrollKeyAction.PageDown ? viewportHeight : 1;
 
 	private static bool ShouldUseScrollPager(ReplPagerMode pagerMode, bool ansiEnabled) =>
 		ansiEnabled && pagerMode is ReplPagerMode.Auto or ReplPagerMode.Scroll;
@@ -461,15 +480,33 @@ internal static class ResultFlowPager
 		}
 	}
 
-	private sealed class ScrollPagerState(string[] lines, int visibleRows, bool hasMorePayload)
+	private enum ScrollKeyAction
 	{
-		public List<string> Buffer { get; } = [.. lines];
+		Other,
+		LineDown,
+		PageDown,
+		Quit,
+	}
 
-		public int ViewportHeight { get; } = Math.Max(1, visibleRows - 1);
+	private sealed class ScrollPagerState
+	{
+		public ScrollPagerState(string[] lines, int visibleRows, bool hasMorePayload)
+		{
+			StickyHeader = TryGetStickyHeader(lines);
+			Buffer = [.. GetContentLines(lines, StickyHeader)];
+			ViewportHeight = Math.Max(1, visibleRows - (StickyHeader is null ? 1 : 2));
+			HasMorePayload = hasMorePayload;
+		}
+
+		public List<string> Buffer { get; }
+
+		public string? StickyHeader { get; }
+
+		public int ViewportHeight { get; }
 
 		public int TopLine { get; set; }
 
-		public bool HasMorePayload { get; set; } = hasMorePayload;
+		public bool HasMorePayload { get; set; }
 
 		public int MaxTopLine => Math.Max(0, Buffer.Count - ViewportHeight);
 
@@ -477,8 +514,18 @@ internal static class ResultFlowPager
 
 		public void Append(string[] lines, bool hasMorePayload)
 		{
-			Buffer.AddRange(lines);
+			Buffer.AddRange(GetContentLines(lines, StickyHeader));
 			HasMorePayload = hasMorePayload;
 		}
+
+		private static string? TryGetStickyHeader(string[] lines) =>
+			lines.Length > 1 && lines[0].Contains("\u001b[1m", StringComparison.Ordinal)
+				? lines[0]
+				: null;
+
+		private static IEnumerable<string> GetContentLines(string[] lines, string? stickyHeader) =>
+			stickyHeader is not null && lines.Length > 0 && string.Equals(lines[0], stickyHeader, StringComparison.Ordinal)
+				? lines.Skip(1)
+				: lines;
 	}
 }

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -9,6 +9,8 @@ internal static class ResultFlowPager
 	private const string ShowCursor = "\u001b[?25h";
 	private const string CursorHome = "\u001b[H";
 	private const string ClearToEndOfScreen = "\u001b[J";
+	private const string DisableLineWrap = "\u001b[?7l";
+	private const string EnableLineWrap = "\u001b[?7h";
 
 	public static int CountLines(string payload) => SplitLines(payload).Length;
 
@@ -254,6 +256,7 @@ internal static class ResultFlowPager
 
 		await output.WriteAsync(EnterAlternateScreen).ConfigureAwait(false);
 		await output.WriteAsync(HideCursor).ConfigureAwait(false);
+		await output.WriteAsync(DisableLineWrap).ConfigureAwait(false);
 		await output.WriteAsync(CursorHome).ConfigureAwait(false);
 		await output.WriteAsync(ClearToEndOfScreen).ConfigureAwait(false);
 		try
@@ -288,6 +291,7 @@ internal static class ResultFlowPager
 		}
 		finally
 		{
+			await output.WriteAsync(EnableLineWrap).ConfigureAwait(false);
 			await output.WriteAsync(ShowCursor).ConfigureAwait(false);
 			await output.WriteAsync(LeaveAlternateScreen).ConfigureAwait(false);
 			await output.FlushAsync(cancellationToken).ConfigureAwait(false);
@@ -679,7 +683,8 @@ internal static class ResultFlowPager
 					: 0;
 			for (var i = start; i < lines.Length; i++)
 			{
-				if (!IsPageFooterLine(lines[i]))
+				if ((stickyHeader is null || !AreSameHeaderLine(lines[i], stickyHeader))
+					&& !IsPageFooterLine(lines[i]))
 				{
 					yield return lines[i];
 				}

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -3,6 +3,12 @@ namespace Repl;
 internal static class ResultFlowPager
 {
 	private const string MorePrompt = "--More-- Space/PageDown: continue, Enter/Down: line, Up/PageUp: back, q/Esc: stop";
+	private const string EnterAlternateScreen = "\u001b[?1049h";
+	private const string LeaveAlternateScreen = "\u001b[?1049l";
+	private const string HideCursor = "\u001b[?25l";
+	private const string ShowCursor = "\u001b[?25h";
+	private const string CursorHome = "\u001b[H";
+	private const string ClearToEndOfScreen = "\u001b[J";
 
 	public static int CountLines(string payload) => SplitLines(payload).Length;
 
@@ -29,6 +35,52 @@ internal static class ResultFlowPager
 		TextWriter output,
 		IReplKeyReader keyReader,
 		int visibleRows,
+		ReplPagerMode pagerMode,
+		bool ansiEnabled,
+		CancellationToken cancellationToken = default)
+	{
+		await WriteAsync(
+				payload,
+				output,
+				keyReader,
+				visibleRows,
+				pagerMode,
+				ansiEnabled,
+				hasMorePayload: false,
+				fetchNextPayload: null,
+				cancellationToken)
+			.ConfigureAwait(false);
+	}
+
+	public static async ValueTask WriteAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		bool hasMorePayload,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		CancellationToken cancellationToken = default)
+	{
+		await WriteAsync(
+				payload,
+				output,
+				keyReader,
+				visibleRows,
+				ReplPagerMode.More,
+				ansiEnabled: false,
+				hasMorePayload,
+				fetchNextPayload,
+				cancellationToken)
+			.ConfigureAwait(false);
+	}
+
+	public static async ValueTask WriteAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		ReplPagerMode pagerMode,
+		bool ansiEnabled,
 		bool hasMorePayload,
 		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
 		CancellationToken cancellationToken = default)
@@ -36,6 +88,40 @@ internal static class ResultFlowPager
 		ArgumentNullException.ThrowIfNull(output);
 		ArgumentNullException.ThrowIfNull(keyReader);
 
+		if (ShouldUseScrollPager(pagerMode, ansiEnabled))
+		{
+			await WriteScrollAsync(
+					payload,
+					output,
+					keyReader,
+					visibleRows,
+					hasMorePayload,
+					fetchNextPayload,
+					cancellationToken)
+				.ConfigureAwait(false);
+			return;
+		}
+
+		await WriteMoreAsync(
+				payload,
+				output,
+				keyReader,
+				visibleRows,
+				hasMorePayload,
+				fetchNextPayload,
+				cancellationToken)
+			.ConfigureAwait(false);
+	}
+
+	private static async ValueTask WriteMoreAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		bool hasMorePayload,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		CancellationToken cancellationToken)
+	{
 		var state = new PagerState(SplitLines(payload), Math.Max(1, visibleRows), hasMorePayload);
 		if (state.Lines.Length == 0 && !state.HasMorePayload)
 		{
@@ -84,6 +170,54 @@ internal static class ResultFlowPager
 			}
 
 			state.Reset(SplitLines(nextPayload.Payload), nextPayload.HasMore);
+		}
+	}
+
+	private static async ValueTask WriteScrollAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		bool hasMorePayload,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		CancellationToken cancellationToken)
+	{
+		var state = new ScrollPagerState(SplitLines(payload), Math.Max(2, visibleRows), hasMorePayload);
+		if (state.Buffer.Count == 0 && !state.HasMorePayload)
+		{
+			return;
+		}
+
+		await output.WriteAsync(EnterAlternateScreen).ConfigureAwait(false);
+		await output.WriteAsync(HideCursor).ConfigureAwait(false);
+		try
+		{
+			await EnsureScrollBufferAsync(state, fetchNextPayload, cancellationToken).ConfigureAwait(false);
+			while (true)
+			{
+				await RenderScrollAsync(state, output, cancellationToken).ConfigureAwait(false);
+				var key = await keyReader.ReadKeyAsync(cancellationToken).ConfigureAwait(false);
+				if (ApplyScrollKey(state, key))
+				{
+					return;
+				}
+
+				if (state.TopLine >= state.MaxTopLine && state.HasMorePayload && fetchNextPayload is not null)
+				{
+					var before = state.Buffer.Count;
+					await FetchIntoScrollBufferAsync(state, fetchNextPayload, cancellationToken).ConfigureAwait(false);
+					if (state.Buffer.Count > before)
+					{
+						state.TopLine = Math.Min(state.TopLine + state.ViewportHeight, state.MaxTopLine);
+					}
+				}
+			}
+		}
+		finally
+		{
+			await output.WriteAsync(ShowCursor).ConfigureAwait(false);
+			await output.WriteAsync(LeaveAlternateScreen).ConfigureAwait(false);
+			await output.FlushAsync(cancellationToken).ConfigureAwait(false);
 		}
 	}
 
@@ -181,6 +315,92 @@ internal static class ResultFlowPager
 		return key;
 	}
 
+	private static async ValueTask EnsureScrollBufferAsync(
+		ScrollPagerState state,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		CancellationToken cancellationToken)
+	{
+		while (state.Buffer.Count == 0 && state.HasMorePayload && fetchNextPayload is not null)
+		{
+			await FetchIntoScrollBufferAsync(state, fetchNextPayload, cancellationToken).ConfigureAwait(false);
+		}
+	}
+
+	private static async ValueTask FetchIntoScrollBufferAsync(
+		ScrollPagerState state,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>> fetchNextPayload,
+		CancellationToken cancellationToken)
+	{
+		var nextPayload = await fetchNextPayload(cancellationToken).ConfigureAwait(false);
+		if (nextPayload is null)
+		{
+			state.HasMorePayload = false;
+			return;
+		}
+
+		state.Append(SplitLines(nextPayload.Payload), nextPayload.HasMore);
+	}
+
+	private static async ValueTask RenderScrollAsync(
+		ScrollPagerState state,
+		TextWriter output,
+		CancellationToken cancellationToken)
+	{
+		await output.WriteAsync(CursorHome).ConfigureAwait(false);
+		await output.WriteAsync(ClearToEndOfScreen).ConfigureAwait(false);
+		var take = Math.Min(state.ViewportHeight, Math.Max(0, state.Buffer.Count - state.TopLine));
+		for (var i = 0; i < take; i++)
+		{
+			await output.WriteLineAsync(state.Buffer[state.TopLine + i]).ConfigureAwait(false);
+		}
+
+		for (var i = take; i < state.ViewportHeight; i++)
+		{
+			await output.WriteLineAsync().ConfigureAwait(false);
+		}
+
+		var lastLine = state.Buffer.Count == 0
+			? 0
+			: Math.Min(state.Buffer.Count, state.TopLine + state.ViewportHeight);
+		var status = state.Buffer.Count == 0
+			? "-- result-flow: loading --"
+			: $"-- result-flow {state.TopLine + 1}-{lastLine}/{state.Buffer.Count}{(state.HasMorePayload ? "+" : string.Empty)}  Space: next  Up/Down: scroll  q: quit --";
+		await output.WriteAsync(status).ConfigureAwait(false);
+		await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+	}
+
+	private static bool ApplyScrollKey(ScrollPagerState state, ConsoleKeyInfo key)
+	{
+		switch (key.Key)
+		{
+			case ConsoleKey.Q:
+			case ConsoleKey.Escape:
+				return true;
+			case ConsoleKey.DownArrow:
+			case ConsoleKey.J:
+				state.TopLine = Math.Min(state.TopLine + 1, state.MaxTopLine);
+				return false;
+			case ConsoleKey.UpArrow:
+			case ConsoleKey.K:
+				state.TopLine = Math.Max(0, state.TopLine - 1);
+				return false;
+			case ConsoleKey.PageUp:
+			case ConsoleKey.B:
+				state.TopLine = Math.Max(0, state.TopLine - state.ViewportHeight);
+				return false;
+			case ConsoleKey.Home:
+			case ConsoleKey.G when key.Modifiers.HasFlag(ConsoleModifiers.Shift):
+				state.TopLine = 0;
+				return false;
+			default:
+				state.TopLine = Math.Min(state.TopLine + state.ViewportHeight, state.MaxTopLine);
+				return false;
+		}
+	}
+
+	private static bool ShouldUseScrollPager(ReplPagerMode pagerMode, bool ansiEnabled) =>
+		ansiEnabled && pagerMode is ReplPagerMode.Auto or ReplPagerMode.Scroll;
+
 	private static string[] SplitLines(string payload) =>
 		string.IsNullOrEmpty(payload)
 			? []
@@ -205,6 +425,25 @@ internal static class ResultFlowPager
 		{
 			Lines = lines;
 			Index = 0;
+			HasMorePayload = hasMorePayload;
+		}
+	}
+
+	private sealed class ScrollPagerState(string[] lines, int visibleRows, bool hasMorePayload)
+	{
+		public List<string> Buffer { get; } = [.. lines];
+
+		public int ViewportHeight { get; } = Math.Max(1, visibleRows - 1);
+
+		public int TopLine { get; set; }
+
+		public bool HasMorePayload { get; set; } = hasMorePayload;
+
+		public int MaxTopLine => Math.Max(0, Buffer.Count - ViewportHeight);
+
+		public void Append(string[] lines, bool hasMorePayload)
+		{
+			Buffer.AddRange(lines);
 			HasMorePayload = hasMorePayload;
 		}
 	}

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -424,27 +424,16 @@ internal static class ResultFlowPager
 	private static string[] SplitNonEmptyPayloadLines(string payload)
 	{
 		var lines = new List<string>();
-		var start = 0;
-		for (var index = 0; index < payload.Length; index++)
+		foreach (var line in payload.AsSpan().EnumerateLines())
 		{
-			var current = payload[index];
-			if (current is not '\r' and not '\n')
-			{
-				continue;
-			}
-
-			lines.Add(payload[start..index]);
-			if (current == '\r' && index + 1 < payload.Length && payload[index + 1] == '\n')
-			{
-				index++;
-			}
-
-			start = index + 1;
+			lines.Add(line.ToString());
 		}
 
-		if (start < payload.Length)
+		// EnumerateLines adds a trailing empty entry when the payload ends with a newline;
+		// strip it to stay consistent with how the pager counts visible lines.
+		if (lines.Count > 0 && lines[^1].Length == 0)
 		{
-			lines.Add(payload[start..]);
+			lines.RemoveAt(lines.Count - 1);
 		}
 
 		return [.. lines];
@@ -452,7 +441,9 @@ internal static class ResultFlowPager
 
 	private sealed class PagerState(string[] lines, int pageSize, bool hasMorePayload)
 	{
-		public string[] Lines { get; private set; } = lines;
+		private string[] _lines = lines;
+
+		public string[] Lines => _lines;
 
 		public int PageSize { get; } = pageSize;
 
@@ -464,7 +455,7 @@ internal static class ResultFlowPager
 
 		public void Reset(string[] lines, bool hasMorePayload)
 		{
-			Lines = lines;
+			_lines = lines;
 			Index = 0;
 			HasMorePayload = hasMorePayload;
 		}

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -4,14 +4,6 @@ internal static class ResultFlowPager
 {
 	private const string MorePrompt = "--More-- Space/PageDown: continue, Enter/Down: line, Up/PageUp: ignored, q/Esc: stop";
 	private const string FullStatus = "-- result-flow {0}-{1}/{2}{3}  Space: next  Up/Down: scroll  Home/End: known bounds  q: quit --";
-	private const string EnterAlternateScreen = "\u001b[?1049h";
-	private const string LeaveAlternateScreen = "\u001b[?1049l";
-	private const string HideCursor = "\u001b[?25l";
-	private const string ShowCursor = "\u001b[?25h";
-	private const string CursorHome = "\u001b[H";
-	private const string ClearToEndOfScreen = "\u001b[J";
-	private const string DisableLineWrap = "\u001b[?7l";
-	private const string EnableLineWrap = "\u001b[?7h";
 	private static readonly System.Text.CompositeFormat FullStatusFormat =
 		System.Text.CompositeFormat.Parse(FullStatus);
 
@@ -179,7 +171,7 @@ internal static class ResultFlowPager
 						Math.Max(2, visibleRows),
 						visibleRowsProvider,
 						fetchNextPayload,
-						useAlternateScreen: true,
+						TerminalSurfaceMode.AlternateScreen,
 						cancellationToken)
 					.ConfigureAwait(false);
 				break;
@@ -191,7 +183,7 @@ internal static class ResultFlowPager
 						Math.Max(2, visibleRows),
 						visibleRowsProvider,
 						fetchNextPayload,
-						useAlternateScreen: false,
+						TerminalSurfaceMode.InlineRegion,
 						cancellationToken)
 					.ConfigureAwait(false);
 				break;
@@ -397,7 +389,7 @@ internal static class ResultFlowPager
 		int visibleRows,
 		Func<int>? visibleRowsProvider,
 		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
-		bool useAlternateScreen,
+		TerminalSurfaceMode surfaceMode,
 		CancellationToken cancellationToken)
 	{
 		var state = new ViewportState(session, visibleRows);
@@ -406,16 +398,11 @@ internal static class ResultFlowPager
 			return;
 		}
 
-		if (useAlternateScreen)
-		{
-			await output.WriteAsync(EnterAlternateScreen).ConfigureAwait(false);
-		}
-
-		await output.WriteAsync(HideCursor).ConfigureAwait(false);
-		await output.WriteAsync(DisableLineWrap).ConfigureAwait(false);
-		await output.WriteAsync(CursorHome).ConfigureAwait(false);
-		await output.WriteAsync(ClearToEndOfScreen).ConfigureAwait(false);
-
+		var surface = await TerminalSurfaceHost.EnterAsync(
+				output,
+				surfaceMode,
+				cancellationToken)
+			.ConfigureAwait(false);
 		try
 		{
 			await EnsureViewportContentAsync(state.Session, fetchNextPayload, cancellationToken).ConfigureAwait(false);
@@ -424,10 +411,10 @@ internal static class ResultFlowPager
 				var currentRows = GetCurrentVisibleRows(visibleRows, visibleRowsProvider);
 				if (state.UpdateVisibleRows(currentRows))
 				{
-					await ClearViewportAsync(output, state, useAlternateScreen).ConfigureAwait(false);
+					await ClearViewportAsync(surface, state).ConfigureAwait(false);
 				}
 
-				await RenderViewportFrameAsync(state, output, useAlternateScreen, cancellationToken).ConfigureAwait(false);
+				await RenderViewportFrameAsync(state, surface, cancellationToken).ConfigureAwait(false);
 				var key = await keyReader.ReadKeyAsync(cancellationToken).ConfigureAwait(false);
 				var beforeTopLine = state.TopLine;
 				var action = ApplyViewportKey(state, key);
@@ -447,14 +434,7 @@ internal static class ResultFlowPager
 		}
 		finally
 		{
-			await output.WriteAsync(EnableLineWrap).ConfigureAwait(false);
-			await output.WriteAsync(ShowCursor).ConfigureAwait(false);
-			if (useAlternateScreen)
-			{
-				await output.WriteAsync(LeaveAlternateScreen).ConfigureAwait(false);
-			}
-
-			await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+			await surface.DisposeAsync().ConfigureAwait(false);
 		}
 	}
 
@@ -484,44 +464,43 @@ internal static class ResultFlowPager
 		session.Append(nextPayload.Payload, nextPayload.HasMore);
 	}
 
-	private static async ValueTask ClearViewportAsync(TextWriter output, ViewportState state, bool useAlternateScreen)
+	private static async ValueTask ClearViewportAsync(TerminalSurfaceScope surface, ViewportState state)
 	{
-		if (useAlternateScreen)
+		if (surface.Mode == TerminalSurfaceMode.AlternateScreen)
 		{
-			await output.WriteAsync(CursorHome).ConfigureAwait(false);
+			await surface.MoveHomeAsync().ConfigureAwait(false);
 		}
 		else if (state.RenderedHeight > 0)
 		{
-			await output.WriteAsync($"\u001b[{state.RenderedHeight}A").ConfigureAwait(false);
-			await output.WriteAsync('\r').ConfigureAwait(false);
+			await surface.MoveCursorUpAsync(state.RenderedHeight).ConfigureAwait(false);
+			await surface.MoveToColumnStartAsync().ConfigureAwait(false);
 		}
 
-		await output.WriteAsync(ClearToEndOfScreen).ConfigureAwait(false);
+		await surface.ClearToEndOfScreenAsync().ConfigureAwait(false);
 		state.ResetRenderedLineLengths();
 	}
 
 	private static async ValueTask RenderViewportFrameAsync(
 		ViewportState state,
-		TextWriter output,
-		bool useAlternateScreen,
+		TerminalSurfaceScope surface,
 		CancellationToken cancellationToken)
 	{
-		await PositionViewportAsync(output, state, useAlternateScreen).ConfigureAwait(false);
+		await PositionViewportAsync(surface, state).ConfigureAwait(false);
 		var row = 0;
 		foreach (var headerLine in state.Session.HeaderLines)
 		{
-			await WriteViewportLineAsync(state, output, row++, headerLine).ConfigureAwait(false);
+			await WriteViewportLineAsync(state, surface.Output, row++, headerLine).ConfigureAwait(false);
 		}
 
 		var take = Math.Min(state.ViewportHeight, Math.Max(0, state.Session.Lines.Count - state.TopLine));
 		for (var i = 0; i < take; i++)
 		{
-			await WriteViewportLineAsync(state, output, row++, state.Session.Lines[state.TopLine + i]).ConfigureAwait(false);
+			await WriteViewportLineAsync(state, surface.Output, row++, state.Session.Lines[state.TopLine + i]).ConfigureAwait(false);
 		}
 
 		for (var i = take; i < state.ViewportHeight; i++)
 		{
-			await WriteViewportLineAsync(state, output, row++, string.Empty).ConfigureAwait(false);
+			await WriteViewportLineAsync(state, surface.Output, row++, string.Empty).ConfigureAwait(false);
 		}
 
 		var lastLine = state.Session.Lines.Count == 0
@@ -536,21 +515,21 @@ internal static class ResultFlowPager
 				lastLine,
 				state.Session.Lines.Count,
 				state.Session.HasMorePayload ? "+" : string.Empty);
-		await WriteViewportLineAsync(state, output, row++, status, appendNewLine: false).ConfigureAwait(false);
+		await WriteViewportLineAsync(state, surface.Output, row++, status, appendNewLine: false).ConfigureAwait(false);
 		state.RenderedHeight = row;
-		await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+		await surface.FlushAsync(cancellationToken).ConfigureAwait(false);
 	}
 
-	private static async ValueTask PositionViewportAsync(TextWriter output, ViewportState state, bool useAlternateScreen)
+	private static async ValueTask PositionViewportAsync(TerminalSurfaceScope surface, ViewportState state)
 	{
-		if (useAlternateScreen)
+		if (surface.Mode == TerminalSurfaceMode.AlternateScreen)
 		{
-			await output.WriteAsync(CursorHome).ConfigureAwait(false);
+			await surface.MoveHomeAsync().ConfigureAwait(false);
 		}
 		else if (state.RenderedHeight > 0)
 		{
-			await output.WriteAsync($"\u001b[{state.RenderedHeight}A").ConfigureAwait(false);
-			await output.WriteAsync('\r').ConfigureAwait(false);
+			await surface.MoveCursorUpAsync(state.RenderedHeight).ConfigureAwait(false);
+			await surface.MoveToColumnStartAsync().ConfigureAwait(false);
 		}
 	}
 

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -386,6 +386,12 @@ internal static class ResultFlowPager
 			case ConsoleKey.Q:
 			case ConsoleKey.Escape:
 				return true;
+			case ConsoleKey.Spacebar:
+			case ConsoleKey.PageDown:
+			case ConsoleKey.F:
+				state.TopLine = Math.Min(state.TopLine + state.ViewportHeight, state.MaxTopLine);
+				return false;
+			case ConsoleKey.Enter:
 			case ConsoleKey.DownArrow:
 			case ConsoleKey.J:
 				state.TopLine = Math.Min(state.TopLine + 1, state.MaxTopLine);
@@ -403,7 +409,6 @@ internal static class ResultFlowPager
 				state.TopLine = 0;
 				return false;
 			default:
-				state.TopLine = Math.Min(state.TopLine + state.ViewportHeight, state.MaxTopLine);
 				return false;
 		}
 	}

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -9,7 +9,6 @@ internal static class ResultFlowPager
 	private const string ShowCursor = "\u001b[?25h";
 	private const string CursorHome = "\u001b[H";
 	private const string ClearToEndOfScreen = "\u001b[J";
-	private const string ClearLine = "\u001b[2K";
 
 	public static int CountLines(string payload) => SplitLines(payload).Length;
 
@@ -71,6 +70,77 @@ internal static class ResultFlowPager
 				ansiEnabled: false,
 				hasMorePayload,
 				fetchNextPayload,
+				visibleRowsProvider: null,
+				cancellationToken)
+			.ConfigureAwait(false);
+	}
+
+	public static async ValueTask WriteAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		Func<int> visibleRowsProvider,
+		ReplPagerMode pagerMode,
+		bool ansiEnabled,
+		bool hasMorePayload,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(visibleRowsProvider);
+
+		await WriteAsync(
+				payload,
+				output,
+				keyReader,
+				visibleRows,
+				pagerMode,
+				ansiEnabled,
+				hasMorePayload,
+				fetchNextPayload,
+				visibleRowsProvider,
+				cancellationToken)
+			.ConfigureAwait(false);
+	}
+
+	private static async ValueTask WriteAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		ReplPagerMode pagerMode,
+		bool ansiEnabled,
+		bool hasMorePayload,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		Func<int>? visibleRowsProvider,
+		CancellationToken cancellationToken)
+	{
+		ArgumentNullException.ThrowIfNull(output);
+		ArgumentNullException.ThrowIfNull(keyReader);
+
+		if (ShouldUseScrollPager(pagerMode, ansiEnabled))
+		{
+			await WriteScrollAsync(
+					payload,
+					output,
+					keyReader,
+					visibleRows,
+					ansiEnabled,
+					hasMorePayload,
+					fetchNextPayload,
+					visibleRowsProvider,
+					cancellationToken)
+				.ConfigureAwait(false);
+			return;
+		}
+
+		await WriteMoreAsync(
+				payload,
+				output,
+				keyReader,
+				visibleRows,
+				hasMorePayload,
+				fetchNextPayload,
 				cancellationToken)
 			.ConfigureAwait(false);
 	}
@@ -86,31 +156,16 @@ internal static class ResultFlowPager
 		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
 		CancellationToken cancellationToken = default)
 	{
-		ArgumentNullException.ThrowIfNull(output);
-		ArgumentNullException.ThrowIfNull(keyReader);
-
-		if (ShouldUseScrollPager(pagerMode, ansiEnabled))
-		{
-			await WriteScrollAsync(
-					payload,
-					output,
-					keyReader,
-					visibleRows,
-					ansiEnabled,
-					hasMorePayload,
-					fetchNextPayload,
-					cancellationToken)
-				.ConfigureAwait(false);
-			return;
-		}
-
-		await WriteMoreAsync(
+		await WriteAsync(
 				payload,
 				output,
 				keyReader,
 				visibleRows,
+				pagerMode,
+				ansiEnabled,
 				hasMorePayload,
 				fetchNextPayload,
+				visibleRowsProvider: null,
 				cancellationToken)
 			.ConfigureAwait(false);
 	}
@@ -183,6 +238,7 @@ internal static class ResultFlowPager
 		bool ansiEnabled,
 		bool hasMorePayload,
 		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		Func<int>? visibleRowsProvider,
 		CancellationToken cancellationToken)
 	{
 		if (!ansiEnabled)
@@ -205,6 +261,13 @@ internal static class ResultFlowPager
 			await EnsureScrollBufferAsync(state, fetchNextPayload, cancellationToken).ConfigureAwait(false);
 			while (true)
 			{
+				if (state.UpdateVisibleRows(GetCurrentVisibleRows(visibleRows, visibleRowsProvider)))
+				{
+					await output.WriteAsync(CursorHome).ConfigureAwait(false);
+					await output.WriteAsync(ClearToEndOfScreen).ConfigureAwait(false);
+					state.ResetRenderedLineLengths();
+				}
+
 				await RenderScrollAsync(state, output, cancellationToken).ConfigureAwait(false);
 				var key = await keyReader.ReadKeyAsync(cancellationToken).ConfigureAwait(false);
 				var beforeTopLine = state.TopLine;
@@ -359,21 +422,19 @@ internal static class ResultFlowPager
 		await output.WriteAsync(CursorHome).ConfigureAwait(false);
 		if (state.StickyHeader is { } header)
 		{
-			await output.WriteAsync(ClearLine).ConfigureAwait(false);
-			await output.WriteLineAsync(header).ConfigureAwait(false);
+			await WriteViewportLineAsync(state, output, row: 0, header).ConfigureAwait(false);
 		}
 
+		var row = state.StickyHeader is null ? 0 : 1;
 		var take = Math.Min(state.ViewportHeight, Math.Max(0, state.Buffer.Count - state.TopLine));
 		for (var i = 0; i < take; i++)
 		{
-			await output.WriteAsync(ClearLine).ConfigureAwait(false);
-			await output.WriteLineAsync(state.Buffer[state.TopLine + i]).ConfigureAwait(false);
+			await WriteViewportLineAsync(state, output, row++, state.Buffer[state.TopLine + i]).ConfigureAwait(false);
 		}
 
 		for (var i = take; i < state.ViewportHeight; i++)
 		{
-			await output.WriteAsync(ClearLine).ConfigureAwait(false);
-			await output.WriteLineAsync().ConfigureAwait(false);
+			await WriteViewportLineAsync(state, output, row++, string.Empty).ConfigureAwait(false);
 		}
 
 		var lastLine = state.Buffer.Count == 0
@@ -382,9 +443,29 @@ internal static class ResultFlowPager
 		var status = state.Buffer.Count == 0
 			? "-- result-flow: loading --"
 			: $"-- result-flow {state.TopLine + 1}-{lastLine}/{state.Buffer.Count}{(state.HasMorePayload ? "+" : string.Empty)}  Space: next  Up/Down: scroll  q: quit --";
-		await output.WriteAsync(ClearLine).ConfigureAwait(false);
-		await output.WriteAsync(status).ConfigureAwait(false);
+		await WriteViewportLineAsync(state, output, row, status, appendNewLine: false).ConfigureAwait(false);
 		await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+	}
+
+	private static async ValueTask WriteViewportLineAsync(
+		ScrollPagerState state,
+		TextWriter output,
+		int row,
+		string line,
+		bool appendNewLine = true)
+	{
+		await output.WriteAsync(line).ConfigureAwait(false);
+		var previousLength = state.GetRenderedLineLength(row);
+		if (previousLength > line.Length)
+		{
+			await output.WriteAsync(new string(' ', previousLength - line.Length)).ConfigureAwait(false);
+		}
+
+		state.SetRenderedLineLength(row, line.Length);
+		if (appendNewLine)
+		{
+			await output.WriteLineAsync().ConfigureAwait(false);
+		}
 	}
 
 	private static ScrollKeyAction ApplyScrollKey(ScrollPagerState state, ConsoleKeyInfo key)
@@ -416,6 +497,9 @@ internal static class ResultFlowPager
 			case ConsoleKey.G when key.Modifiers.HasFlag(ConsoleModifiers.Shift):
 				state.TopLine = 0;
 				return ScrollKeyAction.Other;
+			case ConsoleKey.End:
+				state.TopLine = state.MaxTopLine;
+				return ScrollKeyAction.Other;
 			default:
 				return ScrollKeyAction.Other;
 		}
@@ -431,6 +515,35 @@ internal static class ResultFlowPager
 
 	private static int GetScrollDelta(ScrollKeyAction action, int viewportHeight) =>
 		action == ScrollKeyAction.PageDown ? viewportHeight : 1;
+
+	private static int GetCurrentVisibleRows(int fallbackVisibleRows, Func<int>? visibleRowsProvider)
+	{
+		if (visibleRowsProvider is null)
+		{
+			return Math.Max(2, fallbackVisibleRows);
+		}
+
+		try
+		{
+			return Math.Max(2, visibleRowsProvider());
+		}
+		catch (IOException)
+		{
+			return Math.Max(2, fallbackVisibleRows);
+		}
+		catch (PlatformNotSupportedException)
+		{
+			return Math.Max(2, fallbackVisibleRows);
+		}
+		catch (InvalidOperationException)
+		{
+			return Math.Max(2, fallbackVisibleRows);
+		}
+		catch (System.Security.SecurityException)
+		{
+			return Math.Max(2, fallbackVisibleRows);
+		}
+	}
 
 	private static bool ShouldUseScrollPager(ReplPagerMode pagerMode, bool ansiEnabled) =>
 		ansiEnabled && pagerMode is ReplPagerMode.Auto or ReplPagerMode.Scroll;
@@ -494,15 +607,20 @@ internal static class ResultFlowPager
 		{
 			StickyHeader = TryGetStickyHeader(lines);
 			Buffer = [.. GetContentLines(lines, StickyHeader)];
-			ViewportHeight = Math.Max(1, visibleRows - (StickyHeader is null ? 1 : 2));
+			VisibleRows = Math.Max(2, visibleRows);
+			ViewportHeight = CalculateViewportHeight(VisibleRows, StickyHeader);
 			HasMorePayload = hasMorePayload;
 		}
 
 		public List<string> Buffer { get; }
 
+		private List<int> RenderedLineLengths { get; } = [];
+
 		public string? StickyHeader { get; }
 
-		public int ViewportHeight { get; }
+		public int VisibleRows { get; private set; }
+
+		public int ViewportHeight { get; private set; }
 
 		public int TopLine { get; set; }
 
@@ -518,14 +636,94 @@ internal static class ResultFlowPager
 			HasMorePayload = hasMorePayload;
 		}
 
+		public bool UpdateVisibleRows(int visibleRows)
+		{
+			visibleRows = Math.Max(2, visibleRows);
+			if (VisibleRows == visibleRows)
+			{
+				return false;
+			}
+
+			VisibleRows = visibleRows;
+			ViewportHeight = CalculateViewportHeight(visibleRows, StickyHeader);
+			TopLine = Math.Min(TopLine, MaxTopLine);
+			return true;
+		}
+
+		public int GetRenderedLineLength(int row) =>
+			row < RenderedLineLengths.Count ? RenderedLineLengths[row] : 0;
+
+		public void SetRenderedLineLength(int row, int length)
+		{
+			while (RenderedLineLengths.Count <= row)
+			{
+				RenderedLineLengths.Add(0);
+			}
+
+			RenderedLineLengths[row] = length;
+		}
+
+		public void ResetRenderedLineLengths() => RenderedLineLengths.Clear();
+
 		private static string? TryGetStickyHeader(string[] lines) =>
 			lines.Length > 1 && lines[0].Contains("\u001b[1m", StringComparison.Ordinal)
 				? lines[0]
 				: null;
 
-		private static IEnumerable<string> GetContentLines(string[] lines, string? stickyHeader) =>
-			stickyHeader is not null && lines.Length > 0 && string.Equals(lines[0], stickyHeader, StringComparison.Ordinal)
-				? lines.Skip(1)
-				: lines;
+		private static IEnumerable<string> GetContentLines(string[] lines, string? stickyHeader)
+		{
+			var start = stickyHeader is not null
+				&& lines.Length > 0
+				&& AreSameHeaderLine(lines[0], stickyHeader)
+					? 1
+					: 0;
+			for (var i = start; i < lines.Length; i++)
+			{
+				if (!IsPageFooterLine(lines[i]))
+				{
+					yield return lines[i];
+				}
+			}
+		}
+
+		private static int CalculateViewportHeight(int visibleRows, string? stickyHeader) =>
+			Math.Max(1, visibleRows - (stickyHeader is null ? 1 : 2));
+
+		private static bool AreSameHeaderLine(string candidate, string stickyHeader) =>
+			string.Equals(NormalizeAnsiLine(candidate), NormalizeAnsiLine(stickyHeader), StringComparison.Ordinal);
+
+		private static bool IsPageFooterLine(string line) =>
+			line.StartsWith("Showing ", StringComparison.Ordinal)
+			&& (line.Contains(" of ", StringComparison.Ordinal)
+				|| line.Contains(" result(s).", StringComparison.Ordinal))
+			&& (line.EndsWith('.')
+				|| line.Contains("Next data page: rerun with --result:cursor ", StringComparison.Ordinal));
+
+		private static string NormalizeAnsiLine(string line)
+		{
+			if (!line.Contains('\u001b', StringComparison.Ordinal))
+			{
+				return line.Trim();
+			}
+
+			var builder = new System.Text.StringBuilder(line.Length);
+			for (var i = 0; i < line.Length; i++)
+			{
+				if (line[i] == '\u001b' && i + 1 < line.Length && line[i + 1] == '[')
+				{
+					i += 2;
+					while (i < line.Length && (line[i] < '@' || line[i] > '~'))
+					{
+						i++;
+					}
+
+					continue;
+				}
+
+				builder.Append(line[i]);
+			}
+
+			return builder.ToString().Trim();
+		}
 	}
 }

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -2,7 +2,8 @@ namespace Repl;
 
 internal static class ResultFlowPager
 {
-	private const string MorePrompt = "--More-- Space/PageDown: continue, Enter/Down: line, Up/PageUp: back, q/Esc: stop";
+	private const string MorePrompt = "--More-- Space/PageDown: continue, Enter/Down: line, Up/PageUp: ignored, q/Esc: stop";
+	private const string FullStatus = "-- result-flow {0}-{1}/{2}{3}  Space: next  Up/Down: scroll  Home/End: known bounds  q: quit --";
 	private const string EnterAlternateScreen = "\u001b[?1049h";
 	private const string LeaveAlternateScreen = "\u001b[?1049l";
 	private const string HideCursor = "\u001b[?25l";
@@ -11,8 +12,10 @@ internal static class ResultFlowPager
 	private const string ClearToEndOfScreen = "\u001b[J";
 	private const string DisableLineWrap = "\u001b[?7l";
 	private const string EnableLineWrap = "\u001b[?7h";
+	private static readonly System.Text.CompositeFormat FullStatusFormat =
+		System.Text.CompositeFormat.Parse(FullStatus);
 
-	public static int CountLines(string payload) => SplitLines(payload).Length;
+	public static int CountLines(string payload) => PagerPayloadParser.Parse(payload, header: null).TotalLineCount;
 
 	public static async ValueTask WriteAsync(
 		string payload,
@@ -68,11 +71,38 @@ internal static class ResultFlowPager
 				output,
 				keyReader,
 				visibleRows,
+				visibleRowsProvider: null,
 				ReplPagerMode.More,
 				ansiEnabled: false,
 				hasMorePayload,
 				fetchNextPayload,
+				pagerRenderers: null,
+				cancellationToken)
+			.ConfigureAwait(false);
+	}
+
+	public static async ValueTask WriteAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		ReplPagerMode pagerMode,
+		bool ansiEnabled,
+		bool hasMorePayload,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		CancellationToken cancellationToken = default)
+	{
+		await WriteAsync(
+				payload,
+				output,
+				keyReader,
+				visibleRows,
 				visibleRowsProvider: null,
+				pagerMode,
+				ansiEnabled,
+				hasMorePayload,
+				fetchNextPayload,
+				pagerRenderers: null,
 				cancellationToken)
 			.ConfigureAwait(false);
 	}
@@ -89,60 +119,17 @@ internal static class ResultFlowPager
 		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
 		CancellationToken cancellationToken = default)
 	{
-		ArgumentNullException.ThrowIfNull(visibleRowsProvider);
-
 		await WriteAsync(
 				payload,
 				output,
 				keyReader,
 				visibleRows,
+				visibleRowsProvider,
 				pagerMode,
 				ansiEnabled,
 				hasMorePayload,
 				fetchNextPayload,
-				visibleRowsProvider,
-				cancellationToken)
-			.ConfigureAwait(false);
-	}
-
-	private static async ValueTask WriteAsync(
-		string payload,
-		TextWriter output,
-		IReplKeyReader keyReader,
-		int visibleRows,
-		ReplPagerMode pagerMode,
-		bool ansiEnabled,
-		bool hasMorePayload,
-		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
-		Func<int>? visibleRowsProvider,
-		CancellationToken cancellationToken)
-	{
-		ArgumentNullException.ThrowIfNull(output);
-		ArgumentNullException.ThrowIfNull(keyReader);
-
-		if (ShouldUseScrollPager(pagerMode, ansiEnabled))
-		{
-			await WriteScrollAsync(
-					payload,
-					output,
-					keyReader,
-					visibleRows,
-					ansiEnabled,
-					hasMorePayload,
-					fetchNextPayload,
-					visibleRowsProvider,
-					cancellationToken)
-				.ConfigureAwait(false);
-			return;
-		}
-
-		await WriteMoreAsync(
-				payload,
-				output,
-				keyReader,
-				visibleRows,
-				hasMorePayload,
-				fetchNextPayload,
+				pagerRenderers: null,
 				cancellationToken)
 			.ConfigureAwait(false);
 	}
@@ -152,140 +139,307 @@ internal static class ResultFlowPager
 		TextWriter output,
 		IReplKeyReader keyReader,
 		int visibleRows,
+		Func<int>? visibleRowsProvider,
 		ReplPagerMode pagerMode,
 		bool ansiEnabled,
 		bool hasMorePayload,
 		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		IEnumerable<IReplPagerRenderer>? pagerRenderers,
 		CancellationToken cancellationToken = default)
 	{
-		await WriteAsync(
+		ArgumentNullException.ThrowIfNull(output);
+		ArgumentNullException.ThrowIfNull(keyReader);
+
+		var mode = ResolveMode(pagerMode, ansiEnabled);
+		if (await TryRenderCustomAsync(
+				mode,
+				pagerRenderers,
 				payload,
 				output,
 				keyReader,
 				visibleRows,
-				pagerMode,
+				visibleRowsProvider,
 				ansiEnabled,
 				hasMorePayload,
 				fetchNextPayload,
-				visibleRowsProvider: null,
 				cancellationToken)
-			.ConfigureAwait(false);
-	}
-
-	private static async ValueTask WriteMoreAsync(
-		string payload,
-		TextWriter output,
-		IReplKeyReader keyReader,
-		int visibleRows,
-		bool hasMorePayload,
-		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
-		CancellationToken cancellationToken)
-	{
-		var state = new PagerState(SplitLines(payload), Math.Max(1, visibleRows), hasMorePayload);
-		if (state.Lines.Length == 0 && !state.HasMorePayload)
+			.ConfigureAwait(false))
 		{
 			return;
 		}
 
-		while (true)
+		var session = new PagerSession(payload, hasMorePayload);
+		switch (mode)
 		{
-			if (state.Lines.Length == 0 && state.HasMorePayload && fetchNextPayload is not null)
-			{
-				var payloadPage = await fetchNextPayload(cancellationToken).ConfigureAwait(false);
-				if (payloadPage is null)
-				{
-					return;
-				}
-
-				state.Reset(SplitLines(payloadPage.Payload), payloadPage.HasMore);
-				continue;
-			}
-
-			if (await WriteCurrentPayloadAsync(state, output, keyReader, cancellationToken).ConfigureAwait(false))
-			{
-				return;
-			}
-
-			if (!state.HasMorePayload || fetchNextPayload is null)
-			{
+			case ReplPagerMode.Full:
+				await RenderViewportAsync(
+						session,
+						output,
+						keyReader,
+						Math.Max(2, visibleRows),
+						visibleRowsProvider,
+						fetchNextPayload,
+						useAlternateScreen: true,
+						cancellationToken)
+					.ConfigureAwait(false);
 				break;
-			}
-
-			var boundaryKey = await ReadPromptAsync(output, keyReader, cancellationToken).ConfigureAwait(false);
-			if (ApplyBoundaryKey(state, boundaryKey))
-			{
-				return;
-			}
-
-			if (state.Index < state.Lines.Length)
-			{
-				continue;
-			}
-
-			var nextPayload = await fetchNextPayload(cancellationToken).ConfigureAwait(false);
-			if (nextPayload is null)
-			{
+			case ReplPagerMode.Inline:
+				await RenderViewportAsync(
+						session,
+						output,
+						keyReader,
+						Math.Max(2, visibleRows),
+						visibleRowsProvider,
+						fetchNextPayload,
+						useAlternateScreen: false,
+						cancellationToken)
+					.ConfigureAwait(false);
 				break;
-			}
-
-			state.Reset(SplitLines(nextPayload.Payload), nextPayload.HasMore);
+			default:
+				await RenderMoreAsync(
+						session,
+						output,
+						keyReader,
+						Math.Max(1, visibleRows),
+						fetchNextPayload,
+						cancellationToken)
+					.ConfigureAwait(false);
+				break;
 		}
 	}
 
-	private static async ValueTask WriteScrollAsync(
+	private static ReplPagerMode ResolveMode(ReplPagerMode pagerMode, bool ansiEnabled) =>
+		pagerMode == ReplPagerMode.Auto
+			? ansiEnabled ? ReplPagerMode.Full : ReplPagerMode.More
+			: pagerMode;
+
+	private static async ValueTask<bool> TryRenderCustomAsync(
+		ReplPagerMode mode,
+		IEnumerable<IReplPagerRenderer>? pagerRenderers,
 		string payload,
 		TextWriter output,
 		IReplKeyReader keyReader,
 		int visibleRows,
+		Func<int>? visibleRowsProvider,
 		bool ansiEnabled,
 		bool hasMorePayload,
 		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
-		Func<int>? visibleRowsProvider,
 		CancellationToken cancellationToken)
 	{
-		if (!ansiEnabled)
+		if (pagerRenderers is null)
 		{
-			throw new InvalidOperationException("The scroll result pager requires ANSI support.");
+			return false;
 		}
 
-		var state = new ScrollPagerState(SplitLines(payload), Math.Max(2, visibleRows), hasMorePayload);
-		if (state.Buffer.Count == 0 && !state.HasMorePayload)
+		foreach (var renderer in pagerRenderers)
+		{
+			if (renderer.Mode != mode)
+			{
+				continue;
+			}
+
+			await renderer.RenderAsync(
+					new ReplPagerRenderContext(
+						payload,
+						output,
+						keyReader,
+						visibleRows,
+						visibleRowsProvider,
+						ansiEnabled,
+						hasMorePayload,
+						fetchNextPayload is null ? null : FetchPublicPayloadAsync),
+					cancellationToken)
+				.ConfigureAwait(false);
+			return true;
+		}
+
+		return false;
+
+		async ValueTask<ReplPagerPayload?> FetchPublicPayloadAsync(CancellationToken token)
+		{
+			var next = await fetchNextPayload!(token).ConfigureAwait(false);
+			return next is null ? null : new ReplPagerPayload(next.Payload, next.HasMore);
+		}
+	}
+
+	private static async ValueTask RenderMoreAsync(
+		PagerSession session,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		CancellationToken cancellationToken)
+	{
+		session.PageSize = Math.Max(1, visibleRows);
+		session.NextWindow = session.PageSize;
+		var headerWritten = false;
+		while (true)
+		{
+			if (session.Lines.Count == 0
+				&& !await TryFetchIntoSessionAsync(session, fetchNextPayload, cancellationToken).ConfigureAwait(false))
+			{
+				return;
+			}
+
+			if (!headerWritten)
+			{
+				foreach (var headerLine in session.HeaderLines)
+				{
+					await output.WriteLineAsync(headerLine).ConfigureAwait(false);
+				}
+
+				headerWritten = true;
+			}
+
+			while (session.Index < session.Lines.Count)
+			{
+				await WriteMoreWindowAsync(session, output).ConfigureAwait(false);
+				if (session.Index >= session.Lines.Count)
+				{
+					break;
+				}
+
+				if (await ReadMoreActionAsync(session, output, keyReader, cancellationToken).ConfigureAwait(false) == PagerAction.Quit)
+				{
+					return;
+				}
+			}
+
+			if (!session.HasMorePayload || fetchNextPayload is null)
+			{
+				return;
+			}
+
+			if (await ReadMoreActionAsync(session, output, keyReader, cancellationToken).ConfigureAwait(false) == PagerAction.Quit)
+			{
+				return;
+			}
+
+			if (!await TryFetchIntoSessionAsync(session, fetchNextPayload, cancellationToken).ConfigureAwait(false))
+			{
+				return;
+			}
+		}
+	}
+
+	private static async ValueTask WriteMoreWindowAsync(PagerSession session, TextWriter output)
+	{
+		var take = Math.Min(session.NextWindow, session.Lines.Count - session.Index);
+		for (var i = 0; i < take; i++)
+		{
+			await output.WriteLineAsync(session.Lines[session.Index + i]).ConfigureAwait(false);
+		}
+
+		session.Index += take;
+	}
+
+	private static async ValueTask<bool> TryFetchIntoSessionAsync(
+		PagerSession session,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		CancellationToken cancellationToken)
+	{
+		if (!session.HasMorePayload || fetchNextPayload is null)
+		{
+			return false;
+		}
+
+		var nextPayload = await fetchNextPayload(cancellationToken).ConfigureAwait(false);
+		if (nextPayload is null)
+		{
+			session.HasMorePayload = false;
+			return false;
+		}
+
+		session.Append(nextPayload.Payload, nextPayload.HasMore);
+		return true;
+	}
+
+	private static async ValueTask<PagerAction> ReadMoreActionAsync(
+		PagerSession session,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		CancellationToken cancellationToken)
+	{
+		while (true)
+		{
+			await output.WriteAsync(MorePrompt).ConfigureAwait(false);
+			await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+			var key = await keyReader.ReadKeyAsync(cancellationToken).ConfigureAwait(false);
+			await output.WriteLineAsync().ConfigureAwait(false);
+
+			switch (key.Key)
+			{
+				case ConsoleKey.Q:
+				case ConsoleKey.Escape:
+					return PagerAction.Quit;
+				case ConsoleKey.Enter:
+				case ConsoleKey.DownArrow:
+					session.NextWindow = 1;
+					return PagerAction.LineDown;
+				case ConsoleKey.UpArrow:
+				case ConsoleKey.PageUp:
+				case ConsoleKey.Home:
+				case ConsoleKey.End:
+					continue;
+				default:
+					session.NextWindow = session.PageSize;
+					return PagerAction.PageDown;
+			}
+		}
+	}
+
+	private static async ValueTask RenderViewportAsync(
+		PagerSession session,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		Func<int>? visibleRowsProvider,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		bool useAlternateScreen,
+		CancellationToken cancellationToken)
+	{
+		var state = new ViewportState(session, visibleRows);
+		if (state.Session.Lines.Count == 0 && !state.Session.HasMorePayload)
 		{
 			return;
 		}
 
-		await output.WriteAsync(EnterAlternateScreen).ConfigureAwait(false);
+		if (useAlternateScreen)
+		{
+			await output.WriteAsync(EnterAlternateScreen).ConfigureAwait(false);
+		}
+
 		await output.WriteAsync(HideCursor).ConfigureAwait(false);
 		await output.WriteAsync(DisableLineWrap).ConfigureAwait(false);
 		await output.WriteAsync(CursorHome).ConfigureAwait(false);
 		await output.WriteAsync(ClearToEndOfScreen).ConfigureAwait(false);
+
 		try
 		{
-			await EnsureScrollBufferAsync(state, fetchNextPayload, cancellationToken).ConfigureAwait(false);
+			await EnsureViewportContentAsync(state.Session, fetchNextPayload, cancellationToken).ConfigureAwait(false);
 			while (true)
 			{
-				if (state.UpdateVisibleRows(GetCurrentVisibleRows(visibleRows, visibleRowsProvider)))
+				var currentRows = GetCurrentVisibleRows(visibleRows, visibleRowsProvider);
+				if (state.UpdateVisibleRows(currentRows))
 				{
-					await output.WriteAsync(CursorHome).ConfigureAwait(false);
-					await output.WriteAsync(ClearToEndOfScreen).ConfigureAwait(false);
-					state.ResetRenderedLineLengths();
+					await ClearViewportAsync(output, state, useAlternateScreen).ConfigureAwait(false);
 				}
 
-				await RenderScrollAsync(state, output, cancellationToken).ConfigureAwait(false);
+				await RenderViewportFrameAsync(state, output, useAlternateScreen, cancellationToken).ConfigureAwait(false);
 				var key = await keyReader.ReadKeyAsync(cancellationToken).ConfigureAwait(false);
 				var beforeTopLine = state.TopLine;
-				var action = ApplyScrollKey(state, key);
-				if (action == ScrollKeyAction.Quit)
+				var action = ApplyViewportKey(state, key);
+				if (action == PagerAction.Quit)
 				{
 					return;
 				}
 
-				if (ShouldFetchForScrollKey(state, action, beforeTopLine)
-					&& state.HasMorePayload
+				if (ShouldFetchForViewportKey(state, action, beforeTopLine)
+					&& state.Session.HasMorePayload
 					&& fetchNextPayload is not null)
 				{
-					await FetchIntoScrollBufferAsync(state, fetchNextPayload, cancellationToken).ConfigureAwait(false);
-					state.TopLine = Math.Min(beforeTopLine + GetScrollDelta(action, state.ViewportHeight), state.MaxTopLine);
+					await FetchIntoSessionAsync(state.Session, fetchNextPayload, cancellationToken).ConfigureAwait(false);
+					state.TopLine = Math.Min(beforeTopLine + GetViewportDelta(action, state.ViewportHeight), state.MaxTopLine);
 				}
 			}
 		}
@@ -293,147 +447,74 @@ internal static class ResultFlowPager
 		{
 			await output.WriteAsync(EnableLineWrap).ConfigureAwait(false);
 			await output.WriteAsync(ShowCursor).ConfigureAwait(false);
-			await output.WriteAsync(LeaveAlternateScreen).ConfigureAwait(false);
+			if (useAlternateScreen)
+			{
+				await output.WriteAsync(LeaveAlternateScreen).ConfigureAwait(false);
+			}
+
 			await output.FlushAsync(cancellationToken).ConfigureAwait(false);
 		}
 	}
 
-	private static async ValueTask<bool> WriteCurrentPayloadAsync(
-		PagerState state,
-		TextWriter output,
-		IReplKeyReader keyReader,
-		CancellationToken cancellationToken)
-	{
-		while (state.Index < state.Lines.Length)
-		{
-			cancellationToken.ThrowIfCancellationRequested();
-			var windowStart = state.Index;
-			var take = Math.Min(state.NextWindow, state.Lines.Length - state.Index);
-			for (var i = 0; i < take; i++)
-			{
-				await output.WriteLineAsync(state.Lines[state.Index + i]).ConfigureAwait(false);
-			}
-
-			state.Index += take;
-			if (state.Index >= state.Lines.Length)
-			{
-				break;
-			}
-
-			var key = await ReadPromptAsync(output, keyReader, cancellationToken).ConfigureAwait(false);
-			if (ApplyWindowKey(state, key, windowStart))
-			{
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	private static bool ApplyWindowKey(PagerState state, ConsoleKeyInfo key, int windowStart)
-	{
-		switch (key.Key)
-		{
-			case ConsoleKey.Q:
-			case ConsoleKey.Escape:
-				return true;
-			case ConsoleKey.Enter:
-			case ConsoleKey.DownArrow:
-				state.NextWindow = 1;
-				return false;
-			case ConsoleKey.UpArrow:
-				state.Index = Math.Max(0, windowStart - 1);
-				state.NextWindow = 1;
-				return false;
-			case ConsoleKey.PageUp:
-				state.Index = Math.Max(0, windowStart - state.PageSize);
-				state.NextWindow = state.PageSize;
-				return false;
-			default:
-				state.NextWindow = state.PageSize;
-				return false;
-		}
-	}
-
-	private static bool ApplyBoundaryKey(PagerState state, ConsoleKeyInfo key)
-	{
-		switch (key.Key)
-		{
-			case ConsoleKey.Q:
-			case ConsoleKey.Escape:
-				return true;
-			case ConsoleKey.Enter:
-			case ConsoleKey.DownArrow:
-				state.NextWindow = 1;
-				return false;
-			case ConsoleKey.UpArrow:
-				state.Index = Math.Max(0, state.Lines.Length - state.PageSize);
-				state.NextWindow = state.PageSize;
-				return false;
-			case ConsoleKey.PageUp:
-				state.Index = Math.Max(0, state.Lines.Length - state.PageSize);
-				state.NextWindow = state.PageSize;
-				return false;
-			default:
-				state.NextWindow = state.PageSize;
-				return false;
-		}
-	}
-
-	private static async ValueTask<ConsoleKeyInfo> ReadPromptAsync(
-		TextWriter output,
-		IReplKeyReader keyReader,
-		CancellationToken cancellationToken)
-	{
-		await output.WriteAsync(MorePrompt).ConfigureAwait(false);
-		await output.FlushAsync(cancellationToken).ConfigureAwait(false);
-		var key = await keyReader.ReadKeyAsync(cancellationToken).ConfigureAwait(false);
-		await output.WriteLineAsync().ConfigureAwait(false);
-		return key;
-	}
-
-	private static async ValueTask EnsureScrollBufferAsync(
-		ScrollPagerState state,
+	private static async ValueTask EnsureViewportContentAsync(
+		PagerSession session,
 		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
 		CancellationToken cancellationToken)
 	{
-		while (state.Buffer.Count == 0 && state.HasMorePayload && fetchNextPayload is not null)
+		while (session.Lines.Count == 0 && session.HasMorePayload && fetchNextPayload is not null)
 		{
-			await FetchIntoScrollBufferAsync(state, fetchNextPayload, cancellationToken).ConfigureAwait(false);
+			await FetchIntoSessionAsync(session, fetchNextPayload, cancellationToken).ConfigureAwait(false);
 		}
 	}
 
-	private static async ValueTask FetchIntoScrollBufferAsync(
-		ScrollPagerState state,
+	private static async ValueTask FetchIntoSessionAsync(
+		PagerSession session,
 		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>> fetchNextPayload,
 		CancellationToken cancellationToken)
 	{
 		var nextPayload = await fetchNextPayload(cancellationToken).ConfigureAwait(false);
 		if (nextPayload is null)
 		{
-			state.HasMorePayload = false;
+			session.HasMorePayload = false;
 			return;
 		}
 
-		state.Append(SplitLines(nextPayload.Payload), nextPayload.HasMore);
+		session.Append(nextPayload.Payload, nextPayload.HasMore);
 	}
 
-	private static async ValueTask RenderScrollAsync(
-		ScrollPagerState state,
-		TextWriter output,
-		CancellationToken cancellationToken)
+	private static async ValueTask ClearViewportAsync(TextWriter output, ViewportState state, bool useAlternateScreen)
 	{
-		await output.WriteAsync(CursorHome).ConfigureAwait(false);
-		if (state.StickyHeader is { } header)
+		if (useAlternateScreen)
 		{
-			await WriteViewportLineAsync(state, output, row: 0, header).ConfigureAwait(false);
+			await output.WriteAsync(CursorHome).ConfigureAwait(false);
+		}
+		else if (state.RenderedHeight > 0)
+		{
+			await output.WriteAsync($"\u001b[{state.RenderedHeight}A").ConfigureAwait(false);
+			await output.WriteAsync('\r').ConfigureAwait(false);
 		}
 
-		var row = state.StickyHeader is null ? 0 : 1;
-		var take = Math.Min(state.ViewportHeight, Math.Max(0, state.Buffer.Count - state.TopLine));
+		await output.WriteAsync(ClearToEndOfScreen).ConfigureAwait(false);
+		state.ResetRenderedLineLengths();
+	}
+
+	private static async ValueTask RenderViewportFrameAsync(
+		ViewportState state,
+		TextWriter output,
+		bool useAlternateScreen,
+		CancellationToken cancellationToken)
+	{
+		await PositionViewportAsync(output, state, useAlternateScreen).ConfigureAwait(false);
+		var row = 0;
+		foreach (var headerLine in state.Session.HeaderLines)
+		{
+			await WriteViewportLineAsync(state, output, row++, headerLine).ConfigureAwait(false);
+		}
+
+		var take = Math.Min(state.ViewportHeight, Math.Max(0, state.Session.Lines.Count - state.TopLine));
 		for (var i = 0; i < take; i++)
 		{
-			await WriteViewportLineAsync(state, output, row++, state.Buffer[state.TopLine + i]).ConfigureAwait(false);
+			await WriteViewportLineAsync(state, output, row++, state.Session.Lines[state.TopLine + i]).ConfigureAwait(false);
 		}
 
 		for (var i = take; i < state.ViewportHeight; i++)
@@ -441,18 +522,38 @@ internal static class ResultFlowPager
 			await WriteViewportLineAsync(state, output, row++, string.Empty).ConfigureAwait(false);
 		}
 
-		var lastLine = state.Buffer.Count == 0
+		var lastLine = state.Session.Lines.Count == 0
 			? 0
-			: Math.Min(state.Buffer.Count, state.TopLine + state.ViewportHeight);
-		var status = state.Buffer.Count == 0
+			: Math.Min(state.Session.Lines.Count, state.TopLine + state.ViewportHeight);
+		var status = state.Session.Lines.Count == 0
 			? "-- result-flow: loading --"
-			: $"-- result-flow {state.TopLine + 1}-{lastLine}/{state.Buffer.Count}{(state.HasMorePayload ? "+" : string.Empty)}  Space: next  Up/Down: scroll  q: quit --";
-		await WriteViewportLineAsync(state, output, row, status, appendNewLine: false).ConfigureAwait(false);
+			: string.Format(
+				System.Globalization.CultureInfo.InvariantCulture,
+				FullStatusFormat,
+				state.TopLine + 1,
+				lastLine,
+				state.Session.Lines.Count,
+				state.Session.HasMorePayload ? "+" : string.Empty);
+		await WriteViewportLineAsync(state, output, row++, status, appendNewLine: false).ConfigureAwait(false);
+		state.RenderedHeight = row;
 		await output.FlushAsync(cancellationToken).ConfigureAwait(false);
 	}
 
+	private static async ValueTask PositionViewportAsync(TextWriter output, ViewportState state, bool useAlternateScreen)
+	{
+		if (useAlternateScreen)
+		{
+			await output.WriteAsync(CursorHome).ConfigureAwait(false);
+		}
+		else if (state.RenderedHeight > 0)
+		{
+			await output.WriteAsync($"\u001b[{state.RenderedHeight}A").ConfigureAwait(false);
+			await output.WriteAsync('\r').ConfigureAwait(false);
+		}
+	}
+
 	private static async ValueTask WriteViewportLineAsync(
-		ScrollPagerState state,
+		ViewportState state,
 		TextWriter output,
 		int row,
 		string line,
@@ -472,53 +573,53 @@ internal static class ResultFlowPager
 		}
 	}
 
-	private static ScrollKeyAction ApplyScrollKey(ScrollPagerState state, ConsoleKeyInfo key)
+	private static PagerAction ApplyViewportKey(ViewportState state, ConsoleKeyInfo key)
 	{
 		switch (key.Key)
 		{
 			case ConsoleKey.Q:
 			case ConsoleKey.Escape:
-				return ScrollKeyAction.Quit;
+				return PagerAction.Quit;
 			case ConsoleKey.Spacebar:
 			case ConsoleKey.PageDown:
 			case ConsoleKey.F:
 				state.TopLine = Math.Min(state.TopLine + state.ViewportHeight, state.MaxTopLine);
-				return ScrollKeyAction.PageDown;
+				return PagerAction.PageDown;
 			case ConsoleKey.Enter:
 			case ConsoleKey.DownArrow:
 			case ConsoleKey.J:
 				state.TopLine = Math.Min(state.TopLine + 1, state.MaxTopLine);
-				return ScrollKeyAction.LineDown;
+				return PagerAction.LineDown;
 			case ConsoleKey.UpArrow:
 			case ConsoleKey.K:
 				state.TopLine = Math.Max(0, state.TopLine - 1);
-				return ScrollKeyAction.Other;
+				return PagerAction.LineUp;
 			case ConsoleKey.PageUp:
 			case ConsoleKey.B:
 				state.TopLine = Math.Max(0, state.TopLine - state.ViewportHeight);
-				return ScrollKeyAction.Other;
+				return PagerAction.PageUp;
 			case ConsoleKey.Home:
 			case ConsoleKey.G when key.Modifiers.HasFlag(ConsoleModifiers.Shift):
 				state.TopLine = 0;
-				return ScrollKeyAction.Other;
+				return PagerAction.Home;
 			case ConsoleKey.End:
 				state.TopLine = state.MaxTopLine;
-				return ScrollKeyAction.Other;
+				return PagerAction.End;
 			default:
-				return ScrollKeyAction.Other;
+				return PagerAction.None;
 		}
 	}
 
-	private static bool ShouldFetchForScrollKey(ScrollPagerState state, ScrollKeyAction action, int beforeTopLine) =>
+	private static bool ShouldFetchForViewportKey(ViewportState state, PagerAction action, int beforeTopLine) =>
 		action switch
 		{
-			ScrollKeyAction.PageDown => state.HasReachedBottom && state.Buffer.Count > state.ViewportHeight,
-			ScrollKeyAction.LineDown => beforeTopLine == state.TopLine && state.HasReachedBottom,
+			PagerAction.PageDown => state.HasReachedBottom && state.Session.Lines.Count > state.ViewportHeight,
+			PagerAction.LineDown => beforeTopLine == state.TopLine && state.HasReachedBottom,
 			_ => false,
 		};
 
-	private static int GetScrollDelta(ScrollKeyAction action, int viewportHeight) =>
-		action == ScrollKeyAction.PageDown ? viewportHeight : 1;
+	private static int GetViewportDelta(PagerAction action, int viewportHeight) =>
+		action == PagerAction.PageDown ? viewportHeight : 1;
 
 	private static int GetCurrentVisibleRows(int fallbackVisibleRows, Func<int>? visibleRowsProvider)
 	{
@@ -549,78 +650,66 @@ internal static class ResultFlowPager
 		}
 	}
 
-	private static bool ShouldUseScrollPager(ReplPagerMode pagerMode, bool ansiEnabled) =>
-		ansiEnabled && pagerMode is ReplPagerMode.Auto or ReplPagerMode.Scroll;
-
-	private static string[] SplitLines(string payload) =>
-		string.IsNullOrEmpty(payload)
-			? []
-			: SplitNonEmptyPayloadLines(payload);
-
-	private static string[] SplitNonEmptyPayloadLines(string payload)
+	private enum PagerAction
 	{
-		var lines = new List<string>();
-		foreach (var line in payload.AsSpan().EnumerateLines())
-		{
-			lines.Add(line.ToString());
-		}
-
-		// EnumerateLines adds a trailing empty entry when the payload ends with a newline;
-		// strip it to stay consistent with how the pager counts visible lines.
-		if (lines.Count > 0 && lines[^1].Length == 0)
-		{
-			lines.RemoveAt(lines.Count - 1);
-		}
-
-		return [.. lines];
-	}
-
-	private sealed class PagerState(string[] lines, int pageSize, bool hasMorePayload)
-	{
-		private string[] _lines = lines;
-
-		public string[] Lines => _lines;
-
-		public int PageSize { get; } = pageSize;
-
-		public int NextWindow { get; set; } = pageSize;
-
-		public int Index { get; set; }
-
-		public bool HasMorePayload { get; private set; } = hasMorePayload;
-
-		public void Reset(string[] lines, bool hasMorePayload)
-		{
-			_lines = lines;
-			Index = 0;
-			HasMorePayload = hasMorePayload;
-		}
-	}
-
-	private enum ScrollKeyAction
-	{
-		Other,
+		None,
 		LineDown,
+		LineUp,
 		PageDown,
+		PageUp,
+		Home,
+		End,
 		Quit,
 	}
 
-	private sealed class ScrollPagerState
+	private sealed class PagerSession
 	{
-		public ScrollPagerState(string[] lines, int visibleRows, bool hasMorePayload)
+		private readonly PagerHeader _header;
+
+		public PagerSession(string initialPayload, bool hasMorePayload)
 		{
-			StickyHeader = TryGetStickyHeader(lines);
-			Buffer = [.. GetContentLines(lines, StickyHeader)];
-			VisibleRows = Math.Max(2, visibleRows);
-			ViewportHeight = CalculateViewportHeight(VisibleRows, StickyHeader);
+			var parsed = PagerPayloadParser.Parse(initialPayload, header: null);
+			_header = parsed.Header;
+			Lines = [.. parsed.ContentLines];
 			HasMorePayload = hasMorePayload;
+			PageSize = 1;
+			NextWindow = 1;
 		}
 
-		public List<string> Buffer { get; }
+		public IReadOnlyList<string> HeaderLines => _header.Lines;
 
-		private List<int> RenderedLineLengths { get; } = [];
+		public List<string> Lines { get; }
 
-		public string? StickyHeader { get; }
+		public int PageSize { get; set; }
+
+		public int NextWindow { get; set; }
+
+		public int Index { get; set; }
+
+		public bool HasMorePayload { get; set; }
+
+		public void Append(string payload, bool hasMorePayload)
+		{
+			var parsed = PagerPayloadParser.Parse(payload, _header);
+			Lines.AddRange(parsed.ContentLines);
+			HasMorePayload = hasMorePayload;
+		}
+	}
+
+	private sealed class ViewportState
+	{
+		private readonly List<int> _renderedLineLengths = [];
+
+		public ViewportState(PagerSession session, int visibleRows)
+		{
+			Session = session;
+			Session.PageSize = Math.Max(1, CalculateViewportHeight(visibleRows));
+			Session.NextWindow = Session.PageSize;
+			VisibleRows = Math.Max(2, visibleRows);
+			ViewportHeight = CalculateViewportHeight(VisibleRows);
+		}
+
+		public PagerSession Session { get; }
 
 		public int VisibleRows { get; private set; }
 
@@ -628,17 +717,11 @@ internal static class ResultFlowPager
 
 		public int TopLine { get; set; }
 
-		public bool HasMorePayload { get; set; }
+		public int RenderedHeight { get; set; }
 
-		public int MaxTopLine => Math.Max(0, Buffer.Count - ViewportHeight);
+		public int MaxTopLine => Math.Max(0, Session.Lines.Count - ViewportHeight);
 
 		public bool HasReachedBottom => TopLine >= MaxTopLine;
-
-		public void Append(string[] lines, bool hasMorePayload)
-		{
-			Buffer.AddRange(GetContentLines(lines, StickyHeader));
-			HasMorePayload = hasMorePayload;
-		}
 
 		public bool UpdateVisibleRows(int visibleRows)
 		{
@@ -649,53 +732,92 @@ internal static class ResultFlowPager
 			}
 
 			VisibleRows = visibleRows;
-			ViewportHeight = CalculateViewportHeight(visibleRows, StickyHeader);
+			ViewportHeight = CalculateViewportHeight(visibleRows);
 			TopLine = Math.Min(TopLine, MaxTopLine);
+			Session.PageSize = ViewportHeight;
 			return true;
 		}
 
 		public int GetRenderedLineLength(int row) =>
-			row < RenderedLineLengths.Count ? RenderedLineLengths[row] : 0;
+			row < _renderedLineLengths.Count ? _renderedLineLengths[row] : 0;
 
 		public void SetRenderedLineLength(int row, int length)
 		{
-			while (RenderedLineLengths.Count <= row)
+			while (_renderedLineLengths.Count <= row)
 			{
-				RenderedLineLengths.Add(0);
+				_renderedLineLengths.Add(0);
 			}
 
-			RenderedLineLengths[row] = length;
+			_renderedLineLengths[row] = length;
 		}
 
-		public void ResetRenderedLineLengths() => RenderedLineLengths.Clear();
+		public void ResetRenderedLineLengths() => _renderedLineLengths.Clear();
 
-		private static string? TryGetStickyHeader(string[] lines) =>
-			lines.Length > 1 && lines[0].Contains("\u001b[1m", StringComparison.Ordinal)
-				? lines[0]
-				: null;
+		private int CalculateViewportHeight(int visibleRows) =>
+			Math.Max(1, visibleRows - Session.HeaderLines.Count - 1);
+	}
 
-		private static IEnumerable<string> GetContentLines(string[] lines, string? stickyHeader)
+	private sealed record PagerHeader(IReadOnlyList<string> Lines, IReadOnlySet<string> NormalizedLines)
+	{
+		public static PagerHeader Empty { get; } = new([], new HashSet<string>(StringComparer.Ordinal));
+	}
+
+	private sealed record ParsedPagerPayload(PagerHeader Header, IReadOnlyList<string> ContentLines)
+	{
+		public int TotalLineCount => Header.Lines.Count + ContentLines.Count;
+	}
+
+	private static class PagerPayloadParser
+	{
+		public static ParsedPagerPayload Parse(string payload, PagerHeader? header)
 		{
-			var start = stickyHeader is not null
-				&& lines.Length > 0
-				&& AreSameHeaderLine(lines[0], stickyHeader)
-					? 1
-					: 0;
-			for (var i = start; i < lines.Length; i++)
+			var lines = SplitLines(payload);
+			var resolvedHeader = header ?? DetectHeader(lines);
+			var content = new List<string>();
+			var headerLineCount = header is null ? resolvedHeader.Lines.Count : 0;
+			for (var i = headerLineCount; i < lines.Length; i++)
 			{
-				if ((stickyHeader is null || !AreSameHeaderLine(lines[i], stickyHeader))
-					&& !IsPageFooterLine(lines[i]))
+				var normalized = NormalizeLine(lines[i]);
+				if (resolvedHeader.NormalizedLines.Contains(normalized) || IsPageFooterLine(lines[i]))
 				{
-					yield return lines[i];
+					continue;
 				}
+
+				content.Add(lines[i]);
 			}
+
+			return new ParsedPagerPayload(resolvedHeader, content);
 		}
 
-		private static int CalculateViewportHeight(int visibleRows, string? stickyHeader) =>
-			Math.Max(1, visibleRows - (stickyHeader is null ? 1 : 2));
+		private static PagerHeader DetectHeader(string[] lines)
+		{
+			if (lines.Length == 0)
+			{
+				return PagerHeader.Empty;
+			}
 
-		private static bool AreSameHeaderLine(string candidate, string stickyHeader) =>
-			string.Equals(NormalizeAnsiLine(candidate), NormalizeAnsiLine(stickyHeader), StringComparison.Ordinal);
+			if (lines.Length > 1 && IsPlainTableSeparator(lines[1]))
+			{
+				return CreateHeader(lines.Take(2).ToArray());
+			}
+
+			return lines[0].Contains("\u001b[1m", StringComparison.Ordinal)
+				? CreateHeader([lines[0]])
+				: PagerHeader.Empty;
+		}
+
+		private static PagerHeader CreateHeader(string[] lines) =>
+			new(
+				lines,
+				lines.Select(NormalizeLine).ToHashSet(StringComparer.Ordinal));
+
+		private static bool IsPlainTableSeparator(string line)
+		{
+			var text = line.Trim();
+			return text.Length > 0
+				&& text.All(ch => ch is '-' or ' ' or '\t')
+				&& text.Contains('-', StringComparison.Ordinal);
+		}
 
 		private static bool IsPageFooterLine(string line) =>
 			line.StartsWith("Showing ", StringComparison.Ordinal)
@@ -704,7 +826,28 @@ internal static class ResultFlowPager
 			&& (line.EndsWith('.')
 				|| line.Contains("Next data page: rerun with --result:cursor ", StringComparison.Ordinal));
 
-		private static string NormalizeAnsiLine(string line)
+		private static string[] SplitLines(string payload)
+		{
+			if (string.IsNullOrEmpty(payload))
+			{
+				return [];
+			}
+
+			var lines = new List<string>();
+			foreach (var line in payload.AsSpan().EnumerateLines())
+			{
+				lines.Add(line.ToString());
+			}
+
+			if (lines.Count > 0 && lines[^1].Length == 0)
+			{
+				lines.RemoveAt(lines.Count - 1);
+			}
+
+			return [.. lines];
+		}
+
+		private static string NormalizeLine(string line)
 		{
 			if (!line.Contains('\u001b', StringComparison.Ordinal))
 			{

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -161,6 +161,30 @@ internal static class ResultFlowPager
 		}
 
 		var session = new PagerSession(payload, hasMorePayload);
+		await RenderBuiltInAsync(
+				mode,
+				session,
+				output,
+				keyReader,
+				visibleRows,
+				visibleRowsProvider,
+				ansiEnabled,
+				fetchNextPayload,
+				cancellationToken)
+			.ConfigureAwait(false);
+	}
+
+	private static async ValueTask RenderBuiltInAsync(
+		ReplPagerMode mode,
+		PagerSession session,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		Func<int>? visibleRowsProvider,
+		bool ansiEnabled,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		CancellationToken cancellationToken)
+	{
 		switch (mode)
 		{
 			case ReplPagerMode.Full:
@@ -193,6 +217,7 @@ internal static class ResultFlowPager
 						output,
 						keyReader,
 						Math.Max(1, visibleRows),
+						ansiEnabled,
 						fetchNextPayload,
 						cancellationToken)
 					.ConfigureAwait(false);
@@ -259,6 +284,7 @@ internal static class ResultFlowPager
 		TextWriter output,
 		IReplKeyReader keyReader,
 		int visibleRows,
+		bool useTransientPrompt,
 		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
 		CancellationToken cancellationToken)
 	{
@@ -291,7 +317,7 @@ internal static class ResultFlowPager
 					break;
 				}
 
-				if (await ReadMoreActionAsync(session, output, keyReader, cancellationToken).ConfigureAwait(false) == PagerAction.Quit)
+				if (await ReadMoreActionAsync(session, output, keyReader, useTransientPrompt, cancellationToken).ConfigureAwait(false) == PagerAction.Quit)
 				{
 					return;
 				}
@@ -302,7 +328,7 @@ internal static class ResultFlowPager
 				return;
 			}
 
-			if (await ReadMoreActionAsync(session, output, keyReader, cancellationToken).ConfigureAwait(false) == PagerAction.Quit)
+			if (await ReadMoreActionAsync(session, output, keyReader, useTransientPrompt, cancellationToken).ConfigureAwait(false) == PagerAction.Quit)
 			{
 				return;
 			}
@@ -350,6 +376,7 @@ internal static class ResultFlowPager
 		PagerSession session,
 		TextWriter output,
 		IReplKeyReader keyReader,
+		bool useTransientPrompt,
 		CancellationToken cancellationToken)
 	{
 		await output.WriteAsync(MorePrompt).ConfigureAwait(false);
@@ -362,11 +389,11 @@ internal static class ResultFlowPager
 			{
 				case ConsoleKey.Q:
 				case ConsoleKey.Escape:
-					await output.WriteLineAsync().ConfigureAwait(false);
+					await FinishMorePromptAsync(output, useTransientPrompt).ConfigureAwait(false);
 					return PagerAction.Quit;
 				case ConsoleKey.Enter:
 				case ConsoleKey.DownArrow:
-					await output.WriteLineAsync().ConfigureAwait(false);
+					await FinishMorePromptAsync(output, useTransientPrompt).ConfigureAwait(false);
 					session.NextWindow = 1;
 					return PagerAction.LineDown;
 				case ConsoleKey.UpArrow:
@@ -375,11 +402,24 @@ internal static class ResultFlowPager
 				case ConsoleKey.End:
 					continue;
 				default:
-					await output.WriteLineAsync().ConfigureAwait(false);
+					await FinishMorePromptAsync(output, useTransientPrompt).ConfigureAwait(false);
 					session.NextWindow = session.PageSize;
 					return PagerAction.PageDown;
 			}
 		}
+	}
+
+	private static async ValueTask FinishMorePromptAsync(TextWriter output, bool useTransientPrompt)
+	{
+		if (!useTransientPrompt)
+		{
+			await output.WriteLineAsync().ConfigureAwait(false);
+			return;
+		}
+
+		await output.WriteAsync('\r').ConfigureAwait(false);
+		await output.WriteAsync(new string(' ', MorePrompt.Length)).ConfigureAwait(false);
+		await output.WriteAsync('\r').ConfigureAwait(false);
 	}
 
 	private static async ValueTask RenderViewportAsync(

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -360,20 +360,21 @@ internal static class ResultFlowPager
 		IReplKeyReader keyReader,
 		CancellationToken cancellationToken)
 	{
+		await output.WriteAsync(MorePrompt).ConfigureAwait(false);
+		await output.FlushAsync(cancellationToken).ConfigureAwait(false);
 		while (true)
 		{
-			await output.WriteAsync(MorePrompt).ConfigureAwait(false);
-			await output.FlushAsync(cancellationToken).ConfigureAwait(false);
 			var key = await keyReader.ReadKeyAsync(cancellationToken).ConfigureAwait(false);
-			await output.WriteLineAsync().ConfigureAwait(false);
 
 			switch (key.Key)
 			{
 				case ConsoleKey.Q:
 				case ConsoleKey.Escape:
+					await output.WriteLineAsync().ConfigureAwait(false);
 					return PagerAction.Quit;
 				case ConsoleKey.Enter:
 				case ConsoleKey.DownArrow:
+					await output.WriteLineAsync().ConfigureAwait(false);
 					session.NextWindow = 1;
 					return PagerAction.LineDown;
 				case ConsoleKey.UpArrow:
@@ -382,6 +383,7 @@ internal static class ResultFlowPager
 				case ConsoleKey.End:
 					continue;
 				default:
+					await output.WriteLineAsync().ConfigureAwait(false);
 					session.NextWindow = session.PageSize;
 					return PagerAction.PageDown;
 			}
@@ -801,6 +803,11 @@ internal static class ResultFlowPager
 				return CreateHeader(lines.Take(2).ToArray());
 			}
 
+			if (IsPlainHumanTableHeader(lines[0]))
+			{
+				return CreateHeader([lines[0]]);
+			}
+
 			return lines[0].Contains("\u001b[1m", StringComparison.Ordinal)
 				? CreateHeader([lines[0]])
 				: PagerHeader.Empty;
@@ -817,6 +824,13 @@ internal static class ResultFlowPager
 			return text.Length > 0
 				&& text.All(ch => ch is '-' or ' ' or '\t')
 				&& text.Contains('-', StringComparison.Ordinal);
+		}
+
+		private static bool IsPlainHumanTableHeader(string line)
+		{
+			var text = line.TrimStart();
+			return text.StartsWith("# ", StringComparison.Ordinal)
+				&& text.Contains("  ", StringComparison.Ordinal);
 		}
 
 		private static bool IsPageFooterLine(string line) =>

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -572,7 +572,7 @@ internal static class ResultFlowPager
 	private static bool ShouldFetchForViewportKey(ViewportState state, PagerAction action, int beforeTopLine) =>
 		action switch
 		{
-			PagerAction.PageDown => state.HasReachedBottom && state.Session.Lines.Count >= state.ViewportHeight,
+			PagerAction.PageDown => state.HasReachedBottom,
 			PagerAction.LineDown => beforeTopLine == state.TopLine && state.HasReachedBottom,
 			_ => false,
 		};

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -6,9 +6,9 @@ internal static class ResultFlowPager
 	private const string SourceReturnedNoDataStatus = "-- paging stopped: source returned no data --";
 	private const string FullStatus = "-- result-flow {0}-{1}/{2}{3}  Space: next  Up/Down: scroll  Home/End: known bounds  q: quit --";
 	private const string FullStatusBufferLimit = "-- result-flow {0}-{1}/{2} buffer limit reached  Up/Down: scroll  q: quit --";
-	private const int DefaultMaxBufferedLines = 10_000;
+	private const int SpacePaddingLength = 256;
 	private static readonly string MorePromptClear = new(' ', MorePrompt.Length);
-	private static readonly string SpacePadding = new(' ', 256);
+	private static readonly string SpacePadding = new(' ', SpacePaddingLength);
 	private static readonly System.Text.CompositeFormat FullStatusFormat =
 		System.Text.CompositeFormat.Parse(FullStatus);
 	private static readonly System.Text.CompositeFormat FullStatusBufferLimitFormat =
@@ -26,182 +26,50 @@ internal static class ResultFlowPager
 			payload,
 			output,
 			keyReader,
-			visibleRows,
-			hasMorePayload: false,
-			fetchNextPayload: null,
+			new ResultFlowPagerOptions { VisibleRows = visibleRows },
 			cancellationToken);
 
 	internal static async ValueTask WriteAsync(
 		string payload,
 		TextWriter output,
 		IReplKeyReader keyReader,
-		int visibleRows,
-		ReplPagerMode pagerMode,
-		bool ansiEnabled,
-		CancellationToken cancellationToken = default)
-	{
-		await WriteAsync(
-				payload,
-				output,
-				keyReader,
-				visibleRows,
-				pagerMode,
-				ansiEnabled,
-				hasMorePayload: false,
-				fetchNextPayload: null,
-				cancellationToken)
-			.ConfigureAwait(false);
-	}
-
-	internal static async ValueTask WriteAsync(
-		string payload,
-		TextWriter output,
-		IReplKeyReader keyReader,
-		int visibleRows,
-		bool hasMorePayload,
-		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
-		CancellationToken cancellationToken = default)
-	{
-		await WriteAsync(
-				payload,
-				output,
-				keyReader,
-				visibleRows,
-				visibleRowsProvider: null,
-				ReplPagerMode.More,
-				ansiEnabled: false,
-				hasMorePayload,
-				fetchNextPayload,
-				pagerRenderers: null,
-				cancellationToken)
-			.ConfigureAwait(false);
-	}
-
-	internal static async ValueTask WriteAsync(
-		string payload,
-		TextWriter output,
-		IReplKeyReader keyReader,
-		int visibleRows,
-		ReplPagerMode pagerMode,
-		bool ansiEnabled,
-		bool hasMorePayload,
-		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
-		CancellationToken cancellationToken = default)
-	{
-		await WriteAsync(
-				payload,
-				output,
-				keyReader,
-				visibleRows,
-				visibleRowsProvider: null,
-				pagerMode,
-				ansiEnabled,
-				hasMorePayload,
-				fetchNextPayload,
-				pagerRenderers: null,
-				cancellationToken)
-			.ConfigureAwait(false);
-	}
-
-	internal static async ValueTask WriteAsync(
-		string payload,
-		TextWriter output,
-		IReplKeyReader keyReader,
-		int visibleRows,
-		Func<int> visibleRowsProvider,
-		ReplPagerMode pagerMode,
-		bool ansiEnabled,
-		bool hasMorePayload,
-		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
-		CancellationToken cancellationToken = default)
-	{
-		await WriteAsync(
-				payload,
-				output,
-				keyReader,
-				visibleRows,
-				visibleRowsProvider,
-				pagerMode,
-				ansiEnabled,
-				hasMorePayload,
-				fetchNextPayload,
-				pagerRenderers: null,
-				cancellationToken)
-			.ConfigureAwait(false);
-	}
-
-	internal static ValueTask WriteAsync(
-		string payload,
-		TextWriter output,
-		IReplKeyReader keyReader,
-		int visibleRows,
-		Func<int>? visibleRowsProvider,
-		ReplPagerMode pagerMode,
-		bool ansiEnabled,
-		bool hasMorePayload,
-		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
-		IEnumerable<IReplPagerRenderer>? pagerRenderers,
-		CancellationToken cancellationToken = default)
-		=> WriteAsync(
-			payload,
-			output,
-			keyReader,
-			visibleRows,
-			visibleRowsProvider,
-			pagerMode,
-			ansiEnabled,
-			hasMorePayload,
-			fetchNextPayload,
-			pagerRenderers,
-			DefaultMaxBufferedLines,
-			cancellationToken);
-
-	internal static async ValueTask WriteAsync(
-		string payload,
-		TextWriter output,
-		IReplKeyReader keyReader,
-		int visibleRows,
-		Func<int>? visibleRowsProvider,
-		ReplPagerMode pagerMode,
-		bool ansiEnabled,
-		bool hasMorePayload,
-		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
-		IEnumerable<IReplPagerRenderer>? pagerRenderers,
-		int maxBufferedLines,
+		ResultFlowPagerOptions options,
 		CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(output);
 		ArgumentNullException.ThrowIfNull(keyReader);
-		maxBufferedLines = Math.Max(1, maxBufferedLines);
+		ArgumentNullException.ThrowIfNull(options);
+		var visibleRows = options.VisibleRows;
+		var maxBufferedLines = Math.Max(1, options.MaxBufferedLines);
 
-		var mode = ResolveMode(pagerMode, ansiEnabled);
+		var mode = ResolveMode(options.PagerMode, options.AnsiEnabled);
 		if (await TryRenderCustomAsync(
 				mode,
-				pagerRenderers,
+				options.PagerRenderers,
 				payload,
 				output,
 				keyReader,
 				visibleRows,
-				visibleRowsProvider,
-				ansiEnabled,
-				hasMorePayload,
-				fetchNextPayload,
+				options.VisibleRowsProvider,
+				options.AnsiEnabled,
+				options.HasMorePayload,
+				options.FetchNextPayload,
 				cancellationToken)
 			.ConfigureAwait(false))
 		{
 			return;
 		}
 
-		var session = new PagerSession(payload, hasMorePayload, maxBufferedLines);
+		var session = new PagerSession(payload, options.HasMorePayload, maxBufferedLines);
 		await RenderBuiltInAsync(
 				mode,
 				session,
 				output,
 				keyReader,
 				visibleRows,
-				visibleRowsProvider,
-				ansiEnabled,
-				fetchNextPayload,
+				options.VisibleRowsProvider,
+				options.AnsiEnabled,
+				options.FetchNextPayload,
 				cancellationToken)
 			.ConfigureAwait(false);
 	}
@@ -650,7 +518,7 @@ internal static class ResultFlowPager
 		bool appendNewLine = true)
 	{
 		await output.WriteAsync(line).ConfigureAwait(false);
-		var visualLength = GetVisualLength(line);
+		var visualLength = Repl.Terminal.AnsiTextMetrics.GetVisualLength(line);
 		var previousLength = state.GetRenderedLineLength(row);
 		if (previousLength > visualLength)
 		{
@@ -725,34 +593,6 @@ internal static class ResultFlowPager
 			await output.WriteAsync(SpacePadding.AsMemory(0, take)).ConfigureAwait(false);
 			count -= take;
 		}
-	}
-
-	private static int GetVisualLength(string line)
-	{
-		var length = 0;
-		for (var i = 0; i < line.Length; i++)
-		{
-			if (line[i] == '\u001b')
-			{
-				if (i + 1 < line.Length && line[i + 1] == '[')
-				{
-					i += 2;
-					while (i < line.Length && (line[i] < '@' || line[i] > '~'))
-					{
-						i++;
-					}
-				}
-
-				continue;
-			}
-
-			if (!char.IsControl(line[i]))
-			{
-				length++;
-			}
-		}
-
-		return length;
 	}
 
 	private static int GetCurrentVisibleRows(int fallbackVisibleRows, Func<int>? visibleRowsProvider)

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -311,7 +311,7 @@ internal static class ResultFlowPager
 
 			while (session.Index < session.Lines.Count)
 			{
-				await WriteMoreWindowAsync(session, output).ConfigureAwait(false);
+				await WriteMoreWindowAsync(session, output, fetchNextPayload, cancellationToken).ConfigureAwait(false);
 				if (session.Index >= session.Lines.Count)
 				{
 					break;
@@ -340,15 +340,27 @@ internal static class ResultFlowPager
 		}
 	}
 
-	private static async ValueTask WriteMoreWindowAsync(PagerSession session, TextWriter output)
+	private static async ValueTask WriteMoreWindowAsync(
+		PagerSession session,
+		TextWriter output,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		CancellationToken cancellationToken)
 	{
-		var take = Math.Min(session.NextWindow, session.Lines.Count - session.Index);
-		for (var i = 0; i < take; i++)
+		var written = 0;
+		while (written < session.NextWindow)
 		{
-			await output.WriteLineAsync(session.Lines[session.Index + i]).ConfigureAwait(false);
-		}
+			if (session.Index >= session.Lines.Count)
+			{
+				if (!await TryFetchIntoSessionAsync(session, fetchNextPayload, cancellationToken).ConfigureAwait(false))
+				{
+					break;
+				}
+			}
 
-		session.Index += take;
+			await output.WriteLineAsync(session.Lines[session.Index]).ConfigureAwait(false);
+			session.Index++;
+			written++;
+		}
 	}
 
 	private static async ValueTask<bool> TryFetchIntoSessionAsync(

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -95,6 +95,7 @@ internal static class ResultFlowPager
 					output,
 					keyReader,
 					visibleRows,
+					ansiEnabled,
 					hasMorePayload,
 					fetchNextPayload,
 					cancellationToken)
@@ -178,10 +179,16 @@ internal static class ResultFlowPager
 		TextWriter output,
 		IReplKeyReader keyReader,
 		int visibleRows,
+		bool ansiEnabled,
 		bool hasMorePayload,
 		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
 		CancellationToken cancellationToken)
 	{
+		if (!ansiEnabled)
+		{
+			throw new InvalidOperationException("The scroll result pager requires ANSI support.");
+		}
+
 		var state = new ScrollPagerState(SplitLines(payload), Math.Max(2, visibleRows), hasMorePayload);
 		if (state.Buffer.Count == 0 && !state.HasMorePayload)
 		{
@@ -404,10 +411,32 @@ internal static class ResultFlowPager
 	private static string[] SplitLines(string payload) =>
 		string.IsNullOrEmpty(payload)
 			? []
-			: payload
-				.Replace("\r\n", "\n", StringComparison.Ordinal)
-				.Replace('\r', '\n')
-				.Split('\n');
+			: SplitNonEmptyPayloadLines(payload);
+
+	private static string[] SplitNonEmptyPayloadLines(string payload)
+	{
+		var lines = new List<string>();
+		var start = 0;
+		for (var index = 0; index < payload.Length; index++)
+		{
+			var current = payload[index];
+			if (current is not '\r' and not '\n')
+			{
+				continue;
+			}
+
+			lines.Add(payload[start..index]);
+			if (current == '\r' && index + 1 < payload.Length && payload[index + 1] == '\n')
+			{
+				index++;
+			}
+
+			start = index + 1;
+		}
+
+		lines.Add(payload[start..]);
+		return [.. lines];
+	}
 
 	private sealed class PagerState(string[] lines, int pageSize, bool hasMorePayload)
 	{

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -209,7 +209,10 @@ internal static class ResultFlowPager
 					return;
 				}
 
-				if (state.TopLine >= state.MaxTopLine && state.HasMorePayload && fetchNextPayload is not null)
+				if (state.HasReachedBottom
+					&& state.Buffer.Count > state.ViewportHeight
+					&& state.HasMorePayload
+					&& fetchNextPayload is not null)
 				{
 					var before = state.Buffer.Count;
 					await FetchIntoScrollBufferAsync(state, fetchNextPayload, cancellationToken).ConfigureAwait(false);
@@ -434,7 +437,11 @@ internal static class ResultFlowPager
 			start = index + 1;
 		}
 
-		lines.Add(payload[start..]);
+		if (start < payload.Length)
+		{
+			lines.Add(payload[start..]);
+		}
+
 		return [.. lines];
 	}
 
@@ -469,6 +476,8 @@ internal static class ResultFlowPager
 		public bool HasMorePayload { get; set; } = hasMorePayload;
 
 		public int MaxTopLine => Math.Max(0, Buffer.Count - ViewportHeight);
+
+		public bool HasReachedBottom => TopLine >= MaxTopLine;
 
 		public void Append(string[] lines, bool hasMorePayload)
 		{

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -774,9 +774,10 @@ internal static class ResultFlowPager
 		public static ParsedPagerPayload Parse(string payload, PagerHeader? header)
 		{
 			var lines = SplitLines(payload);
-			var resolvedHeader = header ?? DetectHeader(lines);
+			var payloadHeader = DetectHeader(lines);
+			var resolvedHeader = header ?? payloadHeader;
+			var headerLineCount = payloadHeader.Lines.Count;
 			var content = new List<string>();
-			var headerLineCount = header is null ? resolvedHeader.Lines.Count : 0;
 			for (var i = headerLineCount; i < lines.Length; i++)
 			{
 				var normalized = NormalizeLine(lines[i]);

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -6,6 +6,8 @@ internal static class ResultFlowPager
 	private const string FullStatus = "-- result-flow {0}-{1}/{2}{3}  Space: next  Up/Down: scroll  Home/End: known bounds  q: quit --";
 	private const string FullStatusBufferLimit = "-- result-flow {0}-{1}/{2} buffer limit reached  Up/Down: scroll  q: quit --";
 	private const int DefaultMaxBufferedLines = 10_000;
+	private static readonly string MorePromptClear = new(' ', MorePrompt.Length);
+	private static readonly string SpacePadding = new(' ', 256);
 	private static readonly System.Text.CompositeFormat FullStatusFormat =
 		System.Text.CompositeFormat.Parse(FullStatus);
 	private static readonly System.Text.CompositeFormat FullStatusBufferLimitFormat =
@@ -459,7 +461,7 @@ internal static class ResultFlowPager
 		}
 
 		await output.WriteAsync('\r').ConfigureAwait(false);
-		await output.WriteAsync(new string(' ', MorePrompt.Length)).ConfigureAwait(false);
+		await output.WriteAsync(MorePromptClear).ConfigureAwait(false);
 		await output.WriteAsync('\r').ConfigureAwait(false);
 	}
 
@@ -640,7 +642,7 @@ internal static class ResultFlowPager
 		var previousLength = state.GetRenderedLineLength(row);
 		if (previousLength > line.Length)
 		{
-			await output.WriteAsync(new string(' ', previousLength - line.Length)).ConfigureAwait(false);
+			await WriteSpacesAsync(output, previousLength - line.Length).ConfigureAwait(false);
 		}
 
 		state.SetRenderedLineLength(row, line.Length);
@@ -698,6 +700,21 @@ internal static class ResultFlowPager
 	private static int GetViewportDelta(PagerAction action, int viewportHeight) =>
 		action == PagerAction.PageDown ? viewportHeight : 1;
 
+	private static async ValueTask WriteSpacesAsync(TextWriter output, int count)
+	{
+		if (count <= 0)
+		{
+			return;
+		}
+
+		while (count > 0)
+		{
+			var take = Math.Min(count, SpacePadding.Length);
+			await output.WriteAsync(SpacePadding.AsMemory(0, take)).ConfigureAwait(false);
+			count -= take;
+		}
+	}
+
 	private static int GetCurrentVisibleRows(int fallbackVisibleRows, Func<int>? visibleRowsProvider)
 	{
 		if (visibleRowsProvider is null)
@@ -709,19 +726,10 @@ internal static class ResultFlowPager
 		{
 			return Math.Max(2, visibleRowsProvider());
 		}
-		catch (IOException)
-		{
-			return Math.Max(2, fallbackVisibleRows);
-		}
-		catch (PlatformNotSupportedException)
-		{
-			return Math.Max(2, fallbackVisibleRows);
-		}
-		catch (InvalidOperationException)
-		{
-			return Math.Max(2, fallbackVisibleRows);
-		}
-		catch (System.Security.SecurityException)
+		catch (Exception ex) when (ex is IOException
+			or PlatformNotSupportedException
+			or InvalidOperationException
+			or System.Security.SecurityException)
 		{
 			return Math.Max(2, fallbackVisibleRows);
 		}

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -409,7 +409,7 @@ internal static class ResultFlowPager
 			return false;
 		}
 
-		session.Append(nextPayload.Payload, nextPayload.HasMore);
+		session.Append(nextPayload.Payload, nextPayload.HasMore, nextPayload.ContainsPresentationChrome);
 		return true;
 	}
 
@@ -542,7 +542,7 @@ internal static class ResultFlowPager
 			return;
 		}
 
-		session.Append(nextPayload.Payload, nextPayload.HasMore);
+		session.Append(nextPayload.Payload, nextPayload.HasMore, nextPayload.ContainsPresentationChrome);
 	}
 
 	private static async ValueTask ClearViewportAsync(TerminalSurfaceScope surface, ViewportState state)
@@ -739,63 +739,6 @@ internal static class ResultFlowPager
 		Quit,
 	}
 
-	private sealed class PagerSession
-	{
-		private readonly PagerHeader _header;
-		private readonly int _maxBufferedLines;
-
-		public PagerSession(string initialPayload, bool hasMorePayload, int maxBufferedLines)
-		{
-			_maxBufferedLines = Math.Max(1, maxBufferedLines);
-			var parsed = PagerPayloadParser.Parse(initialPayload, header: null);
-			_header = parsed.Header;
-			Lines = [];
-			AppendContent(parsed.ContentLines, hasMorePayload);
-			PageSize = 1;
-			NextWindow = 1;
-		}
-
-		public IReadOnlyList<string> HeaderLines => _header.Lines;
-
-		public List<string> Lines { get; }
-
-		public int PageSize { get; set; }
-
-		public int NextWindow { get; set; }
-
-		public int Index { get; set; }
-
-		public bool HasMorePayload { get; set; }
-
-		public bool BufferLimitReached { get; private set; }
-
-		public void Append(string payload, bool hasMorePayload)
-		{
-			var parsed = PagerPayloadParser.Parse(payload, _header);
-			AppendContent(parsed.ContentLines, hasMorePayload);
-		}
-
-		private void AppendContent(IReadOnlyList<string> contentLines, bool hasMorePayload)
-		{
-			var available = _maxBufferedLines - Lines.Count;
-			if (available <= 0)
-			{
-				BufferLimitReached = true;
-				HasMorePayload = false;
-				return;
-			}
-
-			var take = Math.Min(available, contentLines.Count);
-			for (var i = 0; i < take; i++)
-			{
-				Lines.Add(contentLines[i]);
-			}
-
-			BufferLimitReached = take < contentLines.Count;
-			HasMorePayload = !BufferLimitReached && hasMorePayload;
-		}
-	}
-
 	private sealed class ViewportState
 	{
 		private readonly List<int> _renderedLineLengths = [];
@@ -857,134 +800,4 @@ internal static class ResultFlowPager
 			Math.Max(1, visibleRows - Session.HeaderLines.Count - 1);
 	}
 
-	private sealed record PagerHeader(IReadOnlyList<string> Lines, IReadOnlySet<string> NormalizedLines)
-	{
-		public static PagerHeader Empty { get; } = new([], new HashSet<string>(StringComparer.Ordinal));
-	}
-
-	private sealed record ParsedPagerPayload(PagerHeader Header, IReadOnlyList<string> ContentLines)
-	{
-		public int TotalLineCount => Header.Lines.Count + ContentLines.Count;
-	}
-
-	private static class PagerPayloadParser
-	{
-		public static ParsedPagerPayload Parse(string payload, PagerHeader? header)
-		{
-			var lines = SplitLines(payload);
-			var payloadHeader = DetectHeader(lines);
-			var resolvedHeader = header ?? payloadHeader;
-			var headerLineCount = payloadHeader.Lines.Count;
-			var content = new List<string>();
-			for (var i = headerLineCount; i < lines.Length; i++)
-			{
-				var normalized = NormalizeLine(lines[i]);
-				if (resolvedHeader.NormalizedLines.Contains(normalized) || IsPageFooterLine(lines[i]))
-				{
-					continue;
-				}
-
-				content.Add(lines[i]);
-			}
-
-			return new ParsedPagerPayload(resolvedHeader, content);
-		}
-
-		private static PagerHeader DetectHeader(string[] lines)
-		{
-			if (lines.Length == 0)
-			{
-				return PagerHeader.Empty;
-			}
-
-			if (lines.Length > 1 && IsPlainTableSeparator(lines[1]))
-			{
-				return CreateHeader(lines.Take(2).ToArray());
-			}
-
-			if (IsPlainHumanTableHeader(lines[0]))
-			{
-				return CreateHeader([lines[0]]);
-			}
-
-			return lines[0].Contains("\u001b[1m", StringComparison.Ordinal)
-				? CreateHeader([lines[0]])
-				: PagerHeader.Empty;
-		}
-
-		private static PagerHeader CreateHeader(string[] lines) =>
-			new(
-				lines,
-				lines.Select(NormalizeLine).ToHashSet(StringComparer.Ordinal));
-
-		private static bool IsPlainTableSeparator(string line)
-		{
-			var text = line.Trim();
-			return text.Length > 0
-				&& text.All(ch => ch is '-' or ' ' or '\t')
-				&& text.Contains('-', StringComparison.Ordinal);
-		}
-
-		private static bool IsPlainHumanTableHeader(string line)
-		{
-			var text = line.TrimStart();
-			return text.StartsWith("# ", StringComparison.Ordinal)
-				&& text.Contains("  ", StringComparison.Ordinal);
-		}
-
-		private static bool IsPageFooterLine(string line) =>
-			line.StartsWith("Showing ", StringComparison.Ordinal)
-			&& (line.Contains(" of ", StringComparison.Ordinal)
-				|| line.Contains(" result(s).", StringComparison.Ordinal))
-			&& (line.EndsWith('.')
-				|| line.Contains("Next data page: rerun with --result:cursor ", StringComparison.Ordinal));
-
-		private static string[] SplitLines(string payload)
-		{
-			if (string.IsNullOrEmpty(payload))
-			{
-				return [];
-			}
-
-			var lines = new List<string>();
-			foreach (var line in payload.AsSpan().EnumerateLines())
-			{
-				lines.Add(line.ToString());
-			}
-
-			if (lines.Count > 0 && lines[^1].Length == 0)
-			{
-				lines.RemoveAt(lines.Count - 1);
-			}
-
-			return [.. lines];
-		}
-
-		private static string NormalizeLine(string line)
-		{
-			if (!line.Contains('\u001b', StringComparison.Ordinal))
-			{
-				return line.Trim();
-			}
-
-			var builder = new System.Text.StringBuilder(line.Length);
-			for (var i = 0; i < line.Length; i++)
-			{
-				if (line[i] == '\u001b' && i + 1 < line.Length && line[i + 1] == '[')
-				{
-					i += 2;
-					while (i < line.Length && (line[i] < '@' || line[i] > '~'))
-					{
-						i++;
-					}
-
-					continue;
-				}
-
-				builder.Append(line[i]);
-			}
-
-			return builder.ToString().Trim();
-		}
-	}
 }

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -2,7 +2,7 @@ namespace Repl;
 
 internal static class ResultFlowPager
 {
-	private const string MorePrompt = "--More--";
+	private const string MorePrompt = "--More-- Space/PageDown: continue, Enter/Down: line, Up/PageUp: back, q/Esc: stop";
 
 	public static int CountLines(string payload) => SplitLines(payload).Length;
 
@@ -13,62 +13,199 @@ internal static class ResultFlowPager
 		int visibleRows,
 		CancellationToken cancellationToken = default)
 	{
+		await WriteAsync(
+				payload,
+				output,
+				keyReader,
+				visibleRows,
+				hasMorePayload: false,
+				fetchNextPayload: null,
+				cancellationToken)
+			.ConfigureAwait(false);
+	}
+
+	public static async ValueTask WriteAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		bool hasMorePayload,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		CancellationToken cancellationToken = default)
+	{
 		ArgumentNullException.ThrowIfNull(output);
 		ArgumentNullException.ThrowIfNull(keyReader);
 
-		var lines = SplitLines(payload);
-		if (lines.Length == 0)
+		var state = new PagerState(SplitLines(payload), Math.Max(1, visibleRows), hasMorePayload);
+		if (state.Lines.Length == 0 && !state.HasMorePayload)
 		{
 			return;
 		}
 
-		var pageSize = Math.Max(1, visibleRows);
-		var nextWindow = pageSize;
-		var index = 0;
-		while (index < lines.Length)
+		while (true)
 		{
-			cancellationToken.ThrowIfCancellationRequested();
-			var take = Math.Min(nextWindow, lines.Length - index);
-			for (var i = 0; i < take; i++)
+			if (state.Lines.Length == 0 && state.HasMorePayload && fetchNextPayload is not null)
 			{
-				await output.WriteLineAsync(lines[index + i]).ConfigureAwait(false);
+				var payloadPage = await fetchNextPayload(cancellationToken).ConfigureAwait(false);
+				if (payloadPage is null)
+				{
+					return;
+				}
+
+				state.Reset(SplitLines(payloadPage.Payload), payloadPage.HasMore);
+				continue;
 			}
 
-			index += take;
-			if (index >= lines.Length)
+			if (await WriteCurrentPayloadAsync(state, output, keyReader, cancellationToken).ConfigureAwait(false))
+			{
+				return;
+			}
+
+			if (!state.HasMorePayload || fetchNextPayload is null)
 			{
 				break;
 			}
 
-			await output.WriteAsync(MorePrompt).ConfigureAwait(false);
-			await output.FlushAsync(cancellationToken).ConfigureAwait(false);
-			var key = await keyReader.ReadKeyAsync(cancellationToken).ConfigureAwait(false);
-			await output.WriteLineAsync().ConfigureAwait(false);
-
-			switch (key.Key)
+			var boundaryKey = await ReadPromptAsync(output, keyReader, cancellationToken).ConfigureAwait(false);
+			if (ApplyBoundaryKey(state, boundaryKey))
 			{
-				case ConsoleKey.Q:
-				case ConsoleKey.Escape:
-					return;
-				case ConsoleKey.Enter:
-				case ConsoleKey.DownArrow:
-					nextWindow = 1;
-					break;
-				case ConsoleKey.UpArrow:
-				case ConsoleKey.PageUp:
-					index = Math.Max(0, index - pageSize - take);
-					nextWindow = key.Key == ConsoleKey.UpArrow ? 1 : pageSize;
-					break;
-				default:
-					nextWindow = pageSize;
-					break;
+				return;
 			}
+
+			if (state.Index < state.Lines.Length)
+			{
+				continue;
+			}
+
+			var nextPayload = await fetchNextPayload(cancellationToken).ConfigureAwait(false);
+			if (nextPayload is null)
+			{
+				break;
+			}
+
+			state.Reset(SplitLines(nextPayload.Payload), nextPayload.HasMore);
 		}
 	}
 
+	private static async ValueTask<bool> WriteCurrentPayloadAsync(
+		PagerState state,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		CancellationToken cancellationToken)
+	{
+		while (state.Index < state.Lines.Length)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			var windowStart = state.Index;
+			var take = Math.Min(state.NextWindow, state.Lines.Length - state.Index);
+			for (var i = 0; i < take; i++)
+			{
+				await output.WriteLineAsync(state.Lines[state.Index + i]).ConfigureAwait(false);
+			}
+
+			state.Index += take;
+			if (state.Index >= state.Lines.Length)
+			{
+				break;
+			}
+
+			var key = await ReadPromptAsync(output, keyReader, cancellationToken).ConfigureAwait(false);
+			if (ApplyWindowKey(state, key, windowStart))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static bool ApplyWindowKey(PagerState state, ConsoleKeyInfo key, int windowStart)
+	{
+		switch (key.Key)
+		{
+			case ConsoleKey.Q:
+			case ConsoleKey.Escape:
+				return true;
+			case ConsoleKey.Enter:
+			case ConsoleKey.DownArrow:
+				state.NextWindow = 1;
+				return false;
+			case ConsoleKey.UpArrow:
+				state.Index = Math.Max(0, windowStart - 1);
+				state.NextWindow = 1;
+				return false;
+			case ConsoleKey.PageUp:
+				state.Index = Math.Max(0, windowStart - state.PageSize);
+				state.NextWindow = state.PageSize;
+				return false;
+			default:
+				state.NextWindow = state.PageSize;
+				return false;
+		}
+	}
+
+	private static bool ApplyBoundaryKey(PagerState state, ConsoleKeyInfo key)
+	{
+		switch (key.Key)
+		{
+			case ConsoleKey.Q:
+			case ConsoleKey.Escape:
+				return true;
+			case ConsoleKey.Enter:
+			case ConsoleKey.DownArrow:
+				state.NextWindow = 1;
+				return false;
+			case ConsoleKey.UpArrow:
+				state.Index = Math.Max(0, state.Lines.Length - state.PageSize);
+				state.NextWindow = state.PageSize;
+				return false;
+			case ConsoleKey.PageUp:
+				state.Index = Math.Max(0, state.Lines.Length - state.PageSize);
+				state.NextWindow = state.PageSize;
+				return false;
+			default:
+				state.NextWindow = state.PageSize;
+				return false;
+		}
+	}
+
+	private static async ValueTask<ConsoleKeyInfo> ReadPromptAsync(
+		TextWriter output,
+		IReplKeyReader keyReader,
+		CancellationToken cancellationToken)
+	{
+		await output.WriteAsync(MorePrompt).ConfigureAwait(false);
+		await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+		var key = await keyReader.ReadKeyAsync(cancellationToken).ConfigureAwait(false);
+		await output.WriteLineAsync().ConfigureAwait(false);
+		return key;
+	}
+
 	private static string[] SplitLines(string payload) =>
-		payload
-			.Replace("\r\n", "\n", StringComparison.Ordinal)
-			.Replace('\r', '\n')
-			.Split('\n');
+		string.IsNullOrEmpty(payload)
+			? []
+			: payload
+				.Replace("\r\n", "\n", StringComparison.Ordinal)
+				.Replace('\r', '\n')
+				.Split('\n');
+
+	private sealed class PagerState(string[] lines, int pageSize, bool hasMorePayload)
+	{
+		public string[] Lines { get; private set; } = lines;
+
+		public int PageSize { get; } = pageSize;
+
+		public int NextWindow { get; set; } = pageSize;
+
+		public int Index { get; set; }
+
+		public bool HasMorePayload { get; private set; } = hasMorePayload;
+
+		public void Reset(string[] lines, bool hasMorePayload)
+		{
+			Lines = lines;
+			Index = 0;
+			HasMorePayload = hasMorePayload;
+		}
+	}
 }

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -3,6 +3,7 @@ namespace Repl;
 internal static class ResultFlowPager
 {
 	private const string MorePrompt = "--More-- Space/PageDown: continue, Enter/Down: line, Up/PageUp: ignored, q/Esc: stop";
+	private const string SourceReturnedNoDataStatus = "-- paging stopped: source returned no data --";
 	private const string FullStatus = "-- result-flow {0}-{1}/{2}{3}  Space: next  Up/Down: scroll  Home/End: known bounds  q: quit --";
 	private const string FullStatusBufferLimit = "-- result-flow {0}-{1}/{2} buffer limit reached  Up/Down: scroll  q: quit --";
 	private const int DefaultMaxBufferedLines = 10_000;
@@ -13,9 +14,9 @@ internal static class ResultFlowPager
 	private static readonly System.Text.CompositeFormat FullStatusBufferLimitFormat =
 		System.Text.CompositeFormat.Parse(FullStatusBufferLimit);
 
-	public static int CountLines(string payload) => PagerPayloadParser.Parse(payload, header: null).TotalLineCount;
+	internal static int CountLines(string payload) => PagerPayloadParser.Parse(payload, header: null).TotalLineCount;
 
-	public static ValueTask WriteAsync(
+	internal static ValueTask WriteAsync(
 		string payload,
 		TextWriter output,
 		IReplKeyReader keyReader,
@@ -30,7 +31,7 @@ internal static class ResultFlowPager
 			fetchNextPayload: null,
 			cancellationToken);
 
-	public static async ValueTask WriteAsync(
+	internal static async ValueTask WriteAsync(
 		string payload,
 		TextWriter output,
 		IReplKeyReader keyReader,
@@ -52,7 +53,7 @@ internal static class ResultFlowPager
 			.ConfigureAwait(false);
 	}
 
-	public static async ValueTask WriteAsync(
+	internal static async ValueTask WriteAsync(
 		string payload,
 		TextWriter output,
 		IReplKeyReader keyReader,
@@ -76,7 +77,7 @@ internal static class ResultFlowPager
 			.ConfigureAwait(false);
 	}
 
-	public static async ValueTask WriteAsync(
+	internal static async ValueTask WriteAsync(
 		string payload,
 		TextWriter output,
 		IReplKeyReader keyReader,
@@ -102,7 +103,7 @@ internal static class ResultFlowPager
 			.ConfigureAwait(false);
 	}
 
-	public static async ValueTask WriteAsync(
+	internal static async ValueTask WriteAsync(
 		string payload,
 		TextWriter output,
 		IReplKeyReader keyReader,
@@ -129,7 +130,7 @@ internal static class ResultFlowPager
 			.ConfigureAwait(false);
 	}
 
-	public static ValueTask WriteAsync(
+	internal static ValueTask WriteAsync(
 		string payload,
 		TextWriter output,
 		IReplKeyReader keyReader,
@@ -155,7 +156,7 @@ internal static class ResultFlowPager
 			DefaultMaxBufferedLines,
 			cancellationToken);
 
-	public static async ValueTask WriteAsync(
+	internal static async ValueTask WriteAsync(
 		string payload,
 		TextWriter output,
 		IReplKeyReader keyReader,
@@ -366,6 +367,7 @@ internal static class ResultFlowPager
 
 			if (!await TryFetchIntoSessionAsync(session, fetchNextPayload, cancellationToken).ConfigureAwait(false))
 			{
+				await WriteSourceReturnedNoDataAsync(session, output).ConfigureAwait(false);
 				return;
 			}
 		}
@@ -380,12 +382,11 @@ internal static class ResultFlowPager
 		var written = 0;
 		while (written < session.NextWindow)
 		{
-			if (session.Index >= session.Lines.Count)
+			if (session.Index >= session.Lines.Count
+				&& !await TryFetchIntoSessionAsync(session, fetchNextPayload, cancellationToken).ConfigureAwait(false))
 			{
-				if (!await TryFetchIntoSessionAsync(session, fetchNextPayload, cancellationToken).ConfigureAwait(false))
-				{
-					break;
-				}
+				await WriteSourceReturnedNoDataAsync(session, output).ConfigureAwait(false);
+				break;
 			}
 
 			await output.WriteLineAsync(session.Lines[session.Index]).ConfigureAwait(false);
@@ -404,9 +405,11 @@ internal static class ResultFlowPager
 			return false;
 		}
 
+		session.SourceReturnedNoData = false;
 		var nextPayload = await fetchNextPayload(cancellationToken).ConfigureAwait(false);
 		if (nextPayload is null)
 		{
+			session.SourceReturnedNoData = true;
 			session.HasMorePayload = false;
 			return false;
 		}
@@ -449,6 +452,14 @@ internal static class ResultFlowPager
 					session.NextWindow = session.PageSize;
 					return PagerAction.PageDown;
 			}
+		}
+	}
+
+	private static async ValueTask WriteSourceReturnedNoDataAsync(PagerSession session, TextWriter output)
+	{
+		if (session.SourceReturnedNoData)
+		{
+			await output.WriteLineAsync(SourceReturnedNoDataStatus).ConfigureAwait(false);
 		}
 	}
 
@@ -537,14 +548,7 @@ internal static class ResultFlowPager
 		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>> fetchNextPayload,
 		CancellationToken cancellationToken)
 	{
-		var nextPayload = await fetchNextPayload(cancellationToken).ConfigureAwait(false);
-		if (nextPayload is null)
-		{
-			session.HasMorePayload = false;
-			return;
-		}
-
-		session.Append(nextPayload.Payload, nextPayload.HasMore, nextPayload.ContainsPresentationChrome);
+		_ = await TryFetchIntoSessionAsync(session, fetchNextPayload, cancellationToken).ConfigureAwait(false);
 	}
 
 	private static async ValueTask ClearViewportAsync(TerminalSurfaceScope surface, ViewportState state)
@@ -599,7 +603,14 @@ internal static class ResultFlowPager
 	{
 		if (state.Session.Lines.Count == 0)
 		{
-			return "-- result-flow: loading --";
+			return state.Session.SourceReturnedNoData
+				? SourceReturnedNoDataStatus
+				: "-- result-flow: loading --";
+		}
+
+		if (state.Session.SourceReturnedNoData)
+		{
+			return SourceReturnedNoDataStatus;
 		}
 
 		return state.Session.BufferLimitReached
@@ -639,13 +650,14 @@ internal static class ResultFlowPager
 		bool appendNewLine = true)
 	{
 		await output.WriteAsync(line).ConfigureAwait(false);
+		var visualLength = GetVisualLength(line);
 		var previousLength = state.GetRenderedLineLength(row);
-		if (previousLength > line.Length)
+		if (previousLength > visualLength)
 		{
-			await WriteSpacesAsync(output, previousLength - line.Length).ConfigureAwait(false);
+			await WriteSpacesAsync(output, previousLength - visualLength).ConfigureAwait(false);
 		}
 
-		state.SetRenderedLineLength(row, line.Length);
+		state.SetRenderedLineLength(row, visualLength);
 		if (appendNewLine)
 		{
 			await output.WriteLineAsync().ConfigureAwait(false);
@@ -692,7 +704,7 @@ internal static class ResultFlowPager
 	private static bool ShouldFetchForViewportKey(ViewportState state, PagerAction action, int beforeTopLine) =>
 		action switch
 		{
-			PagerAction.PageDown => state.HasReachedBottom && state.Session.Lines.Count > state.ViewportHeight,
+			PagerAction.PageDown => state.HasReachedBottom && state.Session.Lines.Count >= state.ViewportHeight,
 			PagerAction.LineDown => beforeTopLine == state.TopLine && state.HasReachedBottom,
 			_ => false,
 		};
@@ -713,6 +725,34 @@ internal static class ResultFlowPager
 			await output.WriteAsync(SpacePadding.AsMemory(0, take)).ConfigureAwait(false);
 			count -= take;
 		}
+	}
+
+	private static int GetVisualLength(string line)
+	{
+		var length = 0;
+		for (var i = 0; i < line.Length; i++)
+		{
+			if (line[i] == '\u001b')
+			{
+				if (i + 1 < line.Length && line[i + 1] == '[')
+				{
+					i += 2;
+					while (i < line.Length && (line[i] < '@' || line[i] > '~'))
+					{
+						i++;
+					}
+				}
+
+				continue;
+			}
+
+			if (!char.IsControl(line[i]))
+			{
+				length++;
+			}
+		}
+
+		return length;
 	}
 
 	private static int GetCurrentVisibleRows(int fallbackVisibleRows, Func<int>? visibleRowsProvider)

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -1,0 +1,74 @@
+namespace Repl;
+
+internal static class ResultFlowPager
+{
+	private const string MorePrompt = "--More--";
+
+	public static int CountLines(string payload) => SplitLines(payload).Length;
+
+	public static async ValueTask WriteAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(output);
+		ArgumentNullException.ThrowIfNull(keyReader);
+
+		var lines = SplitLines(payload);
+		if (lines.Length == 0)
+		{
+			return;
+		}
+
+		var pageSize = Math.Max(1, visibleRows);
+		var nextWindow = pageSize;
+		var index = 0;
+		while (index < lines.Length)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			var take = Math.Min(nextWindow, lines.Length - index);
+			for (var i = 0; i < take; i++)
+			{
+				await output.WriteLineAsync(lines[index + i]).ConfigureAwait(false);
+			}
+
+			index += take;
+			if (index >= lines.Length)
+			{
+				break;
+			}
+
+			await output.WriteAsync(MorePrompt).ConfigureAwait(false);
+			await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+			var key = await keyReader.ReadKeyAsync(cancellationToken).ConfigureAwait(false);
+			await output.WriteLineAsync().ConfigureAwait(false);
+
+			switch (key.Key)
+			{
+				case ConsoleKey.Q:
+				case ConsoleKey.Escape:
+					return;
+				case ConsoleKey.Enter:
+				case ConsoleKey.DownArrow:
+					nextWindow = 1;
+					break;
+				case ConsoleKey.UpArrow:
+				case ConsoleKey.PageUp:
+					index = Math.Max(0, index - pageSize - take);
+					nextWindow = key.Key == ConsoleKey.UpArrow ? 1 : pageSize;
+					break;
+				default:
+					nextWindow = pageSize;
+					break;
+			}
+		}
+	}
+
+	private static string[] SplitLines(string payload) =>
+		payload
+			.Replace("\r\n", "\n", StringComparison.Ordinal)
+			.Replace('\r', '\n')
+			.Split('\n');
+}

--- a/src/Repl.Core/ResultFlow/ResultFlowPager.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPager.cs
@@ -4,28 +4,29 @@ internal static class ResultFlowPager
 {
 	private const string MorePrompt = "--More-- Space/PageDown: continue, Enter/Down: line, Up/PageUp: ignored, q/Esc: stop";
 	private const string FullStatus = "-- result-flow {0}-{1}/{2}{3}  Space: next  Up/Down: scroll  Home/End: known bounds  q: quit --";
+	private const string FullStatusBufferLimit = "-- result-flow {0}-{1}/{2} buffer limit reached  Up/Down: scroll  q: quit --";
+	private const int DefaultMaxBufferedLines = 10_000;
 	private static readonly System.Text.CompositeFormat FullStatusFormat =
 		System.Text.CompositeFormat.Parse(FullStatus);
+	private static readonly System.Text.CompositeFormat FullStatusBufferLimitFormat =
+		System.Text.CompositeFormat.Parse(FullStatusBufferLimit);
 
 	public static int CountLines(string payload) => PagerPayloadParser.Parse(payload, header: null).TotalLineCount;
 
-	public static async ValueTask WriteAsync(
+	public static ValueTask WriteAsync(
 		string payload,
 		TextWriter output,
 		IReplKeyReader keyReader,
 		int visibleRows,
 		CancellationToken cancellationToken = default)
-	{
-		await WriteAsync(
-				payload,
-				output,
-				keyReader,
-				visibleRows,
-				hasMorePayload: false,
-				fetchNextPayload: null,
-				cancellationToken)
-			.ConfigureAwait(false);
-	}
+		=> WriteAsync(
+			payload,
+			output,
+			keyReader,
+			visibleRows,
+			hasMorePayload: false,
+			fetchNextPayload: null,
+			cancellationToken);
 
 	public static async ValueTask WriteAsync(
 		string payload,
@@ -126,7 +127,7 @@ internal static class ResultFlowPager
 			.ConfigureAwait(false);
 	}
 
-	public static async ValueTask WriteAsync(
+	public static ValueTask WriteAsync(
 		string payload,
 		TextWriter output,
 		IReplKeyReader keyReader,
@@ -138,9 +139,37 @@ internal static class ResultFlowPager
 		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
 		IEnumerable<IReplPagerRenderer>? pagerRenderers,
 		CancellationToken cancellationToken = default)
+		=> WriteAsync(
+			payload,
+			output,
+			keyReader,
+			visibleRows,
+			visibleRowsProvider,
+			pagerMode,
+			ansiEnabled,
+			hasMorePayload,
+			fetchNextPayload,
+			pagerRenderers,
+			DefaultMaxBufferedLines,
+			cancellationToken);
+
+	public static async ValueTask WriteAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		Func<int>? visibleRowsProvider,
+		ReplPagerMode pagerMode,
+		bool ansiEnabled,
+		bool hasMorePayload,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		IEnumerable<IReplPagerRenderer>? pagerRenderers,
+		int maxBufferedLines,
+		CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(output);
 		ArgumentNullException.ThrowIfNull(keyReader);
+		maxBufferedLines = Math.Max(1, maxBufferedLines);
 
 		var mode = ResolveMode(pagerMode, ansiEnabled);
 		if (await TryRenderCustomAsync(
@@ -160,7 +189,7 @@ internal static class ResultFlowPager
 			return;
 		}
 
-		var session = new PagerSession(payload, hasMorePayload);
+		var session = new PagerSession(payload, hasMorePayload, maxBufferedLines);
 		await RenderBuiltInAsync(
 				mode,
 				session,
@@ -558,8 +587,26 @@ internal static class ResultFlowPager
 		var lastLine = state.Session.Lines.Count == 0
 			? 0
 			: Math.Min(state.Session.Lines.Count, state.TopLine + state.ViewportHeight);
-		var status = state.Session.Lines.Count == 0
-			? "-- result-flow: loading --"
+		var status = CreateViewportStatus(state, lastLine);
+		await WriteViewportLineAsync(state, surface.Output, row++, status, appendNewLine: false).ConfigureAwait(false);
+		state.RenderedHeight = row;
+		await surface.FlushAsync(cancellationToken).ConfigureAwait(false);
+	}
+
+	private static string CreateViewportStatus(ViewportState state, int lastLine)
+	{
+		if (state.Session.Lines.Count == 0)
+		{
+			return "-- result-flow: loading --";
+		}
+
+		return state.Session.BufferLimitReached
+			? string.Format(
+				System.Globalization.CultureInfo.InvariantCulture,
+				FullStatusBufferLimitFormat,
+				state.TopLine + 1,
+				lastLine,
+				state.Session.Lines.Count)
 			: string.Format(
 				System.Globalization.CultureInfo.InvariantCulture,
 				FullStatusFormat,
@@ -567,9 +614,6 @@ internal static class ResultFlowPager
 				lastLine,
 				state.Session.Lines.Count,
 				state.Session.HasMorePayload ? "+" : string.Empty);
-		await WriteViewportLineAsync(state, surface.Output, row++, status, appendNewLine: false).ConfigureAwait(false);
-		state.RenderedHeight = row;
-		await surface.FlushAsync(cancellationToken).ConfigureAwait(false);
 	}
 
 	private static async ValueTask PositionViewportAsync(TerminalSurfaceScope surface, ViewportState state)
@@ -698,13 +742,15 @@ internal static class ResultFlowPager
 	private sealed class PagerSession
 	{
 		private readonly PagerHeader _header;
+		private readonly int _maxBufferedLines;
 
-		public PagerSession(string initialPayload, bool hasMorePayload)
+		public PagerSession(string initialPayload, bool hasMorePayload, int maxBufferedLines)
 		{
+			_maxBufferedLines = Math.Max(1, maxBufferedLines);
 			var parsed = PagerPayloadParser.Parse(initialPayload, header: null);
 			_header = parsed.Header;
-			Lines = [.. parsed.ContentLines];
-			HasMorePayload = hasMorePayload;
+			Lines = [];
+			AppendContent(parsed.ContentLines, hasMorePayload);
 			PageSize = 1;
 			NextWindow = 1;
 		}
@@ -721,11 +767,32 @@ internal static class ResultFlowPager
 
 		public bool HasMorePayload { get; set; }
 
+		public bool BufferLimitReached { get; private set; }
+
 		public void Append(string payload, bool hasMorePayload)
 		{
 			var parsed = PagerPayloadParser.Parse(payload, _header);
-			Lines.AddRange(parsed.ContentLines);
-			HasMorePayload = hasMorePayload;
+			AppendContent(parsed.ContentLines, hasMorePayload);
+		}
+
+		private void AppendContent(IReadOnlyList<string> contentLines, bool hasMorePayload)
+		{
+			var available = _maxBufferedLines - Lines.Count;
+			if (available <= 0)
+			{
+				BufferLimitReached = true;
+				HasMorePayload = false;
+				return;
+			}
+
+			var take = Math.Min(available, contentLines.Count);
+			for (var i = 0; i < take; i++)
+			{
+				Lines.Add(contentLines[i]);
+			}
+
+			BufferLimitReached = take < contentLines.Count;
+			HasMorePayload = !BufferLimitReached && hasMorePayload;
 		}
 	}
 

--- a/src/Repl.Core/ResultFlow/ResultFlowPagerOptions.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPagerOptions.cs
@@ -1,0 +1,20 @@
+namespace Repl;
+
+internal sealed record ResultFlowPagerOptions
+{
+	public int VisibleRows { get; init; }
+
+	public Func<int>? VisibleRowsProvider { get; init; }
+
+	public ReplPagerMode PagerMode { get; init; } = ReplPagerMode.More;
+
+	public bool AnsiEnabled { get; init; }
+
+	public bool HasMorePayload { get; init; }
+
+	public Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? FetchNextPayload { get; init; }
+
+	public IEnumerable<IReplPagerRenderer>? PagerRenderers { get; init; }
+
+	public int MaxBufferedLines { get; init; } = ResultFlowOptions.DefaultMaxBufferedLines;
+}

--- a/src/Repl.Core/ResultFlow/ResultFlowPagerOptions.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPagerOptions.cs
@@ -14,7 +14,7 @@ internal sealed record ResultFlowPagerOptions
 
 	public Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? FetchNextPayload { get; init; }
 
-	public IEnumerable<IReplPagerRenderer>? PagerRenderers { get; init; }
+	public IReadOnlyList<IReplPagerRenderer>? PagerRenderers { get; init; }
 
 	public int MaxBufferedLines { get; init; } = ResultFlowOptions.DefaultMaxBufferedLines;
 }

--- a/src/Repl.Core/ResultFlow/ResultFlowPagerPage.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPagerPage.cs
@@ -1,3 +1,6 @@
 namespace Repl;
 
-internal sealed record ResultFlowPagerPage(string Payload, bool HasMore);
+internal sealed record ResultFlowPagerPage(
+	string Payload,
+	bool HasMore,
+	bool ContainsPresentationChrome = true);

--- a/src/Repl.Core/ResultFlow/ResultFlowPagerPage.cs
+++ b/src/Repl.Core/ResultFlow/ResultFlowPagerPage.cs
@@ -1,0 +1,3 @@
+namespace Repl;
+
+internal sealed record ResultFlowPagerPage(string Payload, bool HasMore);

--- a/src/Repl.Core/ResultFlowPageRenderMode.cs
+++ b/src/Repl.Core/ResultFlowPageRenderMode.cs
@@ -1,0 +1,7 @@
+namespace Repl;
+
+internal enum ResultFlowPageRenderMode
+{
+	Initial,
+	Continuation,
+}

--- a/src/Repl.Core/Terminal/AnsiSequences.cs
+++ b/src/Repl.Core/Terminal/AnsiSequences.cs
@@ -1,0 +1,15 @@
+namespace Repl.Terminal;
+
+internal static class AnsiSequences
+{
+	public const string EnterAlternateScreen = "\u001b[?1049h";
+	public const string LeaveAlternateScreen = "\u001b[?1049l";
+	public const string HideCursor = "\u001b[?25l";
+	public const string ShowCursor = "\u001b[?25h";
+	public const string CursorHome = "\u001b[H";
+	public const string ClearToEndOfScreen = "\u001b[J";
+	public const string DisableLineWrap = "\u001b[?7l";
+	public const string EnableLineWrap = "\u001b[?7h";
+
+	public static string CursorUp(int rows) => $"\u001b[{rows}A";
+}

--- a/src/Repl.Core/Terminal/AnsiTextMetrics.cs
+++ b/src/Repl.Core/Terminal/AnsiTextMetrics.cs
@@ -2,7 +2,10 @@ namespace Repl.Terminal;
 
 internal static class AnsiTextMetrics
 {
-	public static int GetVisualLength(string text)
+	public static int GetVisualLength(string text) =>
+		GetVisualLength(text.AsSpan());
+
+	public static int GetVisualLength(ReadOnlySpan<char> text)
 	{
 		var length = 0;
 		for (var i = 0; i < text.Length; i++)
@@ -14,16 +17,7 @@ internal static class AnsiTextMetrics
 					continue;
 				}
 
-				// ANSI control sequences are terminal protocol bytes, not columns.
-				// CSI covers styling/cursor controls; OSC covers hyperlinks and titles; SS3 covers special keys.
-				i = text[i + 1] switch
-				{
-					'[' => SkipCsiSequence(text, i + 2),
-					']' => SkipOscSequence(text, i + 2),
-					'O' => Math.Min(text.Length - 1, i + 2),
-					_ => i + 1,
-				};
-
+				i = SkipEscapeSequence(text, i);
 				continue;
 			}
 
@@ -36,7 +30,64 @@ internal static class AnsiTextMetrics
 		return length;
 	}
 
-	private static int SkipCsiSequence(string text, int start)
+	public static string StripControlSequences(string text)
+	{
+		if (!text.Contains('\u001b', StringComparison.Ordinal))
+		{
+			return text;
+		}
+
+		return StripControlSequences(text.AsSpan());
+	}
+
+	public static string StripControlSequences(ReadOnlySpan<char> text)
+	{
+		var escapeIndex = text.IndexOf('\u001b');
+		if (escapeIndex < 0)
+		{
+			return text.ToString();
+		}
+
+		var builder = new System.Text.StringBuilder(text.Length);
+		builder.Append(text[..escapeIndex]);
+		for (var i = escapeIndex; i < text.Length; i++)
+		{
+			if (text[i] == '\u001b')
+			{
+				if (i + 1 >= text.Length)
+				{
+					continue;
+				}
+
+				i = SkipEscapeSequence(text, i);
+				continue;
+			}
+
+			builder.Append(text[i]);
+		}
+
+		return builder.ToString();
+	}
+
+	private static int SkipEscapeSequence(ReadOnlySpan<char> text, int escapeIndex)
+	{
+		if (escapeIndex + 1 >= text.Length)
+		{
+			return escapeIndex;
+		}
+
+		// ANSI escape sequences are terminal protocol bytes, not columns.
+		// CSI covers styling/cursor controls; OSC covers hyperlinks and titles; SS3 covers special keys.
+		return text[escapeIndex + 1] switch
+		{
+			'[' => SkipCsiSequence(text, escapeIndex + 2),
+			']' => SkipOscSequence(text, escapeIndex + 2),
+			'O' => Math.Min(text.Length - 1, escapeIndex + 2),
+			_ => escapeIndex + 1,
+		};
+	}
+
+	private static int SkipCsiSequence(ReadOnlySpan<char> text, int start)
 	{
 		var i = start;
 		while (i < text.Length && (text[i] < '@' || text[i] > '~'))
@@ -47,7 +98,7 @@ internal static class AnsiTextMetrics
 		return Math.Min(i, text.Length - 1);
 	}
 
-	private static int SkipOscSequence(string text, int start)
+	private static int SkipOscSequence(ReadOnlySpan<char> text, int start)
 	{
 		for (var i = start; i < text.Length; i++)
 		{

--- a/src/Repl.Core/Terminal/AnsiTextMetrics.cs
+++ b/src/Repl.Core/Terminal/AnsiTextMetrics.cs
@@ -1,0 +1,67 @@
+namespace Repl.Terminal;
+
+internal static class AnsiTextMetrics
+{
+	public static int GetVisualLength(string text)
+	{
+		var length = 0;
+		for (var i = 0; i < text.Length; i++)
+		{
+			if (text[i] == '\u001b')
+			{
+				if (i + 1 >= text.Length)
+				{
+					continue;
+				}
+
+				// ANSI control sequences are terminal protocol bytes, not columns.
+				// CSI covers styling/cursor controls; OSC covers hyperlinks and titles; SS3 covers special keys.
+				i = text[i + 1] switch
+				{
+					'[' => SkipCsiSequence(text, i + 2),
+					']' => SkipOscSequence(text, i + 2),
+					'O' => Math.Min(text.Length - 1, i + 2),
+					_ => i + 1,
+				};
+
+				continue;
+			}
+
+			if (!char.IsControl(text[i]))
+			{
+				length++;
+			}
+		}
+
+		return length;
+	}
+
+	private static int SkipCsiSequence(string text, int start)
+	{
+		var i = start;
+		while (i < text.Length && (text[i] < '@' || text[i] > '~'))
+		{
+			i++;
+		}
+
+		return Math.Min(i, text.Length - 1);
+	}
+
+	private static int SkipOscSequence(string text, int start)
+	{
+		for (var i = start; i < text.Length; i++)
+		{
+			if (text[i] == '\u0007')
+			{
+				return i;
+			}
+
+			if (text[i] == '\u001b' && i + 1 < text.Length && text[i + 1] == '\\')
+			{
+				return i + 1;
+			}
+		}
+
+		return text.Length - 1;
+	}
+}

--- a/src/Repl.Core/Terminal/TerminalSurfaceHost.cs
+++ b/src/Repl.Core/Terminal/TerminalSurfaceHost.cs
@@ -1,0 +1,29 @@
+namespace Repl.Terminal;
+
+internal static class TerminalSurfaceHost
+{
+	public static async ValueTask<TerminalSurfaceScope> EnterAsync(
+		TextWriter output,
+		TerminalSurfaceMode mode,
+		CancellationToken cancellationToken)
+	{
+		ArgumentNullException.ThrowIfNull(output);
+
+		if (mode == TerminalSurfaceMode.AlternateScreen)
+		{
+			await output.WriteAsync(AnsiSequences.EnterAlternateScreen).ConfigureAwait(false);
+		}
+
+		await output.WriteAsync(AnsiSequences.HideCursor).ConfigureAwait(false);
+		await output.WriteAsync(AnsiSequences.DisableLineWrap).ConfigureAwait(false);
+		if (mode == TerminalSurfaceMode.AlternateScreen)
+		{
+			await output.WriteAsync(AnsiSequences.CursorHome).ConfigureAwait(false);
+		}
+
+		await output.WriteAsync(AnsiSequences.ClearToEndOfScreen).ConfigureAwait(false);
+		await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+		return new TerminalSurfaceScope(output, mode);
+	}
+}

--- a/src/Repl.Core/Terminal/TerminalSurfaceHost.cs
+++ b/src/Repl.Core/Terminal/TerminalSurfaceHost.cs
@@ -9,20 +9,28 @@ internal static class TerminalSurfaceHost
 	{
 		ArgumentNullException.ThrowIfNull(output);
 
-		if (mode == TerminalSurfaceMode.AlternateScreen)
+		try
 		{
-			await output.WriteAsync(AnsiSequences.EnterAlternateScreen).ConfigureAwait(false);
-		}
+			if (mode == TerminalSurfaceMode.AlternateScreen)
+			{
+				await output.WriteAsync(AnsiSequences.EnterAlternateScreen).ConfigureAwait(false);
+			}
 
-		await output.WriteAsync(AnsiSequences.HideCursor).ConfigureAwait(false);
-		await output.WriteAsync(AnsiSequences.DisableLineWrap).ConfigureAwait(false);
-		if (mode == TerminalSurfaceMode.AlternateScreen)
+			await output.WriteAsync(AnsiSequences.HideCursor).ConfigureAwait(false);
+			await output.WriteAsync(AnsiSequences.DisableLineWrap).ConfigureAwait(false);
+			if (mode == TerminalSurfaceMode.AlternateScreen)
+			{
+				await output.WriteAsync(AnsiSequences.CursorHome).ConfigureAwait(false);
+			}
+
+			await output.WriteAsync(AnsiSequences.ClearToEndOfScreen).ConfigureAwait(false);
+			await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+		}
+		catch
 		{
-			await output.WriteAsync(AnsiSequences.CursorHome).ConfigureAwait(false);
+			await TerminalSurfaceScope.RestoreAsync(output, mode).ConfigureAwait(false);
+			throw;
 		}
-
-		await output.WriteAsync(AnsiSequences.ClearToEndOfScreen).ConfigureAwait(false);
-		await output.FlushAsync(cancellationToken).ConfigureAwait(false);
 
 		return new TerminalSurfaceScope(output, mode);
 	}

--- a/src/Repl.Core/Terminal/TerminalSurfaceMode.cs
+++ b/src/Repl.Core/Terminal/TerminalSurfaceMode.cs
@@ -1,0 +1,7 @@
+namespace Repl.Terminal;
+
+internal enum TerminalSurfaceMode
+{
+	InlineRegion,
+	AlternateScreen,
+}

--- a/src/Repl.Core/Terminal/TerminalSurfaceScope.cs
+++ b/src/Repl.Core/Terminal/TerminalSurfaceScope.cs
@@ -1,0 +1,56 @@
+namespace Repl.Terminal;
+
+internal sealed class TerminalSurfaceScope(TextWriter output, TerminalSurfaceMode mode) : IAsyncDisposable
+{
+	private bool _disposed;
+
+	public TextWriter Output { get; } = output;
+
+	public TerminalSurfaceMode Mode { get; } = mode;
+
+	public ValueTask MoveHomeAsync() =>
+		WriteAsync(AnsiSequences.CursorHome);
+
+	public async ValueTask MoveCursorUpAsync(int rows)
+	{
+		if (rows <= 0)
+		{
+			return;
+		}
+
+		await Output.WriteAsync(AnsiSequences.CursorUp(rows)).ConfigureAwait(false);
+	}
+
+	public ValueTask MoveToColumnStartAsync() =>
+		WriteAsync('\r');
+
+	public ValueTask ClearToEndOfScreenAsync() =>
+		WriteAsync(AnsiSequences.ClearToEndOfScreen);
+
+	public ValueTask FlushAsync(CancellationToken cancellationToken) =>
+		new(Output.FlushAsync(cancellationToken));
+
+	public async ValueTask DisposeAsync()
+	{
+		if (_disposed)
+		{
+			return;
+		}
+
+		_disposed = true;
+		await Output.WriteAsync(AnsiSequences.EnableLineWrap).ConfigureAwait(false);
+		await Output.WriteAsync(AnsiSequences.ShowCursor).ConfigureAwait(false);
+		if (Mode == TerminalSurfaceMode.AlternateScreen)
+		{
+			await Output.WriteAsync(AnsiSequences.LeaveAlternateScreen).ConfigureAwait(false);
+		}
+
+		await Output.FlushAsync().ConfigureAwait(false);
+	}
+
+	private ValueTask WriteAsync(string value) =>
+		new(Output.WriteAsync(value));
+
+	private ValueTask WriteAsync(char value) =>
+		new(Output.WriteAsync(value));
+}

--- a/src/Repl.Core/Terminal/TerminalSurfaceScope.cs
+++ b/src/Repl.Core/Terminal/TerminalSurfaceScope.cs
@@ -38,14 +38,28 @@ internal sealed class TerminalSurfaceScope(TextWriter output, TerminalSurfaceMod
 		}
 
 		_disposed = true;
-		await Output.WriteAsync(AnsiSequences.EnableLineWrap).ConfigureAwait(false);
-		await Output.WriteAsync(AnsiSequences.ShowCursor).ConfigureAwait(false);
-		if (Mode == TerminalSurfaceMode.AlternateScreen)
+		await RestoreAsync(Output, Mode).ConfigureAwait(false);
+	}
+
+	internal static async ValueTask RestoreAsync(TextWriter output, TerminalSurfaceMode mode)
+	{
+		await TryWriteAsync(output, AnsiSequences.EnableLineWrap).ConfigureAwait(false);
+		await TryWriteAsync(output, AnsiSequences.ShowCursor).ConfigureAwait(false);
+		if (mode == TerminalSurfaceMode.AlternateScreen)
 		{
-			await Output.WriteAsync(AnsiSequences.LeaveAlternateScreen).ConfigureAwait(false);
+			await TryWriteAsync(output, AnsiSequences.LeaveAlternateScreen).ConfigureAwait(false);
 		}
 
-		await Output.FlushAsync().ConfigureAwait(false);
+		try
+		{
+			await output.FlushAsync().ConfigureAwait(false);
+		}
+		catch (IOException)
+		{
+		}
+		catch (ObjectDisposedException)
+		{
+		}
 	}
 
 	private ValueTask WriteAsync(string value) =>
@@ -53,4 +67,18 @@ internal sealed class TerminalSurfaceScope(TextWriter output, TerminalSurfaceMod
 
 	private ValueTask WriteAsync(char value) =>
 		new(Output.WriteAsync(value));
+
+	private static async ValueTask TryWriteAsync(TextWriter output, string value)
+	{
+		try
+		{
+			await output.WriteAsync(value).ConfigureAwait(false);
+		}
+		catch (IOException)
+		{
+		}
+		catch (ObjectDisposedException)
+		{
+		}
+	}
 }

--- a/src/Repl.Core/Terminal/TerminalSurfaceScope.cs
+++ b/src/Repl.Core/Terminal/TerminalSurfaceScope.cs
@@ -56,9 +56,11 @@ internal sealed class TerminalSurfaceScope(TextWriter output, TerminalSurfaceMod
 		}
 		catch (IOException)
 		{
+			// Best-effort terminal restore; output may be closed during process shutdown or pipe teardown.
 		}
 		catch (ObjectDisposedException)
 		{
+			// Best-effort terminal restore; output may already be disposed by the host.
 		}
 	}
 
@@ -76,9 +78,11 @@ internal sealed class TerminalSurfaceScope(TextWriter output, TerminalSurfaceMod
 		}
 		catch (IOException)
 		{
+			// Best-effort terminal write; output may be closed during process shutdown or pipe teardown.
 		}
 		catch (ObjectDisposedException)
 		{
+			// Best-effort terminal write; output may already be disposed by the host.
 		}
 	}
 }

--- a/src/Repl.Defaults/ReplApp.cs
+++ b/src/Repl.Defaults/ReplApp.cs
@@ -640,6 +640,10 @@ public sealed class ReplApp : IReplApp
 			external.GetService(typeof(TimeProvider)) as TimeProvider);
 		defaults[typeof(IReplInteractionChannel)] = channel;
 		defaults[typeof(IReplSessionInfo)] = new LiveSessionInfo();
+		if (EnsureSharedProvider().GetService<IReplResultFlowDiagnostics>() is { } diagnostics)
+		{
+			defaults[typeof(IReplResultFlowDiagnostics)] = diagnostics;
+		}
 
 		return new SessionOverlayServiceProvider(external, defaults);
 	}

--- a/src/Repl.IntegrationTests/Given_HelpDiscovery.cs
+++ b/src/Repl.IntegrationTests/Given_HelpDiscovery.cs
@@ -434,7 +434,7 @@ public sealed class Given_HelpDiscovery
 		output.Text.Should().Contain("--result:page-size <n>");
 		output.Text.Should().Contain("--result:cursor <value>");
 		output.Text.Should().Contain("--result:all");
-		output.Text.Should().Contain("--result:pager=auto|off|more|scroll|external");
+		output.Text.Should().Contain("--result:pager=auto|off|more|inline|full");
 	}
 
 	[TestMethod]

--- a/src/Repl.IntegrationTests/Given_HelpDiscovery.cs
+++ b/src/Repl.IntegrationTests/Given_HelpDiscovery.cs
@@ -531,8 +531,7 @@ public sealed class Given_HelpDiscovery
 					Cursor: request.Cursor,
 					NextCursor: null,
 					TotalCount: 0,
-					PageSize: request.PageSize,
-					HasMore: false)));
+					PageSize: request.PageSize)));
 	}
 
 	[TestMethod]

--- a/src/Repl.IntegrationTests/Given_HelpDiscovery.cs
+++ b/src/Repl.IntegrationTests/Given_HelpDiscovery.cs
@@ -7,6 +7,8 @@ namespace Repl.IntegrationTests;
 [DoNotParallelize]
 public sealed class Given_HelpDiscovery
 {
+	private static readonly string[] SingleResult = ["one"];
+
 	[TestMethod]
 	[Description("Regression guard: verifies requesting root help so that hidden commands are excluded.")]
 	public void When_RequestingRootHelp_Then_HiddenCommandsAreExcluded()
@@ -418,6 +420,85 @@ public sealed class Given_HelpDiscovery
 	}
 
 	[TestMethod]
+	[Description("Regression guard: verifies command help explains result-flow paging controls for paged handlers.")]
+	public void When_RequestingCommandHelpForPagedHandler_Then_ResultFlowOptionsAreShown()
+	{
+		var sut = ReplApp.Create();
+		sut.Map("activity", (IReplPagingContext paging) =>
+			paging.Page(["one"], nextCursor: "next", totalCount: 2));
+
+		var output = ConsoleCaptureHelper.Capture(() => sut.Run(["activity", "--help", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("Result Flow:");
+		output.Text.Should().Contain("--result:page-size <n>");
+		output.Text.Should().Contain("--result:cursor <value>");
+		output.Text.Should().Contain("--result:all");
+		output.Text.Should().Contain("--result:pager=auto|off|more|scroll|external");
+	}
+
+	[TestMethod]
+	[Description("Regression guard: verifies Spectre command help explains result-flow paging controls for paged handlers.")]
+	public void When_RequestingCommandHelpForPagedHandlerInSpectre_Then_ResultFlowOptionsAreShown()
+	{
+		var sut = ReplApp.Create(services => services.AddSpectreConsole())
+			.UseSpectreConsole();
+		sut.Map("activity", (IReplPagingContext paging) =>
+			paging.Page(["one"], nextCursor: "next", totalCount: 2));
+
+		var output = ConsoleCaptureHelper.Capture(() => sut.Run(["activity", "--help", "--spectre", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("Result Flow");
+		output.Text.Should().Contain("--result:page-size <n>");
+	}
+
+	[TestMethod]
+	[Description("Regression guard: verifies markdown command help explains result-flow paging controls for paged handlers.")]
+	public void When_RequestingCommandHelpForPagedHandlerInMarkdown_Then_ResultFlowOptionsAreShown()
+	{
+		var sut = ReplApp.Create();
+		sut.Map("activity", (IReplPagingContext paging) =>
+			paging.Page(["one"], nextCursor: "next", totalCount: 2));
+
+		var output = ConsoleCaptureHelper.Capture(() => sut.Run(["activity", "--help", "--markdown", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("# `activity`");
+		output.Text.Should().Contain("## Result Flow");
+		output.Text.Should().Contain("`--result:page-size <n>`");
+		output.Text.Should().NotContain("| Field | Value |");
+	}
+
+	[TestMethod]
+	[Description("Regression guard: verifies command help explains result-flow paging controls for page-source handlers.")]
+	public void When_RequestingCommandHelpForPageSourceHandler_Then_ResultFlowOptionsAreShown()
+	{
+		var sut = ReplApp.Create();
+		sut.Map("activity", () => new StaticPageSource<string>());
+
+		var output = ConsoleCaptureHelper.Capture(() => sut.Run(["activity", "--help", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("Result Flow:");
+		output.Text.Should().Contain("--result:page-size <n>");
+	}
+
+	[TestMethod]
+	[Description("Regression guard: verifies result-flow controls stay hidden for handlers that do not support paging.")]
+	public void When_RequestingCommandHelpForNonPagedHandler_Then_ResultFlowOptionsAreHidden()
+	{
+		var sut = ReplApp.Create();
+		sut.Map("list", () => SingleResult);
+
+		var output = ConsoleCaptureHelper.Capture(() => sut.Run(["list", "--help", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().NotContain("Result Flow:");
+		output.Text.Should().NotContain("--result:page-size <n>");
+	}
+
+	[TestMethod]
 	[Description("Regression guard: verifies injected global-options accessor parameters are omitted from command help.")]
 	public void When_RequestingCommandHelpWithGlobalOptionsAccessor_Then_AccessorIsNotListedAsCommandOption()
 	{
@@ -437,6 +518,21 @@ public sealed class Given_HelpDiscovery
 	{
 		Fast,
 		Slow,
+	}
+
+	private sealed class StaticPageSource<T> : IReplPageSource<T>
+	{
+		public ValueTask<ReplPage<T>> FetchAsync(
+			ReplPageRequest request,
+			CancellationToken cancellationToken = default) =>
+			ValueTask.FromResult(new ReplPage<T>(
+				[],
+				new ReplPageInfo(
+					Cursor: request.Cursor,
+					NextCursor: null,
+					TotalCount: 0,
+					PageSize: request.PageSize,
+					HasMore: false)));
 	}
 
 	[TestMethod]

--- a/src/Repl.IntegrationTests/Given_OutputFormatting.cs
+++ b/src/Repl.IntegrationTests/Given_OutputFormatting.cs
@@ -249,8 +249,7 @@ public sealed partial class Given_OutputFormatting
 						request.Cursor,
 						nextCursor,
 						contacts.Length,
-						request.PageSize,
-						nextCursor is not null)));
+						request.PageSize)));
 			}));
 
 		using var output = new StringWriter();

--- a/src/Repl.IntegrationTests/Given_OutputFormatting.cs
+++ b/src/Repl.IntegrationTests/Given_OutputFormatting.cs
@@ -197,6 +197,80 @@ public sealed class Given_OutputFormatting
 	}
 
 	[TestMethod]
+	[Description("Regression guard: verifies paged results render their current page and continuation hint in human output.")]
+	public void When_RenderingPagedResultInHuman_Then_ItemsAndContinuationAreRendered()
+	{
+		var sut = ReplApp.Create();
+		sut.Map("contact list", (IReplPagingContext paging) =>
+			paging.Page(
+				new[]
+				{
+					new ContactRow("Alice Martin", "alice@example.com"),
+					new ContactRow("Bob Tremblay", "bob@example.com"),
+				},
+				nextCursor: "page-2",
+				totalCount: 3));
+
+		var output = ConsoleCaptureHelper.Capture(() =>
+			sut.Run(["contact", "list", "--result:page-size=2", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("Alice Martin");
+		output.Text.Should().Contain("Bob Tremblay");
+		output.Text.Should().Contain("Showing 2 of 3.");
+		output.Text.Should().Contain("--result:cursor page-2");
+	}
+
+	[TestMethod]
+	[Description("Regression guard: verifies paged results serialize to a clean JSON envelope for automation.")]
+	public void When_RenderingPagedResultInJson_Then_ItemsAndPageInfoAreSerialized()
+	{
+		var sut = ReplApp.Create();
+		sut.Map("contact list", (IReplPagingContext paging) =>
+			paging.Page(
+				new[]
+				{
+					new Contact(1, "Alice"),
+				},
+				nextCursor: "page-2",
+				totalCount: 2));
+
+		var output = ConsoleCaptureHelper.Capture(() =>
+			sut.Run(["contact", "list", "--json", "--result:page-size=1", "--result:cursor=start", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("\"items\"");
+		output.Text.Should().Contain("\"pageInfo\"");
+		output.Text.Should().Contain("\"nextCursor\": \"page-2\"");
+		output.Text.Should().Contain("\"cursor\": \"start\"");
+		output.Text.Should().Contain("\"totalCount\": 2");
+		output.Text.Should().NotContain("itemType");
+		output.Text.Should().NotContain("untypedItems");
+	}
+
+	[TestMethod]
+	[Description("Regression guard: verifies paged results render their current page in markdown output.")]
+	public void When_RenderingPagedResultInMarkdown_Then_ItemsAndContinuationAreRendered()
+	{
+		var sut = ReplApp.Create();
+		sut.Map("contact list", (IReplPagingContext paging) =>
+			paging.Page(
+				new[]
+				{
+					new ContactMarkdownRow(1, "Alice Martin", "alice@example.com"),
+				},
+				nextCursor: "page-2"));
+
+		var output = ConsoleCaptureHelper.Capture(() =>
+			sut.Run(["contact", "list", "--markdown", "--result:page-size=1", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("| Id | Name | Email |");
+		output.Text.Should().Contain("| 1 | Alice Martin | alice@example.com |");
+		output.Text.Should().Contain("`--result:cursor page-2`");
+	}
+
+	[TestMethod]
 	[Description("Regression guard: verifies requesting unknown output format so that user gets a clear error and non-zero exit code.")]
 	public void When_RenderingWithUnknownFormat_Then_ClearErrorIsShownAndExitCodeIsNonZero()
 	{

--- a/src/Repl.IntegrationTests/Given_OutputFormatting.cs
+++ b/src/Repl.IntegrationTests/Given_OutputFormatting.cs
@@ -1,11 +1,12 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
 using Repl.Spectre;
 
 namespace Repl.IntegrationTests;
 
 [TestClass]
 [DoNotParallelize]
-public sealed class Given_OutputFormatting
+public sealed partial class Given_OutputFormatting
 {
 	[TestMethod]
 	[Description("Regression guard: verifies rendering human string result so that output contains raw text.")]
@@ -218,7 +219,53 @@ public sealed class Given_OutputFormatting
 		output.Text.Should().Contain("Alice Martin");
 		output.Text.Should().Contain("Bob Tremblay");
 		output.Text.Should().Contain("Showing 2 of 3.");
+		output.Text.Should().Contain("Next data page:");
 		output.Text.Should().Contain("--result:cursor page-2");
+	}
+
+	[TestMethod]
+	[Description("Regression guard: verifies human page sources continue interactively instead of asking users to rerun with a cursor.")]
+	public void When_RenderingPageSourceInHumanPager_Then_SpaceFetchesNextPageWithoutCursorRerun()
+	{
+		var sut = ReplApp.Create();
+		var fetchedCursors = new List<string?>();
+		var contacts = new[]
+		{
+			new ContactRow("Alice Martin", "alice@example.com"),
+			new ContactRow("Bob Tremblay", "bob@example.com"),
+		};
+
+		sut.Map("contact list", (IReplPagingContext paging) =>
+			paging.CreateSource<ContactRow>((request, _) =>
+			{
+				fetchedCursors.Add(request.Cursor);
+				var offset = string.Equals(request.Cursor, "1", StringComparison.Ordinal) ? 1 : 0;
+				var items = contacts.Skip(offset).Take(request.PageSize).ToArray();
+				var nextOffset = offset + items.Length;
+				var nextCursor = nextOffset < contacts.Length ? "1" : null;
+				return ValueTask.FromResult(new ReplPage<ContactRow>(
+					items,
+					new ReplPageInfo(
+						request.Cursor,
+						nextCursor,
+						contacts.Length,
+						request.PageSize,
+						nextCursor is not null)));
+			}));
+
+		using var output = new StringWriter();
+		using var session = ReplSessionIO.SetSession(output, TextReader.Null);
+		ReplSessionIO.KeyReader = new QueueKeyReader([Key(ConsoleKey.Spacebar, ' ')]);
+		ReplSessionIO.WindowSize = (100, 20);
+
+		var exitCode = sut.Run(["contact", "list", "--result:page-size=1", "--no-logo"]);
+
+		exitCode.Should().Be(0);
+		fetchedCursors.Should().Equal(null, "1");
+		var text = output.ToString();
+		text.Should().Contain("Alice Martin");
+		text.Should().Contain("Bob Tremblay");
+		text.Should().NotContain("rerun with --result:cursor");
 	}
 
 	[TestMethod]
@@ -531,7 +578,8 @@ public sealed class Given_OutputFormatting
 
 		var output = ConsoleCaptureHelper.Capture(() => sut.Run(["contact", "list", "--no-logo"]));
 		var lines = output.Text
-			.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+			.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+			.Select(StripAnsi);
 
 		output.ExitCode.Should().Be(0);
 		lines.Should().OnlyContain(line => line.Length <= width);
@@ -617,6 +665,29 @@ public sealed class Given_OutputFormatting
 				DescriptionStyle: "\u001b[33m");
 	}
 
+	private sealed class QueueKeyReader(IEnumerable<ConsoleKeyInfo> keys) : IReplKeyReader
+	{
+		private readonly Queue<ConsoleKeyInfo> _keys = new(keys);
+
+		public bool KeyAvailable => _keys.Count > 0;
+
+		public ValueTask<ConsoleKeyInfo> ReadKeyAsync(CancellationToken ct)
+		{
+			ct.ThrowIfCancellationRequested();
+			return _keys.TryDequeue(out var key)
+				? ValueTask.FromResult(key)
+				: throw new InvalidOperationException("No key available in QueueKeyReader.");
+		}
+	}
+
+	private static ConsoleKeyInfo Key(ConsoleKey key, char keyChar) =>
+		new(keyChar, key, shift: false, alt: false, control: false);
+
+	private static string StripAnsi(string value) =>
+		BuildAnsiEscapeRegex().Replace(value, string.Empty);
+
+	[GeneratedRegex(@"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", RegexOptions.None, matchTimeoutMilliseconds: 50)]
+	private static partial Regex BuildAnsiEscapeRegex();
 }
 
 

--- a/src/Repl.IntegrationTests/Given_OutputFormatting.cs
+++ b/src/Repl.IntegrationTests/Given_OutputFormatting.cs
@@ -539,6 +539,30 @@ public sealed class Given_OutputFormatting
 	}
 
 	[TestMethod]
+	[Description("Regression guard: verifies Spectre renders paged result pages with continuation metadata.")]
+	public void When_SpectreOutputAndPagedResult_Then_ItemsAndContinuationAreRendered()
+	{
+		var sut = ReplApp.Create(services => services.AddSpectreConsole())
+			.UseSpectreConsole();
+		sut.Map("contact list", (IReplPagingContext paging) =>
+			paging.Page(
+				new[]
+				{
+					new ContactRow("Alice Martin", "alice@example.com"),
+				},
+				nextCursor: "page-2",
+				totalCount: 2));
+
+		var output = ConsoleCaptureHelper.Capture(() =>
+			sut.Run(["contact", "list", "--result:page-size=1", "--no-logo"]));
+
+		output.ExitCode.Should().Be(0);
+		output.Text.Should().Contain("Alice Martin");
+		output.Text.Should().Contain("Showing 1 of 2.");
+		output.Text.Should().Contain("--result:cursor page-2");
+	}
+
+	[TestMethod]
 	[Description("Regression guard: verifies --human remains available even when Spectre is the default output format.")]
 	public void When_UsingHumanAliasWithSpectreDefault_Then_ClassicHumanTransformerIsUsed()
 	{

--- a/src/Repl.IntegrationTests/Given_OutputFormatting.cs
+++ b/src/Repl.IntegrationTests/Given_OutputFormatting.cs
@@ -270,6 +270,32 @@ public sealed partial class Given_OutputFormatting
 	}
 
 	[TestMethod]
+	[Description("Regression guard: verifies paging.CreateSource receives the caller cursor and suggested page size through the first source request.")]
+	public void When_PageSourceIsCreatedFromPagingContext_Then_FirstRequestUsesCurrentPagingIntent()
+	{
+		var sut = ReplApp.Create();
+		ReplPageRequest? capturedRequest = null;
+
+		sut.Map("contact list", (IReplPagingContext paging) =>
+			paging.CreateSource<ContactRow>((request, _) =>
+			{
+				capturedRequest = request;
+				return ValueTask.FromResult(request.Page(
+					[new ContactRow("Alice Martin", "alice@example.com")]));
+			}));
+
+		using var output = new StringWriter();
+		using var session = ReplSessionIO.SetSession(output, TextReader.Null);
+
+		var exitCode = sut.Run(["contact", "list", "--result:page-size=7", "--result:cursor=page-2", "--no-logo"]);
+
+		exitCode.Should().Be(0);
+		capturedRequest.Should().NotBeNull();
+		capturedRequest!.Cursor.Should().Be("page-2");
+		capturedRequest.PageSize.Should().Be(7);
+	}
+
+	[TestMethod]
 	[Description("Regression guard: verifies paged results serialize to a clean JSON envelope for automation.")]
 	public void When_RenderingPagedResultInJson_Then_ItemsAndPageInfoAreSerialized()
 	{

--- a/src/Repl.IntegrationTests/Given_OutputFormatting.cs
+++ b/src/Repl.IntegrationTests/Given_OutputFormatting.cs
@@ -265,6 +265,8 @@ public sealed partial class Given_OutputFormatting
 		text.Should().Contain("Alice Martin");
 		text.Should().Contain("Bob Tremblay");
 		text.Should().NotContain("rerun with --result:cursor");
+		text.Split("Name", StringSplitOptions.None).Should().HaveCount(2);
+		text.Should().NotContain("Showing ");
 	}
 
 	[TestMethod]

--- a/src/Repl.Logging/ReplLoggingServiceCollectionExtensions.cs
+++ b/src/Repl.Logging/ReplLoggingServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class ReplLoggingServiceCollectionExtensions
 
 		services.AddLogging();
 		services.TryAddSingleton<IReplLogContextAccessor, LiveReplLogContextAccessor>();
+		services.TryAddSingleton<IReplResultFlowDiagnostics, ReplResultFlowLoggerDiagnostics>();
 		return services;
 	}
 }

--- a/src/Repl.Logging/ReplResultFlowLoggerDiagnostics.cs
+++ b/src/Repl.Logging/ReplResultFlowLoggerDiagnostics.cs
@@ -3,27 +3,33 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Repl;
 
-internal sealed partial class ReplResultFlowLoggerDiagnostics(IServiceProvider services) : IReplResultFlowDiagnostics
+internal sealed partial class ReplResultFlowLoggerDiagnostics : IReplResultFlowDiagnostics
 {
 	private const string LoggerCategory = "Repl.ResultFlow";
+	private readonly ILogger _logger;
+
+	public ReplResultFlowLoggerDiagnostics(IServiceProvider services)
+	{
+		ArgumentNullException.ThrowIfNull(services);
+		var loggerFactory = services.GetService(typeof(ILoggerFactory)) as ILoggerFactory
+			?? NullLoggerFactory.Instance;
+		_logger = loggerFactory.CreateLogger(LoggerCategory);
+	}
 
 	public void OnDiagnostic(ReplResultFlowDiagnostic diagnostic)
 	{
 		ArgumentNullException.ThrowIfNull(diagnostic);
-		var loggerFactory = services.GetService(typeof(ILoggerFactory)) as ILoggerFactory
-			?? NullLoggerFactory.Instance;
-		var logger = loggerFactory.CreateLogger(LoggerCategory);
 
 		switch (diagnostic.Kind)
 		{
 			case ReplResultFlowDiagnosticKind.PageFetchStarting:
-				PageFetchStarting(logger, diagnostic.Cursor, diagnostic.PageSize);
+				PageFetchStarting(_logger, diagnostic.Cursor, diagnostic.PageSize);
 				break;
 			case ReplResultFlowDiagnosticKind.PageFetchSucceeded:
-				PageFetchSucceeded(logger, diagnostic.Cursor, diagnostic.PageSize, diagnostic.ItemCount ?? 0);
+				PageFetchSucceeded(_logger, diagnostic.Cursor, diagnostic.PageSize, diagnostic.ItemCount ?? 0);
 				break;
 			case ReplResultFlowDiagnosticKind.PageFetchFailed:
-				PageFetchFailed(logger, diagnostic.Exception, diagnostic.Cursor, diagnostic.PageSize);
+				PageFetchFailed(_logger, diagnostic.Exception, diagnostic.Cursor, diagnostic.PageSize);
 				break;
 		}
 	}

--- a/src/Repl.Logging/ReplResultFlowLoggerDiagnostics.cs
+++ b/src/Repl.Logging/ReplResultFlowLoggerDiagnostics.cs
@@ -40,6 +40,6 @@ internal sealed partial class ReplResultFlowLoggerDiagnostics : IReplResultFlowD
 	[LoggerMessage(EventId = 1002, Level = LogLevel.Debug, Message = "Result-flow page fetch succeeded. Cursor: {Cursor}; PageSize: {PageSize}; ItemCount: {ItemCount}.")]
 	private static partial void PageFetchSucceeded(ILogger logger, string? cursor, int pageSize, int itemCount);
 
-	[LoggerMessage(EventId = 1003, Level = LogLevel.Warning, Message = "Result-flow page fetch failed. Cursor: {Cursor}; PageSize: {PageSize}.")]
+	[LoggerMessage(EventId = 1003, Level = LogLevel.Error, Message = "Result-flow page fetch failed. Cursor: {Cursor}; PageSize: {PageSize}.")]
 	private static partial void PageFetchFailed(ILogger logger, Exception? exception, string? cursor, int pageSize);
 }

--- a/src/Repl.Logging/ReplResultFlowLoggerDiagnostics.cs
+++ b/src/Repl.Logging/ReplResultFlowLoggerDiagnostics.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Repl;
+
+internal sealed partial class ReplResultFlowLoggerDiagnostics(IServiceProvider services) : IReplResultFlowDiagnostics
+{
+	private const string LoggerCategory = "Repl.ResultFlow";
+
+	public void OnDiagnostic(ReplResultFlowDiagnostic diagnostic)
+	{
+		ArgumentNullException.ThrowIfNull(diagnostic);
+		var loggerFactory = services.GetService(typeof(ILoggerFactory)) as ILoggerFactory
+			?? NullLoggerFactory.Instance;
+		var logger = loggerFactory.CreateLogger(LoggerCategory);
+
+		switch (diagnostic.Kind)
+		{
+			case ReplResultFlowDiagnosticKind.PageFetchStarting:
+				PageFetchStarting(logger, diagnostic.Cursor, diagnostic.PageSize);
+				break;
+			case ReplResultFlowDiagnosticKind.PageFetchSucceeded:
+				PageFetchSucceeded(logger, diagnostic.Cursor, diagnostic.PageSize, diagnostic.ItemCount ?? 0);
+				break;
+			case ReplResultFlowDiagnosticKind.PageFetchFailed:
+				PageFetchFailed(logger, diagnostic.Exception, diagnostic.Cursor, diagnostic.PageSize);
+				break;
+		}
+	}
+
+	[LoggerMessage(EventId = 1001, Level = LogLevel.Debug, Message = "Result-flow page fetch starting. Cursor: {Cursor}; PageSize: {PageSize}.")]
+	private static partial void PageFetchStarting(ILogger logger, string? cursor, int pageSize);
+
+	[LoggerMessage(EventId = 1002, Level = LogLevel.Debug, Message = "Result-flow page fetch succeeded. Cursor: {Cursor}; PageSize: {PageSize}; ItemCount: {ItemCount}.")]
+	private static partial void PageFetchSucceeded(ILogger logger, string? cursor, int pageSize, int itemCount);
+
+	[LoggerMessage(EventId = 1003, Level = LogLevel.Warning, Message = "Result-flow page fetch failed. Cursor: {Cursor}; PageSize: {PageSize}.")]
+	private static partial void PageFetchFailed(ILogger logger, Exception? exception, string? cursor, int pageSize);
+}

--- a/src/Repl.Mcp/McpPagedResultTextMode.cs
+++ b/src/Repl.Mcp/McpPagedResultTextMode.cs
@@ -8,15 +8,15 @@ public enum McpPagedResultTextMode
 	/// <summary>
 	/// Emit compact serialized JSON in <c>Content</c> for MCP clients that ignore structured content.
 	/// </summary>
-	SerializedJson,
+	SerializedJson = 0,
 
 	/// <summary>
 	/// Emit only a short summary, minimizing token cost and keeping raw cursors out of text content.
 	/// </summary>
-	SummaryOnly,
+	SummaryOnly = 1,
 
 	/// <summary>
 	/// Emit a short summary followed by compact serialized JSON.
 	/// </summary>
-	SummaryAndSerializedJson,
+	SummaryAndSerializedJson = 2,
 }

--- a/src/Repl.Mcp/McpPagedResultTextMode.cs
+++ b/src/Repl.Mcp/McpPagedResultTextMode.cs
@@ -1,0 +1,22 @@
+namespace Repl.Mcp;
+
+/// <summary>
+/// Controls the text fallback emitted with structured MCP paged results.
+/// </summary>
+public enum McpPagedResultTextMode
+{
+	/// <summary>
+	/// Emit compact serialized JSON in <c>Content</c> for MCP clients that ignore structured content.
+	/// </summary>
+	SerializedJson,
+
+	/// <summary>
+	/// Emit only a short summary, minimizing token cost and keeping raw cursors out of text content.
+	/// </summary>
+	SummaryOnly,
+
+	/// <summary>
+	/// Emit a short summary followed by compact serialized JSON.
+	/// </summary>
+	SummaryAndSerializedJson,
+}

--- a/src/Repl.Mcp/McpResultFlowArgumentNames.cs
+++ b/src/Repl.Mcp/McpResultFlowArgumentNames.cs
@@ -1,0 +1,7 @@
+namespace Repl.Mcp;
+
+internal static class McpResultFlowArgumentNames
+{
+	public const string Cursor = "_replCursor";
+	public const string PageSize = "_replPageSize";
+}

--- a/src/Repl.Mcp/McpResultFlowArgumentNames.cs
+++ b/src/Repl.Mcp/McpResultFlowArgumentNames.cs
@@ -2,6 +2,6 @@ namespace Repl.Mcp;
 
 internal static class McpResultFlowArgumentNames
 {
-	public const string Cursor = "_replCursor";
-	public const string PageSize = "_replPageSize";
+	public const string Cursor = ReplResultFlowOptionNames.McpCursor;
+	public const string PageSize = ReplResultFlowOptionNames.McpPageSize;
 }

--- a/src/Repl.Mcp/McpSchemaGenerator.cs
+++ b/src/Repl.Mcp/McpSchemaGenerator.cs
@@ -103,30 +103,30 @@ internal static class McpSchemaGenerator
 			["type"] = "object",
 			["properties"] = new JsonObject
 			{
-				["$type"] = new JsonObject
+				[ReplPageWireNames.Type] = new JsonObject
 				{
 					["type"] = "string",
-					["const"] = "page",
+					["const"] = ReplPageWireNames.PageType,
 				},
-				["items"] = new JsonObject
+				[ReplPageWireNames.Items] = new JsonObject
 				{
 					["type"] = "array",
-					["items"] = new JsonObject(),
+					[ReplPageWireNames.Items] = new JsonObject(),
 				},
-				["pageInfo"] = new JsonObject
+				[ReplPageWireNames.PageInfo] = new JsonObject
 				{
 					["type"] = "object",
 					["properties"] = new JsonObject
 					{
-						["cursor"] = new JsonObject { ["type"] = "string" },
-						["nextCursor"] = new JsonObject { ["type"] = "string" },
-						["totalCount"] = new JsonObject { ["type"] = "integer" },
-						["pageSize"] = new JsonObject { ["type"] = "integer" },
-						["hasMore"] = new JsonObject { ["type"] = "boolean" },
+						[ReplPageWireNames.Cursor] = new JsonObject { ["type"] = "string" },
+						[ReplPageWireNames.NextCursor] = new JsonObject { ["type"] = "string" },
+						[ReplPageWireNames.TotalCount] = new JsonObject { ["type"] = "integer" },
+						[ReplPageWireNames.PageSize] = new JsonObject { ["type"] = "integer" },
+						[ReplPageWireNames.HasMore] = new JsonObject { ["type"] = "boolean" },
 					},
 				},
 			},
-			["required"] = new JsonArray(["$type", "items", "pageInfo"]),
+			["required"] = new JsonArray([ReplPageWireNames.Type, ReplPageWireNames.Items, ReplPageWireNames.PageInfo]),
 		};
 
 		return JsonSerializer.SerializeToElement(schema, McpJsonContext.Default.JsonObject);

--- a/src/Repl.Mcp/McpSchemaGenerator.cs
+++ b/src/Repl.Mcp/McpSchemaGenerator.cs
@@ -57,7 +57,10 @@ internal static class McpSchemaGenerator
 		}
 
 		AddAnswerProperties(command, properties);
-		AddResultFlowProperties(properties);
+		if (command.AcceptsPagingInput || command.EmitsPagedResult)
+		{
+			AddResultFlowProperties(properties);
+		}
 
 		var schema = new JsonObject
 		{
@@ -86,6 +89,47 @@ internal static class McpSchemaGenerator
 			["description"] = "Requested Repl page size for large tool results.",
 			["minimum"] = 1,
 		};
+	}
+
+	public static JsonElement? BuildOutputSchema(ReplDocCommand command)
+	{
+		if (!command.EmitsPagedResult)
+		{
+			return null;
+		}
+
+		var schema = new JsonObject
+		{
+			["type"] = "object",
+			["properties"] = new JsonObject
+			{
+				["$type"] = new JsonObject
+				{
+					["type"] = "string",
+					["const"] = "page",
+				},
+				["items"] = new JsonObject
+				{
+					["type"] = "array",
+					["items"] = new JsonObject(),
+				},
+				["pageInfo"] = new JsonObject
+				{
+					["type"] = "object",
+					["properties"] = new JsonObject
+					{
+						["cursor"] = new JsonObject { ["type"] = "string" },
+						["nextCursor"] = new JsonObject { ["type"] = "string" },
+						["totalCount"] = new JsonObject { ["type"] = "integer" },
+						["pageSize"] = new JsonObject { ["type"] = "integer" },
+						["hasMore"] = new JsonObject { ["type"] = "boolean" },
+					},
+				},
+			},
+			["required"] = new JsonArray(["$type", "items", "pageInfo"]),
+		};
+
+		return JsonSerializer.SerializeToElement(schema, McpJsonContext.Default.JsonObject);
 	}
 
 	private static void AddAnswerProperties(ReplDocCommand command, JsonObject properties)

--- a/src/Repl.Mcp/McpSchemaGenerator.cs
+++ b/src/Repl.Mcp/McpSchemaGenerator.cs
@@ -57,6 +57,7 @@ internal static class McpSchemaGenerator
 		}
 
 		AddAnswerProperties(command, properties);
+		AddResultFlowProperties(properties);
 
 		var schema = new JsonObject
 		{
@@ -70,6 +71,21 @@ internal static class McpSchemaGenerator
 		}
 
 		return JsonSerializer.SerializeToElement(schema, McpJsonContext.Default.JsonObject);
+	}
+
+	private static void AddResultFlowProperties(JsonObject properties)
+	{
+		properties[McpResultFlowArgumentNames.Cursor] = new JsonObject
+		{
+			["type"] = "string",
+			["description"] = "Opaque Repl continuation cursor returned by a previous paged tool result.",
+		};
+		properties[McpResultFlowArgumentNames.PageSize] = new JsonObject
+		{
+			["type"] = "integer",
+			["description"] = "Requested Repl page size for large tool results.",
+			["minimum"] = 1,
+		};
 	}
 
 	private static void AddAnswerProperties(ReplDocCommand command, JsonObject properties)

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -221,7 +221,7 @@ internal sealed partial class McpToolAdapter
 		return summary;
 	}
 
-	private static (List<string> Tokens, Dictionary<string, string> Prefills) PrepareExecution(
+	internal static (List<string> Tokens, Dictionary<string, string> Prefills) PrepareExecution(
 		string routePath,
 		IDictionary<string, JsonElement> arguments)
 	{
@@ -241,6 +241,7 @@ internal sealed partial class McpToolAdapter
 			}
 			else if (string.Equals(key, McpResultFlowArgumentNames.Cursor, StringComparison.Ordinal))
 			{
+				ValidateResultCursor(strValue);
 				resultFlowTokens.Add("--result:cursor");
 				resultFlowTokens.Add(strValue);
 			}
@@ -258,6 +259,24 @@ internal sealed partial class McpToolAdapter
 		var tokens = ReconstructTokens(routePath, stringArgs);
 		tokens.InsertRange(0, resultFlowTokens);
 		return (tokens, prefills);
+	}
+
+	private static void ValidateResultCursor(string cursor)
+	{
+		if (cursor.Length > 512)
+		{
+			throw new InvalidOperationException("The MCP result cursor cannot exceed 512 characters.");
+		}
+
+		if (cursor.Length > 0 && cursor[0] == '-')
+		{
+			throw new InvalidOperationException("The MCP result cursor cannot start like a CLI option.");
+		}
+
+		if (cursor.Any(char.IsWhiteSpace))
+		{
+			throw new InvalidOperationException("The MCP result cursor cannot contain whitespace.");
+		}
 	}
 
 	/// <summary>

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -180,6 +180,9 @@ internal sealed partial class McpToolAdapter
 			using var document = JsonDocument.Parse(output);
 			var root = document.RootElement;
 			if (root.ValueKind != JsonValueKind.Object
+				|| !root.TryGetProperty("$type", out var type)
+				|| type.ValueKind != JsonValueKind.String
+				|| !string.Equals(type.GetString(), "page", StringComparison.Ordinal)
 				|| !root.TryGetProperty("items", out var items)
 				|| items.ValueKind != JsonValueKind.Array
 				|| !root.TryGetProperty("pageInfo", out var pageInfo)
@@ -212,7 +215,7 @@ internal sealed partial class McpToolAdapter
 			&& nextCursor.ValueKind == JsonValueKind.String
 			&& !string.IsNullOrWhiteSpace(nextCursor.GetString()))
 		{
-			summary += $" Continue with {McpResultFlowArgumentNames.Cursor}={nextCursor.GetString()}.";
+			summary += $" Continue with {McpResultFlowArgumentNames.Cursor}; cursor available in structured content.";
 		}
 
 		return summary;

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -107,8 +107,8 @@ internal sealed partial class McpToolAdapter
 		ProgressToken? progressToken,
 		CancellationToken ct)
 	{
-		var coreApp = _app as CoreReplApp
-			?? throw new InvalidOperationException("MCP tool adapter requires CoreReplApp.");
+		var invocableApp = _app as ISubInvocableReplApp
+			?? throw new InvalidOperationException("MCP tool adapter requires an app that supports sub-invocation.");
 
 		var outputWriter = new StringWriter();
 		var inputReader = new StringReader(string.Empty);
@@ -136,7 +136,7 @@ internal sealed partial class McpToolAdapter
 			isHostedSession: true))
 		{
 			ReplSessionIO.IsProgrammatic = true;
-			var exitCode = await coreApp.RunSubInvocationAsync(
+			var exitCode = await invocableApp.RunSubInvocationAsync(
 				effectiveTokens.ToArray(), mcpServices, ct).ConfigureAwait(false);
 
 			var output = outputWriter.ToString().Trim();
@@ -191,12 +191,12 @@ internal sealed partial class McpToolAdapter
 			using var document = JsonDocument.Parse(output);
 			var root = document.RootElement;
 			if (root.ValueKind != JsonValueKind.Object
-				|| !root.TryGetProperty("$type", out var type)
+				|| !root.TryGetProperty(ReplPageWireNames.Type, out var type)
 				|| type.ValueKind != JsonValueKind.String
-				|| !string.Equals(type.GetString(), "page", StringComparison.Ordinal)
-				|| !root.TryGetProperty("items", out var items)
+				|| !string.Equals(type.GetString(), ReplPageWireNames.PageType, StringComparison.Ordinal)
+				|| !root.TryGetProperty(ReplPageWireNames.Items, out var items)
 				|| items.ValueKind != JsonValueKind.Array
-				|| !root.TryGetProperty("pageInfo", out var pageInfo)
+				|| !root.TryGetProperty(ReplPageWireNames.PageInfo, out var pageInfo)
 				|| pageInfo.ValueKind != JsonValueKind.Object)
 			{
 				return false;
@@ -215,14 +215,14 @@ internal sealed partial class McpToolAdapter
 	private static string BuildPagedSummary(int count, JsonElement pageInfo)
 	{
 		var summary = $"Returned {count.ToString(System.Globalization.CultureInfo.InvariantCulture)} item(s).";
-		if (pageInfo.TryGetProperty("totalCount", out var totalCount)
+		if (pageInfo.TryGetProperty(ReplPageWireNames.TotalCount, out var totalCount)
 			&& totalCount.ValueKind == JsonValueKind.Number
 			&& totalCount.TryGetInt64(out var total))
 		{
 			summary += $" Total: {total.ToString(System.Globalization.CultureInfo.InvariantCulture)}.";
 		}
 
-		if (pageInfo.TryGetProperty("nextCursor", out var nextCursor)
+		if (pageInfo.TryGetProperty(ReplPageWireNames.NextCursor, out var nextCursor)
 			&& nextCursor.ValueKind == JsonValueKind.String
 			&& !string.IsNullOrWhiteSpace(nextCursor.GetString()))
 		{
@@ -239,11 +239,6 @@ internal sealed partial class McpToolAdapter
 		var allowedArgumentNames = BuildAllowedArgumentNames(command);
 		return PrepareExecution(command.Path, arguments, allowedArgumentNames);
 	}
-
-	internal static (List<string> Tokens, Dictionary<string, string> Prefills) PrepareExecution(
-		string routePath,
-		IDictionary<string, JsonElement> arguments)
-		=> PrepareExecution(routePath, arguments, allowedArgumentNames: null);
 
 	private static (List<string> Tokens, Dictionary<string, string> Prefills) PrepareExecution(
 		string routePath,
@@ -270,13 +265,13 @@ internal sealed partial class McpToolAdapter
 			{
 				prefills[key["answer.".Length..]] = strValue;
 			}
-			else if (string.Equals(key, McpResultFlowArgumentNames.Cursor, StringComparison.Ordinal))
+			else if (string.Equals(key, McpResultFlowArgumentNames.Cursor, StringComparison.OrdinalIgnoreCase))
 			{
 				ValidateResultCursor(strValue);
 				resultFlowTokens.Add(ReplResultFlowOptionNames.Cursor);
 				resultFlowTokens.Add(strValue);
 			}
-			else if (string.Equals(key, McpResultFlowArgumentNames.PageSize, StringComparison.Ordinal))
+			else if (string.Equals(key, McpResultFlowArgumentNames.PageSize, StringComparison.OrdinalIgnoreCase))
 			{
 				ValidateResultPageSize(strValue);
 				resultFlowTokens.Add(ReplResultFlowOptionNames.PageSize);
@@ -304,7 +299,7 @@ internal sealed partial class McpToolAdapter
 			throw new InvalidOperationException("The MCP result page size cannot exceed 10 characters.");
 		}
 
-		if (pageSize.Length == 0 || ContainsNonDigit(pageSize))
+		if (pageSize.Length == 0 || pageSize.AsSpan().IndexOfAnyExceptInRange('0', '9') >= 0)
 		{
 			throw new InvalidOperationException("The MCP result page size must be numeric.");
 		}
@@ -314,19 +309,6 @@ internal sealed partial class McpToolAdapter
 		{
 			throw new InvalidOperationException("The MCP result page size must fit in a positive 32-bit integer.");
 		}
-	}
-
-	private static bool ContainsNonDigit(string value)
-	{
-		foreach (var c in value)
-		{
-			if (c < '0' || c > '9')
-			{
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	private static void ValidateCommandArgumentValue(string value)

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -247,6 +247,7 @@ internal sealed partial class McpToolAdapter
 			}
 			else if (string.Equals(key, McpResultFlowArgumentNames.PageSize, StringComparison.Ordinal))
 			{
+				ValidateResultPageSize(strValue);
 				resultFlowTokens.Add("--result:page-size");
 				resultFlowTokens.Add(strValue);
 			}
@@ -276,6 +277,19 @@ internal sealed partial class McpToolAdapter
 		if (cursor.Any(char.IsWhiteSpace))
 		{
 			throw new InvalidOperationException("The MCP result cursor cannot contain whitespace.");
+		}
+	}
+
+	private static void ValidateResultPageSize(string pageSize)
+	{
+		if (pageSize.Length > 20)
+		{
+			throw new InvalidOperationException("The MCP result page size cannot exceed 20 characters.");
+		}
+
+		if (pageSize.Length == 0 || pageSize.Any(static c => c < '0' || c > '9'))
+		{
+			throw new InvalidOperationException("The MCP result page size must be numeric.");
 		}
 	}
 

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -145,12 +145,77 @@ internal sealed partial class McpToolAdapter
 				output = exitCode == 0 ? "OK" : $"Command failed with exit code {exitCode}.";
 			}
 
+			return BuildToolResult(output, exitCode);
+		}
+	}
+
+	private static CallToolResult BuildToolResult(string output, int exitCode)
+	{
+		if (exitCode == 0 && TryCreatePagedStructuredResult(output, out var structuredContent, out var summary))
+		{
 			return new CallToolResult
 			{
-				Content = [new TextContentBlock { Text = output }],
-				IsError = exitCode != 0,
+				Content = [new TextContentBlock { Text = summary }],
+				StructuredContent = structuredContent,
+				IsError = false,
 			};
 		}
+
+		return new CallToolResult
+		{
+			Content = [new TextContentBlock { Text = output }],
+			IsError = exitCode != 0,
+		};
+	}
+
+	private static bool TryCreatePagedStructuredResult(
+		string output,
+		out JsonElement structuredContent,
+		out string summary)
+	{
+		structuredContent = default;
+		summary = string.Empty;
+		try
+		{
+			using var document = JsonDocument.Parse(output);
+			var root = document.RootElement;
+			if (root.ValueKind != JsonValueKind.Object
+				|| !root.TryGetProperty("items", out var items)
+				|| items.ValueKind != JsonValueKind.Array
+				|| !root.TryGetProperty("pageInfo", out var pageInfo)
+				|| pageInfo.ValueKind != JsonValueKind.Object)
+			{
+				return false;
+			}
+
+			structuredContent = root.Clone();
+			summary = BuildPagedSummary(items.GetArrayLength(), pageInfo);
+			return true;
+		}
+		catch (JsonException)
+		{
+			return false;
+		}
+	}
+
+	private static string BuildPagedSummary(int count, JsonElement pageInfo)
+	{
+		var summary = $"Returned {count.ToString(System.Globalization.CultureInfo.InvariantCulture)} item(s).";
+		if (pageInfo.TryGetProperty("totalCount", out var totalCount)
+			&& totalCount.ValueKind == JsonValueKind.Number
+			&& totalCount.TryGetInt64(out var total))
+		{
+			summary += $" Total: {total.ToString(System.Globalization.CultureInfo.InvariantCulture)}.";
+		}
+
+		if (pageInfo.TryGetProperty("nextCursor", out var nextCursor)
+			&& nextCursor.ValueKind == JsonValueKind.String
+			&& !string.IsNullOrWhiteSpace(nextCursor.GetString()))
+		{
+			summary += $" Continue with {McpResultFlowArgumentNames.Cursor}={nextCursor.GetString()}.";
+		}
+
+		return summary;
 	}
 
 	private static (List<string> Tokens, Dictionary<string, string> Prefills) PrepareExecution(
@@ -159,6 +224,7 @@ internal sealed partial class McpToolAdapter
 	{
 		var stringArgs = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
 		var prefills = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		var resultFlowTokens = new List<string>();
 
 		foreach (var (key, value) in arguments)
 		{
@@ -170,13 +236,25 @@ internal sealed partial class McpToolAdapter
 			{
 				prefills[key["answer.".Length..]] = strValue;
 			}
+			else if (string.Equals(key, McpResultFlowArgumentNames.Cursor, StringComparison.Ordinal))
+			{
+				resultFlowTokens.Add("--result:cursor");
+				resultFlowTokens.Add(strValue);
+			}
+			else if (string.Equals(key, McpResultFlowArgumentNames.PageSize, StringComparison.Ordinal))
+			{
+				resultFlowTokens.Add("--result:page-size");
+				resultFlowTokens.Add(strValue);
+			}
 			else
 			{
 				stringArgs[key] = strValue;
 			}
 		}
 
-		return (ReconstructTokens(routePath, stringArgs), prefills);
+		var tokens = ReconstructTokens(routePath, stringArgs);
+		tokens.InsertRange(0, resultFlowTokens);
+		return (tokens, prefills);
 	}
 
 	/// <summary>

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -242,13 +242,13 @@ internal sealed partial class McpToolAdapter
 			else if (string.Equals(key, McpResultFlowArgumentNames.Cursor, StringComparison.Ordinal))
 			{
 				ValidateResultCursor(strValue);
-				resultFlowTokens.Add("--result:cursor");
+				resultFlowTokens.Add(ReplResultFlowOptionNames.Cursor);
 				resultFlowTokens.Add(strValue);
 			}
 			else if (string.Equals(key, McpResultFlowArgumentNames.PageSize, StringComparison.Ordinal))
 			{
 				ValidateResultPageSize(strValue);
-				resultFlowTokens.Add("--result:page-size");
+				resultFlowTokens.Add(ReplResultFlowOptionNames.PageSize);
 				resultFlowTokens.Add(strValue);
 			}
 			else

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -145,17 +145,17 @@ internal sealed partial class McpToolAdapter
 				output = exitCode == 0 ? "OK" : $"Command failed with exit code {exitCode}.";
 			}
 
-			return BuildToolResult(output, exitCode);
+			return BuildToolResult(output, exitCode, _options.PagedResultTextMode);
 		}
 	}
 
-	private static CallToolResult BuildToolResult(string output, int exitCode)
+	private static CallToolResult BuildToolResult(string output, int exitCode, McpPagedResultTextMode pagedTextMode)
 	{
 		if (exitCode == 0 && TryCreatePagedStructuredResult(output, out var structuredContent, out var summary))
 		{
 			return new CallToolResult
 			{
-				Content = [new TextContentBlock { Text = summary }],
+				Content = [new TextContentBlock { Text = BuildPagedTextContent(output, summary, pagedTextMode) }],
 				StructuredContent = structuredContent,
 				IsError = false,
 			};
@@ -167,6 +167,17 @@ internal sealed partial class McpToolAdapter
 			IsError = exitCode != 0,
 		};
 	}
+
+	private static string BuildPagedTextContent(
+		string serializedPage,
+		string summary,
+		McpPagedResultTextMode mode) =>
+		mode switch
+		{
+			McpPagedResultTextMode.SummaryOnly => summary,
+			McpPagedResultTextMode.SummaryAndSerializedJson => string.Concat(summary, Environment.NewLine, serializedPage),
+			_ => serializedPage,
+		};
 
 	private static bool TryCreatePagedStructuredResult(
 		string output,
@@ -249,6 +260,12 @@ internal sealed partial class McpToolAdapter
 				? value.GetString() ?? ""
 				: value.GetRawText();
 
+			if (allowedArgumentNames is not null && !allowedArgumentNames.Contains(key))
+			{
+				throw new InvalidOperationException(
+					$"The MCP argument '{key}' is not defined by the tool schema.");
+			}
+
 			if (key.StartsWith("answer.", StringComparison.OrdinalIgnoreCase))
 			{
 				prefills[key["answer.".Length..]] = strValue;
@@ -267,12 +284,7 @@ internal sealed partial class McpToolAdapter
 			}
 			else
 			{
-				if (allowedArgumentNames is not null && !allowedArgumentNames.Contains(key))
-				{
-					throw new InvalidOperationException(
-						$"The MCP argument '{key}' is not defined by the tool schema.");
-				}
-
+				ValidateCommandArgumentValue(strValue);
 				stringArgs[key] = strValue;
 			}
 		}
@@ -292,7 +304,7 @@ internal sealed partial class McpToolAdapter
 			throw new InvalidOperationException("The MCP result page size cannot exceed 10 characters.");
 		}
 
-		if (pageSize.Length == 0 || pageSize.Any(static c => c < '0' || c > '9'))
+		if (pageSize.Length == 0 || ContainsNonDigit(pageSize))
 		{
 			throw new InvalidOperationException("The MCP result page size must be numeric.");
 		}
@@ -301,6 +313,27 @@ internal sealed partial class McpToolAdapter
 			|| value <= 0)
 		{
 			throw new InvalidOperationException("The MCP result page size must fit in a positive 32-bit integer.");
+		}
+	}
+
+	private static bool ContainsNonDigit(string value)
+	{
+		foreach (var c in value)
+		{
+			if (c < '0' || c > '9')
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static void ValidateCommandArgumentValue(string value)
+	{
+		if (value.StartsWith("--", StringComparison.Ordinal))
+		{
+			throw new InvalidOperationException("The MCP argument value cannot start like a CLI option.");
 		}
 	}
 
@@ -325,8 +358,12 @@ internal sealed partial class McpToolAdapter
 			}
 		}
 
-		names.Add(McpResultFlowArgumentNames.Cursor);
-		names.Add(McpResultFlowArgumentNames.PageSize);
+		if (command.AcceptsPagingInput || command.EmitsPagedResult)
+		{
+			names.Add(McpResultFlowArgumentNames.Cursor);
+			names.Add(McpResultFlowArgumentNames.PageSize);
+		}
+
 		return names;
 	}
 

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -263,22 +263,7 @@ internal sealed partial class McpToolAdapter
 	}
 
 	private static void ValidateResultCursor(string cursor)
-	{
-		if (cursor.Length > 512)
-		{
-			throw new InvalidOperationException("The MCP result cursor cannot exceed 512 characters.");
-		}
-
-		if (cursor.Length > 0 && cursor[0] == '-')
-		{
-			throw new InvalidOperationException("The MCP result cursor cannot start like a CLI option.");
-		}
-
-		if (cursor.Any(char.IsWhiteSpace))
-		{
-			throw new InvalidOperationException("The MCP result cursor cannot contain whitespace.");
-		}
-	}
+		=> ResultFlowCursorPolicy.ValidateOrThrow(cursor);
 
 	private static void ValidateResultPageSize(string pageSize)
 	{

--- a/src/Repl.Mcp/McpToolAdapter.cs
+++ b/src/Repl.Mcp/McpToolAdapter.cs
@@ -95,7 +95,7 @@ internal sealed partial class McpToolAdapter
 			return ErrorResult($"Unknown tool: {toolName}");
 		}
 
-		var (tokens, prefills) = PrepareExecution(command.Path, arguments);
+		var (tokens, prefills) = PrepareExecution(command, arguments);
 		return await ExecuteThroughPipelineAsync(tokens, prefills, server, progressToken, ct)
 			.ConfigureAwait(false);
 	}
@@ -222,8 +222,22 @@ internal sealed partial class McpToolAdapter
 	}
 
 	internal static (List<string> Tokens, Dictionary<string, string> Prefills) PrepareExecution(
+		ReplDocCommand command,
+		IDictionary<string, JsonElement> arguments)
+	{
+		var allowedArgumentNames = BuildAllowedArgumentNames(command);
+		return PrepareExecution(command.Path, arguments, allowedArgumentNames);
+	}
+
+	internal static (List<string> Tokens, Dictionary<string, string> Prefills) PrepareExecution(
 		string routePath,
 		IDictionary<string, JsonElement> arguments)
+		=> PrepareExecution(routePath, arguments, allowedArgumentNames: null);
+
+	private static (List<string> Tokens, Dictionary<string, string> Prefills) PrepareExecution(
+		string routePath,
+		IDictionary<string, JsonElement> arguments,
+		HashSet<string>? allowedArgumentNames)
 	{
 		var stringArgs = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
 		var prefills = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -253,6 +267,12 @@ internal sealed partial class McpToolAdapter
 			}
 			else
 			{
+				if (allowedArgumentNames is not null && !allowedArgumentNames.Contains(key))
+				{
+					throw new InvalidOperationException(
+						$"The MCP argument '{key}' is not defined by the tool schema.");
+				}
+
 				stringArgs[key] = strValue;
 			}
 		}
@@ -267,15 +287,47 @@ internal sealed partial class McpToolAdapter
 
 	private static void ValidateResultPageSize(string pageSize)
 	{
-		if (pageSize.Length > 20)
+		if (pageSize.Length > 10)
 		{
-			throw new InvalidOperationException("The MCP result page size cannot exceed 20 characters.");
+			throw new InvalidOperationException("The MCP result page size cannot exceed 10 characters.");
 		}
 
 		if (pageSize.Length == 0 || pageSize.Any(static c => c < '0' || c > '9'))
 		{
 			throw new InvalidOperationException("The MCP result page size must be numeric.");
 		}
+
+		if (!int.TryParse(pageSize, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var value)
+			|| value <= 0)
+		{
+			throw new InvalidOperationException("The MCP result page size must fit in a positive 32-bit integer.");
+		}
+	}
+
+	private static HashSet<string> BuildAllowedArgumentNames(ReplDocCommand command)
+	{
+		var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var argument in command.Arguments)
+		{
+			names.Add(argument.Name);
+		}
+
+		foreach (var option in command.Options)
+		{
+			names.Add(option.Name);
+		}
+
+		if (command.Answers is { Count: > 0 })
+		{
+			foreach (var answer in command.Answers)
+			{
+				names.Add($"answer.{answer.Name}");
+			}
+		}
+
+		names.Add(McpResultFlowArgumentNames.Cursor);
+		names.Add(McpResultFlowArgumentNames.PageSize);
+		return names;
 	}
 
 	/// <summary>

--- a/src/Repl.Mcp/ReplMcpServerOptions.cs
+++ b/src/Repl.Mcp/ReplMcpServerOptions.cs
@@ -53,6 +53,11 @@ public sealed class ReplMcpServerOptions
 	public InteractivityMode InteractivityMode { get; set; } = InteractivityMode.PrefillThenFail;
 
 	/// <summary>
+	/// Controls the text fallback emitted alongside structured paged tool results.
+	/// </summary>
+	public McpPagedResultTextMode PagedResultTextMode { get; set; } = McpPagedResultTextMode.SerializedJson;
+
+	/// <summary>
 	/// Optional filter controlling which commands are exposed as MCP tools.
 	/// When <c>null</c>, all non-hidden, non-<see cref="CommandAnnotations.AutomationHidden"/> commands are exposed.
 	/// </summary>

--- a/src/Repl.Mcp/ReplMcpServerTool.cs
+++ b/src/Repl.Mcp/ReplMcpServerTool.cs
@@ -29,6 +29,7 @@ internal sealed class ReplMcpServerTool : McpServerTool
 			Name = toolName,
 			Description = McpSchemaGenerator.BuildDescription(command),
 			InputSchema = McpSchemaGenerator.BuildInputSchema(command),
+			OutputSchema = McpSchemaGenerator.BuildOutputSchema(command),
 			Annotations = McpSchemaGenerator.MapAnnotations(command.Annotations),
 			Execution = command.Annotations?.LongRunning == true
 				? new ToolExecution { TaskSupport = ToolTaskSupport.Optional }

--- a/src/Repl.Mcp/ReplPageWireNames.cs
+++ b/src/Repl.Mcp/ReplPageWireNames.cs
@@ -1,0 +1,14 @@
+namespace Repl.Mcp;
+
+internal static class ReplPageWireNames
+{
+	public const string Type = "$type";
+	public const string PageType = "page";
+	public const string Items = "items";
+	public const string PageInfo = "pageInfo";
+	public const string Cursor = "cursor";
+	public const string NextCursor = "nextCursor";
+	public const string TotalCount = "totalCount";
+	public const string PageSize = "pageSize";
+	public const string HasMore = "hasMore";
+}

--- a/src/Repl.McpTests/Given_McpSchemaGenerator.cs
+++ b/src/Repl.McpTests/Given_McpSchemaGenerator.cs
@@ -134,6 +134,56 @@ public sealed class Given_McpSchemaGenerator
 		prop.GetProperty("description").GetString().Should().Be("Contact name");
 	}
 
+	[TestMethod]
+	[Description("Paged commands expose result-flow continuation inputs.")]
+	public void When_CommandUsesResultFlow_Then_InputSchemaContainsContinuationInputs()
+	{
+		var cmd = CreateCommand(usesResultFlow: true);
+
+		var schema = McpSchemaGenerator.BuildInputSchema(cmd);
+		var properties = schema.GetProperty("properties");
+
+		properties.TryGetProperty("_replCursor", out _).Should().BeTrue();
+		properties.TryGetProperty("_replPageSize", out _).Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("Non-paged commands do not expose result-flow continuation inputs.")]
+	public void When_CommandDoesNotUseResultFlow_Then_InputSchemaDoesNotContainContinuationInputs()
+	{
+		var cmd = CreateCommand(usesResultFlow: false);
+
+		var schema = McpSchemaGenerator.BuildInputSchema(cmd);
+		var properties = schema.GetProperty("properties");
+
+		properties.TryGetProperty("_replCursor", out _).Should().BeFalse();
+		properties.TryGetProperty("_replPageSize", out _).Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("Paged commands expose an output schema for structured page results.")]
+	public void When_CommandEmitsPagedResult_Then_OutputSchemaContainsPageEnvelope()
+	{
+		var cmd = CreateCommand(emitsPagedResult: true);
+
+		var schema = McpSchemaGenerator.BuildOutputSchema(cmd);
+
+		schema.Should().NotBeNull();
+		schema!.Value.GetProperty("properties").GetProperty("$type").GetProperty("const").GetString()
+			.Should().Be("page");
+		schema.Value.GetProperty("properties").TryGetProperty("items", out _).Should().BeTrue();
+		schema.Value.GetProperty("properties").TryGetProperty("pageInfo", out _).Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("Non-paged commands do not expose a result-flow output schema.")]
+	public void When_CommandDoesNotEmitPagedResult_Then_OutputSchemaIsNull()
+	{
+		var cmd = CreateCommand(emitsPagedResult: false);
+
+		McpSchemaGenerator.BuildOutputSchema(cmd).Should().BeNull();
+	}
+
 	// ── Annotation mapping ─────────────────────────────────────────────
 
 	[TestMethod]
@@ -208,7 +258,9 @@ public sealed class Given_McpSchemaGenerator
 		string? description = null,
 		string? details = null,
 		ReplDocArgument[]? arguments = null,
-		ReplDocOption[]? options = null) =>
+		ReplDocOption[]? options = null,
+		bool usesResultFlow = false,
+		bool emitsPagedResult = false) =>
 		new(
 			Path: path,
 			Description: description,
@@ -216,7 +268,14 @@ public sealed class Given_McpSchemaGenerator
 			IsHidden: false,
 			Arguments: arguments ?? [],
 			Options: options ?? [],
-			Details: details);
+			Details: details,
+			AcceptsPagingInput: usesResultFlow,
+			EmitsPagedResult: emitsPagedResult,
+			Metadata: new Dictionary<string, object>(StringComparer.Ordinal)
+			{
+				["ResultFlow.AcceptsPagingInput"] = usesResultFlow,
+				["ResultFlow.EmitsPagedResult"] = emitsPagedResult,
+			});
 
 	private static ReplDocOption CreateOption(
 		string name,

--- a/src/Repl.McpTests/Given_McpSchemaGenerator.cs
+++ b/src/Repl.McpTests/Given_McpSchemaGenerator.cs
@@ -169,10 +169,11 @@ public sealed class Given_McpSchemaGenerator
 		var schema = McpSchemaGenerator.BuildOutputSchema(cmd);
 
 		schema.Should().NotBeNull();
-		schema!.Value.GetProperty("properties").GetProperty("$type").GetProperty("const").GetString()
+		var schemaValue = schema!.Value;
+		schemaValue.GetProperty("properties").GetProperty("$type").GetProperty("const").GetString()
 			.Should().Be("page");
-		schema.Value.GetProperty("properties").TryGetProperty("items", out _).Should().BeTrue();
-		schema.Value.GetProperty("properties").TryGetProperty("pageInfo", out _).Should().BeTrue();
+		schemaValue.GetProperty("properties").TryGetProperty("items", out _).Should().BeTrue();
+		schemaValue.GetProperty("properties").TryGetProperty("pageInfo", out _).Should().BeTrue();
 	}
 
 	[TestMethod]

--- a/src/Repl.McpTests/Given_McpServerEndToEnd.cs
+++ b/src/Repl.McpTests/Given_McpServerEndToEnd.cs
@@ -113,7 +113,70 @@ public sealed class Given_McpServerEndToEnd
 		var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text;
 		text.Should().NotBeNull();
 		text!.Should().Contain("Returned 1 item(s).");
-		text.Should().Contain("_replCursor=page-2");
+		text.Should().Contain("cursor available");
+		text.Should().NotContain("page-2");
+	}
+
+	[TestMethod]
+	[Description("tools/call does not treat arbitrary JSON objects with items and pageInfo properties as paged results.")]
+	public async Task When_ToolsCallReturnsPageShapedObject_Then_ResultIsPlainText()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(app =>
+		{
+			app.Map(
+					"shape",
+					() => new
+					{
+						Items = PageShapedItems,
+						PageInfo = new { NextCursor = "raw-cursor" },
+					})
+				.ReadOnly();
+		});
+
+		var result = await fixture.Client.CallToolAsync(
+			"shape",
+			new Dictionary<string, object?>(StringComparer.Ordinal));
+
+		result.StructuredContent.Should().BeNull();
+		result.Content.OfType<TextContentBlock>().Single().Text.Should().Contain("not-a-page");
+	}
+
+	[TestMethod]
+	[Description("tools/call returns page-source results as structured pages and consumes MCP cursor arguments.")]
+	public async Task When_ToolsCallReturnsPageSource_Then_CursorFetchesNextPage()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(app =>
+		{
+			app.Map("contacts", () => ReplPageSource.FromItems(
+				[
+					new ContactDto(1, "Alice"),
+					new ContactDto(2, "Bob"),
+				]))
+				.ReadOnly();
+		});
+
+		var first = await fixture.Client.CallToolAsync(
+			"contacts",
+			new Dictionary<string, object?>(StringComparer.Ordinal)
+			{
+				["_replPageSize"] = 1,
+			});
+		var firstRoot = first.StructuredContent!.Value;
+		var nextCursor = firstRoot.GetProperty("pageInfo").GetProperty("nextCursor").GetString();
+
+		var second = await fixture.Client.CallToolAsync(
+			"contacts",
+			new Dictionary<string, object?>(StringComparer.Ordinal)
+			{
+				["_replPageSize"] = 1,
+				["_replCursor"] = nextCursor,
+			});
+
+		second.IsError.Should().NotBeTrue();
+		var secondRoot = second.StructuredContent!.Value;
+		secondRoot.GetProperty("items")[0].GetProperty("name").GetString().Should().Be("Bob");
+		secondRoot.GetProperty("pageInfo").GetProperty("cursor").GetString().Should().Be(nextCursor);
+		secondRoot.GetProperty("pageInfo").GetProperty("hasMore").GetBoolean().Should().BeFalse();
 	}
 
 	[TestMethod]
@@ -347,6 +410,8 @@ public sealed class Given_McpServerEndToEnd
 	private sealed class AnotherService;
 
 	private sealed record ContactDto(int Id, string Name);
+
+	private static readonly string[] PageShapedItems = ["not-a-page"];
 
 	// ── Prompts ────────────────────────────────────────────────────────
 

--- a/src/Repl.McpTests/Given_McpServerEndToEnd.cs
+++ b/src/Repl.McpTests/Given_McpServerEndToEnd.cs
@@ -51,6 +51,10 @@ public sealed class Given_McpServerEndToEnd
 			.Should().Be("string");
 		schema.GetProperty("properties").GetProperty("id").GetProperty("format").GetString()
 			.Should().Be("uuid");
+		schema.GetProperty("properties").TryGetProperty("_replCursor", out _)
+			.Should().BeTrue("MCP tools should expose Repl continuation cursors for paged data");
+		schema.GetProperty("properties").TryGetProperty("_replPageSize", out _)
+			.Should().BeTrue("MCP tools should expose Repl page sizing for large data");
 		schema.GetProperty("required")[0].GetString()
 			.Should().Be("id");
 	}
@@ -72,6 +76,44 @@ public sealed class Given_McpServerEndToEnd
 		var textBlock = result.Content.OfType<TextContentBlock>().FirstOrDefault();
 		textBlock.Should().NotBeNull("the tool call should produce text content");
 		textBlock!.Text.Should().Contain("Hello, Alice!");
+	}
+
+	[TestMethod]
+	[Description("tools/call returns paged results as structured content with a continuation summary.")]
+	public async Task When_ToolsCallReturnsPagedResult_Then_StructuredContentContainsPageInfo()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(app =>
+		{
+			app.Map("contacts", (IReplPagingContext paging) =>
+				paging.Page(
+					new[]
+					{
+						new ContactDto(1, "Alice"),
+					},
+					nextCursor: "page-2",
+					totalCount: 2))
+				.ReadOnly();
+		});
+
+		var result = await fixture.Client.CallToolAsync(
+			"contacts",
+			new Dictionary<string, object?>(StringComparer.Ordinal)
+			{
+				["_replPageSize"] = 1,
+				["_replCursor"] = "start",
+			});
+
+		result.IsError.Should().NotBeTrue();
+		result.StructuredContent.Should().NotBeNull();
+		var root = result.StructuredContent!.Value;
+		root.GetProperty("items").GetArrayLength().Should().Be(1);
+		root.GetProperty("pageInfo").GetProperty("cursor").GetString().Should().Be("start");
+		root.GetProperty("pageInfo").GetProperty("nextCursor").GetString().Should().Be("page-2");
+		root.GetProperty("pageInfo").GetProperty("totalCount").GetInt64().Should().Be(2);
+		var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text;
+		text.Should().NotBeNull();
+		text!.Should().Contain("Returned 1 item(s).");
+		text.Should().Contain("_replCursor=page-2");
 	}
 
 	[TestMethod]
@@ -303,6 +345,8 @@ public sealed class Given_McpServerEndToEnd
 	}
 
 	private sealed class AnotherService;
+
+	private sealed record ContactDto(int Id, string Name);
 
 	// ── Prompts ────────────────────────────────────────────────────────
 

--- a/src/Repl.McpTests/Given_McpServerEndToEnd.cs
+++ b/src/Repl.McpTests/Given_McpServerEndToEnd.cs
@@ -110,9 +110,9 @@ public sealed class Given_McpServerEndToEnd
 		root.GetProperty("pageInfo").GetProperty("cursor").GetString().Should().Be("start");
 		root.GetProperty("pageInfo").GetProperty("nextCursor").GetString().Should().Be("page-2");
 		root.GetProperty("pageInfo").GetProperty("totalCount").GetInt64().Should().Be(2);
-		var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text;
-		text.Should().NotBeNull();
-		text!.Should().Contain("Returned 1 item(s).");
+		var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text
+			?? throw new AssertFailedException("Expected a text content block.");
+		text.Should().Contain("Returned 1 item(s).");
 		text.Should().Contain("cursor available");
 		text.Should().NotContain("page-2");
 	}

--- a/src/Repl.McpTests/Given_McpServerEndToEnd.cs
+++ b/src/Repl.McpTests/Given_McpServerEndToEnd.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
+using Repl.Mcp;
 using Repl.Parameters;
 
 namespace Repl.McpTests;
@@ -52,9 +53,9 @@ public sealed class Given_McpServerEndToEnd
 		schema.GetProperty("properties").GetProperty("id").GetProperty("format").GetString()
 			.Should().Be("uuid");
 		schema.GetProperty("properties").TryGetProperty("_replCursor", out _)
-			.Should().BeTrue("MCP tools should expose Repl continuation cursors for paged data");
+			.Should().BeFalse("non-paged MCP tools should not expose Repl continuation cursors");
 		schema.GetProperty("properties").TryGetProperty("_replPageSize", out _)
-			.Should().BeTrue("MCP tools should expose Repl page sizing for large data");
+			.Should().BeFalse("non-paged MCP tools should not expose Repl page sizing");
 		schema.GetProperty("required")[0].GetString()
 			.Should().Be("id");
 	}
@@ -112,9 +113,40 @@ public sealed class Given_McpServerEndToEnd
 		root.GetProperty("pageInfo").GetProperty("totalCount").GetInt64().Should().Be(2);
 		var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text
 			?? throw new AssertFailedException("Expected a text content block.");
+		text.Should().Contain("page-2");
+		text.Should().Contain("\"items\"");
+	}
+
+	[TestMethod]
+	[Description("tools/call can use summary-only paged text content for low-token clients.")]
+	public async Task When_PagedResultTextModeIsSummaryOnly_Then_RawCursorStaysOutOfText()
+	{
+		await using var fixture = await McpTestFixture.CreateAsync(
+			app =>
+			{
+				app.Map("contacts", (IReplPagingContext paging) =>
+					paging.Page(
+						new[] { new ContactDto(1, "Alice") },
+						nextCursor: "page-2",
+						totalCount: 2))
+					.ReadOnly();
+			},
+			options => options.PagedResultTextMode = McpPagedResultTextMode.SummaryOnly);
+
+		var result = await fixture.Client.CallToolAsync(
+			"contacts",
+			new Dictionary<string, object?>(StringComparer.Ordinal)
+			{
+				["_replPageSize"] = 1,
+			});
+
+		result.StructuredContent.Should().NotBeNull();
+		var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text
+			?? throw new AssertFailedException("Expected a text content block.");
 		text.Should().Contain("Returned 1 item(s).");
 		text.Should().Contain("cursor available");
 		text.Should().NotContain("page-2");
+		text.Should().NotContain("\"items\"");
 	}
 
 	[TestMethod]

--- a/src/Repl.McpTests/Given_McpToolAdapter.cs
+++ b/src/Repl.McpTests/Given_McpToolAdapter.cs
@@ -1,4 +1,5 @@
 using Repl.Mcp;
+using System.Text.Json;
 
 namespace Repl.McpTests;
 
@@ -86,5 +87,64 @@ public sealed class Given_McpToolAdapter
 		var tokens = McpToolAdapter.ReconstructTokens("contact {id:int} delete", args);
 
 		tokens.Should().BeEquivalentTo(["contact", "42", "delete", "--verbose", "true"]);
+	}
+
+	[TestMethod]
+	[Description("PrepareExecution accepts compact opaque result cursors and emits them as result-flow tokens.")]
+	public void When_ResultCursorIsValid_Then_ResultFlowTokenIsEmitted()
+	{
+		var (tokens, _) = McpToolAdapter.PrepareExecution(
+			"contacts",
+			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+			{
+				[McpResultFlowArgumentNames.Cursor] = JsonSerializer.SerializeToElement("abc_DEF-123"),
+			});
+
+		tokens.Should().ContainInOrder("--result:cursor", "abc_DEF-123", "contacts");
+	}
+
+	[TestMethod]
+	[Description("PrepareExecution rejects result cursors that could be confused with CLI token boundaries.")]
+	public void When_ResultCursorContainsWhitespace_Then_Rejected()
+	{
+		var action = () => McpToolAdapter.PrepareExecution(
+			"contacts",
+			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+			{
+				[McpResultFlowArgumentNames.Cursor] = JsonSerializer.SerializeToElement("abc def"),
+			});
+
+		action.Should().Throw<InvalidOperationException>()
+			.WithMessage("*cursor*whitespace*");
+	}
+
+	[TestMethod]
+	[Description("PrepareExecution rejects result cursors that start like CLI options.")]
+	public void When_ResultCursorStartsWithDash_Then_Rejected()
+	{
+		var action = () => McpToolAdapter.PrepareExecution(
+			"contacts",
+			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+			{
+				[McpResultFlowArgumentNames.Cursor] = JsonSerializer.SerializeToElement("--result:all"),
+			});
+
+		action.Should().Throw<InvalidOperationException>()
+			.WithMessage("*cursor*option*");
+	}
+
+	[TestMethod]
+	[Description("PrepareExecution rejects overly large result cursors.")]
+	public void When_ResultCursorIsTooLong_Then_Rejected()
+	{
+		var action = () => McpToolAdapter.PrepareExecution(
+			"contacts",
+			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+			{
+				[McpResultFlowArgumentNames.Cursor] = JsonSerializer.SerializeToElement(new string('a', 513)),
+			});
+
+		action.Should().Throw<InvalidOperationException>()
+			.WithMessage("*cursor*512*");
 	}
 }

--- a/src/Repl.McpTests/Given_McpToolAdapter.cs
+++ b/src/Repl.McpTests/Given_McpToolAdapter.cs
@@ -1,4 +1,5 @@
 using Repl.Mcp;
+using Repl.Documentation;
 using System.Text.Json;
 
 namespace Repl.McpTests;
@@ -200,10 +201,49 @@ public sealed class Given_McpToolAdapter
 			"contacts",
 			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
 			{
-				[McpResultFlowArgumentNames.PageSize] = JsonSerializer.SerializeToElement(new string('1', 21)),
+				[McpResultFlowArgumentNames.PageSize] = JsonSerializer.SerializeToElement(new string('1', 11)),
 			});
 
 		action.Should().Throw<InvalidOperationException>()
-			.WithMessage("*page size*20*");
+			.WithMessage("*page size*10*");
+	}
+
+	[TestMethod]
+	[Description("PrepareExecution rejects result page sizes that do not fit in a positive Int32.")]
+	public void When_ResultPageSizeOverflowsInt32_Then_Rejected()
+	{
+		var action = () => McpToolAdapter.PrepareExecution(
+			"contacts",
+			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+			{
+				[McpResultFlowArgumentNames.PageSize] = JsonSerializer.SerializeToElement("9999999999"),
+			});
+
+		action.Should().Throw<InvalidOperationException>()
+			.WithMessage("*page size*32-bit*");
+	}
+
+	[TestMethod]
+	[Description("PrepareExecution rejects MCP arguments that are not declared by the command schema.")]
+	public void When_ArgumentIsNotInToolSchema_Then_Rejected()
+	{
+		var command = new ReplDocCommand(
+			Path: "contacts {id}",
+			Description: null,
+			Aliases: [],
+			IsHidden: false,
+			Arguments: [new ReplDocArgument("id", "string", Required: true, Description: null)],
+			Options: [new ReplDocOption("format", "string", Required: false, Description: null, Aliases: [], ReverseAliases: [], ValueAliases: [], EnumValues: [], DefaultValue: null)]);
+
+		var action = () => McpToolAdapter.PrepareExecution(
+			command,
+			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+			{
+				["id"] = JsonSerializer.SerializeToElement("abc"),
+				["output:xml"] = JsonSerializer.SerializeToElement("true"),
+			});
+
+		action.Should().Throw<InvalidOperationException>()
+			.WithMessage("*not defined*schema*");
 	}
 }

--- a/src/Repl.McpTests/Given_McpToolAdapter.cs
+++ b/src/Repl.McpTests/Given_McpToolAdapter.cs
@@ -147,4 +147,48 @@ public sealed class Given_McpToolAdapter
 		action.Should().Throw<InvalidOperationException>()
 			.WithMessage("*cursor*512*");
 	}
+
+	[TestMethod]
+	[Description("PrepareExecution accepts compact numeric result page sizes and emits them as result-flow tokens.")]
+	public void When_ResultPageSizeIsValid_Then_ResultFlowTokenIsEmitted()
+	{
+		var (tokens, _) = McpToolAdapter.PrepareExecution(
+			"contacts",
+			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+			{
+				[McpResultFlowArgumentNames.PageSize] = JsonSerializer.SerializeToElement(25),
+			});
+
+		tokens.Should().ContainInOrder("--result:page-size", "25", "contacts");
+	}
+
+	[TestMethod]
+	[Description("PrepareExecution rejects result page sizes that are not numeric.")]
+	public void When_ResultPageSizeIsNotNumeric_Then_Rejected()
+	{
+		var action = () => McpToolAdapter.PrepareExecution(
+			"contacts",
+			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+			{
+				[McpResultFlowArgumentNames.PageSize] = JsonSerializer.SerializeToElement("abc"),
+			});
+
+		action.Should().Throw<InvalidOperationException>()
+			.WithMessage("*page size*numeric*");
+	}
+
+	[TestMethod]
+	[Description("PrepareExecution rejects overly large result page size tokens.")]
+	public void When_ResultPageSizeTokenIsTooLong_Then_Rejected()
+	{
+		var action = () => McpToolAdapter.PrepareExecution(
+			"contacts",
+			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+			{
+				[McpResultFlowArgumentNames.PageSize] = JsonSerializer.SerializeToElement(new string('1', 21)),
+			});
+
+		action.Should().Throw<InvalidOperationException>()
+			.WithMessage("*page size*20*");
+	}
 }

--- a/src/Repl.McpTests/Given_McpToolAdapter.cs
+++ b/src/Repl.McpTests/Given_McpToolAdapter.cs
@@ -246,4 +246,73 @@ public sealed class Given_McpToolAdapter
 		action.Should().Throw<InvalidOperationException>()
 			.WithMessage("*not defined*schema*");
 	}
+
+	[TestMethod]
+	[Description("PrepareExecution rejects token-like MCP argument values before reconstructing CLI tokens.")]
+	public void When_ArgumentValueStartsWithDashDash_Then_Rejected()
+	{
+		var command = new ReplDocCommand(
+			Path: "contacts",
+			Description: null,
+			Aliases: [],
+			IsHidden: false,
+			Arguments: [],
+			Options: [new ReplDocOption("format", "string", Required: false, Description: null, Aliases: [], ReverseAliases: [], ValueAliases: [], EnumValues: [], DefaultValue: null)]);
+
+		var action = () => McpToolAdapter.PrepareExecution(
+			command,
+			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+			{
+				["format"] = JsonSerializer.SerializeToElement("--result:all"),
+			});
+
+		action.Should().Throw<InvalidOperationException>()
+			.WithMessage("*argument value*CLI option*");
+	}
+
+	[TestMethod]
+	[Description("PrepareExecution rejects answer prefills that are not declared by the command schema.")]
+	public void When_AnswerPrefillIsNotInToolSchema_Then_Rejected()
+	{
+		var command = new ReplDocCommand(
+			Path: "wizard",
+			Description: null,
+			Aliases: [],
+			IsHidden: false,
+			Arguments: [],
+			Options: []);
+
+		var action = () => McpToolAdapter.PrepareExecution(
+			command,
+			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+			{
+				["answer.confirm"] = JsonSerializer.SerializeToElement("yes"),
+			});
+
+		action.Should().Throw<InvalidOperationException>()
+			.WithMessage("*not defined*schema*");
+	}
+
+	[TestMethod]
+	[Description("PrepareExecution rejects result-flow inputs for commands that do not expose paging in their schema.")]
+	public void When_ResultFlowInputIsNotInToolSchema_Then_Rejected()
+	{
+		var command = new ReplDocCommand(
+			Path: "contacts",
+			Description: null,
+			Aliases: [],
+			IsHidden: false,
+			Arguments: [],
+			Options: []);
+
+		var action = () => McpToolAdapter.PrepareExecution(
+			command,
+			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+			{
+				[McpResultFlowArgumentNames.Cursor] = JsonSerializer.SerializeToElement("abc123"),
+			});
+
+		action.Should().Throw<InvalidOperationException>()
+			.WithMessage("*not defined*schema*");
+	}
 }

--- a/src/Repl.McpTests/Given_McpToolAdapter.cs
+++ b/src/Repl.McpTests/Given_McpToolAdapter.cs
@@ -149,6 +149,21 @@ public sealed class Given_McpToolAdapter
 	}
 
 	[TestMethod]
+	[Description("PrepareExecution rejects result cursors that contain control characters.")]
+	public void When_ResultCursorContainsControlCharacter_Then_Rejected()
+	{
+		var action = () => McpToolAdapter.PrepareExecution(
+			"contacts",
+			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+			{
+				[McpResultFlowArgumentNames.Cursor] = JsonSerializer.SerializeToElement("abc\u001b[2J"),
+			});
+
+		action.Should().Throw<InvalidOperationException>()
+			.WithMessage("*cursor*control*");
+	}
+
+	[TestMethod]
 	[Description("PrepareExecution accepts compact numeric result page sizes and emits them as result-flow tokens.")]
 	public void When_ResultPageSizeIsValid_Then_ResultFlowTokenIsEmitted()
 	{

--- a/src/Repl.McpTests/Given_McpToolAdapter.cs
+++ b/src/Repl.McpTests/Given_McpToolAdapter.cs
@@ -95,7 +95,7 @@ public sealed class Given_McpToolAdapter
 	public void When_ResultCursorIsValid_Then_ResultFlowTokenIsEmitted()
 	{
 		var (tokens, _) = McpToolAdapter.PrepareExecution(
-			"contacts",
+			CreatePagedCommand("contacts"),
 			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
 			{
 				[McpResultFlowArgumentNames.Cursor] = JsonSerializer.SerializeToElement("abc_DEF-123"),
@@ -109,7 +109,7 @@ public sealed class Given_McpToolAdapter
 	public void When_ResultCursorContainsWhitespace_Then_Rejected()
 	{
 		var action = () => McpToolAdapter.PrepareExecution(
-			"contacts",
+			CreatePagedCommand("contacts"),
 			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
 			{
 				[McpResultFlowArgumentNames.Cursor] = JsonSerializer.SerializeToElement("abc def"),
@@ -124,7 +124,7 @@ public sealed class Given_McpToolAdapter
 	public void When_ResultCursorStartsWithDash_Then_Rejected()
 	{
 		var action = () => McpToolAdapter.PrepareExecution(
-			"contacts",
+			CreatePagedCommand("contacts"),
 			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
 			{
 				[McpResultFlowArgumentNames.Cursor] = JsonSerializer.SerializeToElement("--result:all"),
@@ -139,7 +139,7 @@ public sealed class Given_McpToolAdapter
 	public void When_ResultCursorIsTooLong_Then_Rejected()
 	{
 		var action = () => McpToolAdapter.PrepareExecution(
-			"contacts",
+			CreatePagedCommand("contacts"),
 			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
 			{
 				[McpResultFlowArgumentNames.Cursor] = JsonSerializer.SerializeToElement(new string('a', 513)),
@@ -154,7 +154,7 @@ public sealed class Given_McpToolAdapter
 	public void When_ResultCursorContainsControlCharacter_Then_Rejected()
 	{
 		var action = () => McpToolAdapter.PrepareExecution(
-			"contacts",
+			CreatePagedCommand("contacts"),
 			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
 			{
 				[McpResultFlowArgumentNames.Cursor] = JsonSerializer.SerializeToElement("abc\u001b[2J"),
@@ -169,7 +169,7 @@ public sealed class Given_McpToolAdapter
 	public void When_ResultPageSizeIsValid_Then_ResultFlowTokenIsEmitted()
 	{
 		var (tokens, _) = McpToolAdapter.PrepareExecution(
-			"contacts",
+			CreatePagedCommand("contacts"),
 			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
 			{
 				[McpResultFlowArgumentNames.PageSize] = JsonSerializer.SerializeToElement(25),
@@ -183,7 +183,7 @@ public sealed class Given_McpToolAdapter
 	public void When_ResultPageSizeIsNotNumeric_Then_Rejected()
 	{
 		var action = () => McpToolAdapter.PrepareExecution(
-			"contacts",
+			CreatePagedCommand("contacts"),
 			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
 			{
 				[McpResultFlowArgumentNames.PageSize] = JsonSerializer.SerializeToElement("abc"),
@@ -198,7 +198,7 @@ public sealed class Given_McpToolAdapter
 	public void When_ResultPageSizeTokenIsTooLong_Then_Rejected()
 	{
 		var action = () => McpToolAdapter.PrepareExecution(
-			"contacts",
+			CreatePagedCommand("contacts"),
 			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
 			{
 				[McpResultFlowArgumentNames.PageSize] = JsonSerializer.SerializeToElement(new string('1', 11)),
@@ -213,7 +213,7 @@ public sealed class Given_McpToolAdapter
 	public void When_ResultPageSizeOverflowsInt32_Then_Rejected()
 	{
 		var action = () => McpToolAdapter.PrepareExecution(
-			"contacts",
+			CreatePagedCommand("contacts"),
 			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
 			{
 				[McpResultFlowArgumentNames.PageSize] = JsonSerializer.SerializeToElement("9999999999"),
@@ -221,6 +221,23 @@ public sealed class Given_McpToolAdapter
 
 		action.Should().Throw<InvalidOperationException>()
 			.WithMessage("*page size*32-bit*");
+	}
+
+	[TestMethod]
+	[Description("PrepareExecution treats reserved result-flow argument names case-insensitively.")]
+	public void When_ResultFlowInputsUseDifferentCase_Then_ReservedDispatchStillValidatesAndEmitsTokens()
+	{
+		var (tokens, _) = McpToolAdapter.PrepareExecution(
+			CreatePagedCommand("contacts"),
+			new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+			{
+				["_replcursor"] = JsonSerializer.SerializeToElement("abc_DEF-123"),
+				["_replpagesize"] = JsonSerializer.SerializeToElement(25),
+			});
+
+		tokens.Should().ContainInOrder("--result:cursor", "abc_DEF-123", "--result:page-size", "25", "contacts");
+		tokens.Should().NotContain("--_replcursor");
+		tokens.Should().NotContain("--_replpagesize");
 	}
 
 	[TestMethod]
@@ -315,4 +332,14 @@ public sealed class Given_McpToolAdapter
 		action.Should().Throw<InvalidOperationException>()
 			.WithMessage("*not defined*schema*");
 	}
+
+	private static ReplDocCommand CreatePagedCommand(string path) =>
+		new(
+			Path: path,
+			Description: null,
+			Aliases: [],
+			IsHidden: false,
+			Arguments: [],
+			Options: [],
+			AcceptsPagingInput: true);
 }

--- a/src/Repl.Spectre/SpectreHumanOutputTransformer.cs
+++ b/src/Repl.Spectre/SpectreHumanOutputTransformer.cs
@@ -30,6 +30,9 @@ internal sealed class SpectreHumanOutputTransformer : IOutputTransformer
 	public string Name => "spectre";
 
 	/// <inheritdoc />
+	public bool SupportsInteractivePaging => true;
+
+	/// <inheritdoc />
 	public ValueTask<string> TransformAsync(object? value, CancellationToken cancellationToken = default)
 	{
 		cancellationToken.ThrowIfCancellationRequested();

--- a/src/Repl.Spectre/SpectreHumanOutputTransformer.cs
+++ b/src/Repl.Spectre/SpectreHumanOutputTransformer.cs
@@ -120,6 +120,13 @@ internal sealed class SpectreHumanOutputTransformer : IOutputTransformer
 			sections.Add(BuildEntryTable(command.Options));
 		}
 
+		if (command.ResultFlow.Count > 0)
+		{
+			AppendSpacer(sections);
+			sections.Add(new Markup("[bold]Result Flow[/]"));
+			sections.Add(BuildEntryTable(command.ResultFlow));
+		}
+
 		if (command.Answers.Count > 0)
 		{
 			AppendSpacer(sections);
@@ -220,7 +227,7 @@ internal sealed class SpectreHumanOutputTransformer : IOutputTransformer
 		{
 			var prefix = $"Showing {count.ToString(CultureInfo.InvariantCulture)} of {total.ToString(CultureInfo.InvariantCulture)}.";
 			return info.HasMore
-				? $"{prefix} Continue with --result:cursor {info.NextCursor}."
+				? $"{prefix} Next data page: rerun with --result:cursor {info.NextCursor}."
 				: prefix;
 		}
 
@@ -229,7 +236,7 @@ internal sealed class SpectreHumanOutputTransformer : IOutputTransformer
 			return string.Empty;
 		}
 
-		return $"Showing {count.ToString(CultureInfo.InvariantCulture)} result(s). Continue with --result:cursor {info.NextCursor}.";
+		return $"Showing {count.ToString(CultureInfo.InvariantCulture)} result(s). Next data page: rerun with --result:cursor {info.NextCursor}.";
 	}
 
 	private bool TryRenderObject(object value, out string text)
@@ -285,13 +292,25 @@ internal sealed class SpectreHumanOutputTransformer : IOutputTransformer
 			for (var i = 0; i < members.Count; i++)
 			{
 				var memberValue = members[i].Property.GetValue(item);
-				cells[i] = new Text(RenderInlineValue(memberValue, members[i]));
+				cells[i] = CreateTableCell(RenderInlineValue(memberValue, members[i]), table.Rows.Count, i);
 			}
 
 			table.AddRow(cells);
 		}
 
 		return table;
+	}
+
+	private static Text CreateTableCell(string text, int rowIndex, int columnIndex)
+	{
+		if (columnIndex == 0)
+		{
+			return new Text(text, new Style(Color.Cyan1, decoration: Decoration.Bold));
+		}
+
+		return rowIndex % 2 == 1
+			? new Text(text, new Style(Color.Grey))
+			: new Text(text);
 	}
 
 	private static Table BuildCommandsTable(IReadOnlyList<HelpRenderCommand> commands)

--- a/src/Repl.Spectre/SpectreHumanOutputTransformer.cs
+++ b/src/Repl.Spectre/SpectreHumanOutputTransformer.cs
@@ -250,7 +250,7 @@ internal sealed class SpectreHumanOutputTransformer : IResultFlowOutputTransform
 		{
 			var prefix = $"Showing {count.ToString(CultureInfo.InvariantCulture)} of {total.ToString(CultureInfo.InvariantCulture)}.";
 			return info.HasMore
-				? $"{prefix} Next data page: rerun with --result:cursor {info.NextCursor}."
+				? $"{prefix} Next data page: rerun with {ResultFlowCursorPolicy.FormatCliContinuation(info.NextCursor)}."
 				: prefix;
 		}
 
@@ -259,7 +259,7 @@ internal sealed class SpectreHumanOutputTransformer : IResultFlowOutputTransform
 			return string.Empty;
 		}
 
-		return $"Showing {count.ToString(CultureInfo.InvariantCulture)} result(s). Next data page: rerun with --result:cursor {info.NextCursor}.";
+		return $"Showing {count.ToString(CultureInfo.InvariantCulture)} result(s). Next data page: rerun with {ResultFlowCursorPolicy.FormatCliContinuation(info.NextCursor)}.";
 	}
 
 	private bool TryRenderObject(object value, out string text)

--- a/src/Repl.Spectre/SpectreHumanOutputTransformer.cs
+++ b/src/Repl.Spectre/SpectreHumanOutputTransformer.cs
@@ -42,6 +42,7 @@ internal sealed class SpectreHumanOutputTransformer : IOutputTransformer
 		return ValueTask.FromResult(value switch
 		{
 			HelpRenderDocument help => RenderHelp(help),
+			IReplPage page => RenderPage(page),
 			IReplResult replResult => RenderReplResult(replResult),
 			string text => text,
 			System.Collections.IEnumerable enumerable => RenderEnumerable(enumerable),
@@ -157,7 +158,9 @@ internal sealed class SpectreHumanOutputTransformer : IOutputTransformer
 			return RenderToString(new Markup(statusMarkup));
 		}
 
-		var details = RenderValueRenderable(result.Details, nested: false);
+		var details = result.Details is IReplPage page
+			? new Text(RenderPage(page))
+			: RenderValueRenderable(result.Details, nested: false);
 		return RenderToString(new Rows(new IRenderable[]
 		{
 			new Markup(statusMarkup),
@@ -196,6 +199,37 @@ internal sealed class SpectreHumanOutputTransformer : IOutputTransformer
 		}
 
 		return RenderToString(BuildObjectTable(items, members));
+	}
+
+	private string RenderPage(IReplPage page)
+	{
+		var body = page.UntypedItems.Count == 0
+			? "No results."
+			: RenderEnumerable(page.UntypedItems);
+		var footer = RenderPageFooter(page);
+		return string.IsNullOrWhiteSpace(footer)
+			? body
+			: string.Concat(body, Environment.NewLine, footer);
+	}
+
+	private static string RenderPageFooter(IReplPage page)
+	{
+		var info = page.PageInfo;
+		var count = page.UntypedItems.Count;
+		if (info.TotalCount is { } total)
+		{
+			var prefix = $"Showing {count.ToString(CultureInfo.InvariantCulture)} of {total.ToString(CultureInfo.InvariantCulture)}.";
+			return info.HasMore
+				? $"{prefix} Continue with --result:cursor {info.NextCursor}."
+				: prefix;
+		}
+
+		if (!info.HasMore)
+		{
+			return string.Empty;
+		}
+
+		return $"Showing {count.ToString(CultureInfo.InvariantCulture)} result(s). Continue with --result:cursor {info.NextCursor}.";
 	}
 
 	private bool TryRenderObject(object value, out string text)

--- a/src/Repl.Spectre/SpectreHumanOutputTransformer.cs
+++ b/src/Repl.Spectre/SpectreHumanOutputTransformer.cs
@@ -11,7 +11,7 @@ namespace Repl.Spectre;
 /// <summary>
 /// Output transformer that renders values using light Spectre.Console layouts.
 /// </summary>
-internal sealed class SpectreHumanOutputTransformer : IOutputTransformer
+internal sealed class SpectreHumanOutputTransformer : IResultFlowOutputTransformer
 {
 	private readonly Func<HumanRenderSettings> _resolveRenderSettings;
 
@@ -52,6 +52,16 @@ internal sealed class SpectreHumanOutputTransformer : IOutputTransformer
 			_ when TryRenderObject(value, out var objectText) => objectText,
 			_ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty,
 		});
+	}
+
+	public ValueTask<string> TransformPageAsync(
+		IReplPage page,
+		ResultFlowPageRenderMode mode,
+		CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(page);
+		cancellationToken.ThrowIfCancellationRequested();
+		return ValueTask.FromResult(RenderPage(page, mode, includeFooter: false));
 	}
 
 	private string RenderHelp(HelpRenderDocument help)
@@ -179,7 +189,9 @@ internal sealed class SpectreHumanOutputTransformer : IOutputTransformer
 		}));
 	}
 
-	private string RenderEnumerable(System.Collections.IEnumerable enumerable)
+	private string RenderEnumerable(
+		System.Collections.IEnumerable enumerable,
+		bool includeTableHeader = true)
 	{
 		var items = enumerable.Cast<object?>().ToArray();
 		if (items.Length == 0)
@@ -208,15 +220,23 @@ internal sealed class SpectreHumanOutputTransformer : IOutputTransformer
 				items.Select(item => Convert.ToString(item, CultureInfo.InvariantCulture) ?? string.Empty));
 		}
 
-		return RenderToString(BuildObjectTable(items, members));
+		return RenderToString(BuildObjectTable(items, members, includeTableHeader));
 	}
 
-	private string RenderPage(IReplPage page)
+	private string RenderPage(IReplPage page) =>
+		RenderPage(page, ResultFlowPageRenderMode.Initial, includeFooter: true);
+
+	private string RenderPage(
+		IReplPage page,
+		ResultFlowPageRenderMode mode,
+		bool includeFooter)
 	{
 		var body = page.UntypedItems.Count == 0
 			? "No results."
-			: RenderEnumerable(page.UntypedItems);
-		var footer = RenderPageFooter(page);
+			: RenderEnumerable(
+				page.UntypedItems,
+				includeTableHeader: mode == ResultFlowPageRenderMode.Initial);
+		var footer = includeFooter ? RenderPageFooter(page) : string.Empty;
 		return string.IsNullOrWhiteSpace(footer)
 			? body
 			: string.Concat(body, Environment.NewLine, footer);
@@ -272,11 +292,18 @@ internal sealed class SpectreHumanOutputTransformer : IOutputTransformer
 		return grid;
 	}
 
-	private static Table BuildObjectTable(object?[] items, IReadOnlyList<DisplayMember> members)
+	private static Table BuildObjectTable(
+		object?[] items,
+		IReadOnlyList<DisplayMember> members,
+		bool includeHeaders = true)
 	{
 		var table = new Table()
 			.Border(TableBorder.None)
 			.Collapse();
+		if (!includeHeaders)
+		{
+			table.HideHeaders();
+		}
 
 		foreach (var member in members)
 		{

--- a/src/Repl.Tests/Given_AnsiTextMetrics.cs
+++ b/src/Repl.Tests/Given_AnsiTextMetrics.cs
@@ -13,6 +13,15 @@ public sealed class Given_AnsiTextMetrics
 	}
 
 	[TestMethod]
+	[Description("Visible length can be computed from a caller-owned text slice without materializing a string.")]
+	public void When_TextIsProvidedAsSpan_Then_VisibleLengthIsComputedFromSlice()
+	{
+		var text = "xx\u001b[1mhello\u001b[0myy";
+
+		AnsiTextMetrics.GetVisualLength(text.AsSpan(2, text.Length - 4)).Should().Be(5);
+	}
+
+	[TestMethod]
 	[Description("Visible length ignores ANSI OSC hyperlinks.")]
 	public void When_TextContainsOscHyperlink_Then_VisibleLengthIgnoresControlBytes()
 	{
@@ -28,5 +37,14 @@ public sealed class Given_AnsiTextMetrics
 		var link = "\u001b]8;;https://example.invalid\u001b\\link\u001b]8;;\u001b\\";
 
 		AnsiTextMetrics.GetVisualLength(link).Should().Be(4);
+	}
+
+	[TestMethod]
+	[Description("ANSI stripping can consume text slices without forcing the caller to allocate first.")]
+	public void When_StrippingAnsiFromSpan_Then_ControlSequencesAreRemoved()
+	{
+		var text = "xx\u001b[1m#\u001b[0m  \u001b[1mAt\u001b[0myy";
+
+		AnsiTextMetrics.StripControlSequences(text.AsSpan(2, text.Length - 4)).Should().Be("#  At");
 	}
 }

--- a/src/Repl.Tests/Given_AnsiTextMetrics.cs
+++ b/src/Repl.Tests/Given_AnsiTextMetrics.cs
@@ -20,4 +20,13 @@ public sealed class Given_AnsiTextMetrics
 
 		AnsiTextMetrics.GetVisualLength(link).Should().Be(4);
 	}
+
+	[TestMethod]
+	[Description("Visible length ignores OSC sequences terminated by ST.")]
+	public void When_TextContainsOscSequenceTerminatedByStringTerminator_Then_VisibleLengthIgnoresControlBytes()
+	{
+		var link = "\u001b]8;;https://example.invalid\u001b\\link\u001b]8;;\u001b\\";
+
+		AnsiTextMetrics.GetVisualLength(link).Should().Be(4);
+	}
 }

--- a/src/Repl.Tests/Given_AnsiTextMetrics.cs
+++ b/src/Repl.Tests/Given_AnsiTextMetrics.cs
@@ -1,0 +1,23 @@
+using Repl.Terminal;
+
+namespace Repl.Tests;
+
+[TestClass]
+public sealed class Given_AnsiTextMetrics
+{
+	[TestMethod]
+	[Description("Visible length ignores ANSI CSI styling bytes.")]
+	public void When_TextContainsCsiSequence_Then_VisibleLengthIgnoresControlBytes()
+	{
+		AnsiTextMetrics.GetVisualLength("\u001b[1mhello\u001b[0m").Should().Be(5);
+	}
+
+	[TestMethod]
+	[Description("Visible length ignores ANSI OSC hyperlinks.")]
+	public void When_TextContainsOscHyperlink_Then_VisibleLengthIgnoresControlBytes()
+	{
+		var link = "\u001b]8;;https://example.invalid\u0007link\u001b]8;;\u0007";
+
+		AnsiTextMetrics.GetVisualLength(link).Should().Be(4);
+	}
+}

--- a/src/Repl.Tests/Given_GlobalOptionParser.cs
+++ b/src/Repl.Tests/Given_GlobalOptionParser.cs
@@ -124,6 +124,23 @@ public sealed class Given_GlobalOptionParser
 	}
 
 	[TestMethod]
+	[Description("Result-flow pager modes parse the current public mode names.")]
+	public void When_ResultFlowPagerModeIsFullOrInline_Then_ParserStoresMode()
+	{
+		var full = GlobalOptionParser.Parse(
+			["users", "list", "--result:pager=full"],
+			new OutputOptions(),
+			new ParsingOptions());
+		var inline = GlobalOptionParser.Parse(
+			["users", "list", "--result:pager=inline"],
+			new OutputOptions(),
+			new ParsingOptions());
+
+		full.ResultFlow.PagerMode.Should().Be(ReplPagerMode.Full);
+		inline.ResultFlow.PagerMode.Should().Be(ReplPagerMode.Inline);
+	}
+
+	[TestMethod]
 	[Description("Result-flow page size is clamped during global option parsing before it reaches handlers or page sources.")]
 	public void When_ResultFlowPageSizeExceedsMaximum_Then_ParserClampsIt()
 	{

--- a/src/Repl.Tests/Given_GlobalOptionParser.cs
+++ b/src/Repl.Tests/Given_GlobalOptionParser.cs
@@ -122,4 +122,19 @@ public sealed class Given_GlobalOptionParser
 		parsed.ResultFlow.AllRequested.Should().BeTrue();
 		parsed.ResultFlow.PagerMode.Should().Be(ReplPagerMode.Off);
 	}
+
+	[TestMethod]
+	[Description("Result-flow page size is clamped during global option parsing before it reaches handlers or page sources.")]
+	public void When_ResultFlowPageSizeExceedsMaximum_Then_ParserClampsIt()
+	{
+		var outputOptions = new OutputOptions();
+		outputOptions.ResultFlow.MaxPageSize = 50;
+
+		var parsed = GlobalOptionParser.Parse(
+			["users", "list", "--result:page-size=2147483647"],
+			outputOptions,
+			new ParsingOptions());
+
+		parsed.ResultFlow.PageSize.Should().Be(50);
+	}
 }

--- a/src/Repl.Tests/Given_GlobalOptionParser.cs
+++ b/src/Repl.Tests/Given_GlobalOptionParser.cs
@@ -105,4 +105,21 @@ public sealed class Given_GlobalOptionParser
 		parsed.RemainingTokens.Should().Equal("deploy");
 		parsed.CustomGlobalNamedOptions["verbose"].Should().ContainSingle().Which.Should().Be("false");
 	}
+
+	[TestMethod]
+	[Description("Result-flow global options are consumed before command parsing and stored separately from custom global options.")]
+	public void When_ResultFlowOptionsArePresent_Then_ParserConsumesThemIntoResultFlow()
+	{
+		var parsed = GlobalOptionParser.Parse(
+			["users", "list", "--result:page-size=25", "--result:cursor", "abc", "--result:all", "--result:pager=off"],
+			new OutputOptions(),
+			new ParsingOptions());
+
+		parsed.RemainingTokens.Should().Equal("users", "list");
+		parsed.CustomGlobalNamedOptions.Should().BeEmpty();
+		parsed.ResultFlow.PageSize.Should().Be(25);
+		parsed.ResultFlow.Cursor.Should().Be("abc");
+		parsed.ResultFlow.AllRequested.Should().BeTrue();
+		parsed.ResultFlow.PagerMode.Should().Be(ReplPagerMode.Off);
+	}
 }

--- a/src/Repl.Tests/Given_GlobalOptionParser.cs
+++ b/src/Repl.Tests/Given_GlobalOptionParser.cs
@@ -154,4 +154,47 @@ public sealed class Given_GlobalOptionParser
 
 		parsed.ResultFlow.PageSize.Should().Be(50);
 	}
+
+	[TestMethod]
+	[Description("Result-flow cursor must be explicit so a missing value is reported before command binding.")]
+	public void When_ResultFlowCursorValueIsMissing_Then_DiagnosticErrorIsProduced()
+	{
+		var parsed = GlobalOptionParser.Parse(
+			["users", "list", "--result:cursor"],
+			new OutputOptions(),
+			new ParsingOptions());
+
+		parsed.Diagnostics.Should().ContainSingle(diagnostic =>
+			diagnostic.Severity == ParseDiagnosticSeverity.Error
+			&& diagnostic.Message.Contains("cursor", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[TestMethod]
+	[Description("Result-flow cursor rejects token-like values that could corrupt downstream CLI reconstruction.")]
+	public void When_ResultFlowCursorStartsWithDash_Then_DiagnosticErrorIsProduced()
+	{
+		var parsed = GlobalOptionParser.Parse(
+			["users", "list", "--result:cursor=--result:all"],
+			new OutputOptions(),
+			new ParsingOptions());
+
+		parsed.Diagnostics.Should().ContainSingle(diagnostic =>
+			diagnostic.Severity == ParseDiagnosticSeverity.Error
+			&& diagnostic.Message.Contains("cursor", StringComparison.OrdinalIgnoreCase)
+			&& diagnostic.Message.Contains("option", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[TestMethod]
+	[Description("Result-flow cursor rejects control characters so rendered continuation text cannot inject terminal escapes.")]
+	public void When_ResultFlowCursorContainsControlCharacter_Then_DiagnosticErrorIsProduced()
+	{
+		var parsed = GlobalOptionParser.Parse(
+			["users", "list", "--result:cursor=abc\u001b[2J"],
+			new OutputOptions(),
+			new ParsingOptions());
+
+		parsed.Diagnostics.Should().ContainSingle(diagnostic =>
+			diagnostic.Severity == ParseDiagnosticSeverity.Error
+			&& diagnostic.Message.Contains("control", StringComparison.OrdinalIgnoreCase));
+	}
 }

--- a/src/Repl.Tests/Given_GlobalOptionParser.cs
+++ b/src/Repl.Tests/Given_GlobalOptionParser.cs
@@ -145,6 +145,7 @@ public sealed class Given_GlobalOptionParser
 	public void When_ResultFlowPageSizeExceedsMaximum_Then_ParserClampsIt()
 	{
 		var outputOptions = new OutputOptions();
+		outputOptions.ResultFlow.DefaultPageSize = 50;
 		outputOptions.ResultFlow.MaxPageSize = 50;
 
 		var parsed = GlobalOptionParser.Parse(
@@ -190,6 +191,20 @@ public sealed class Given_GlobalOptionParser
 	{
 		var parsed = GlobalOptionParser.Parse(
 			["users", "list", "--result:cursor=abc\u001b[2J"],
+			new OutputOptions(),
+			new ParsingOptions());
+
+		parsed.Diagnostics.Should().ContainSingle(diagnostic =>
+			diagnostic.Severity == ParseDiagnosticSeverity.Error
+			&& diagnostic.Message.Contains("control", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[TestMethod]
+	[Description("Result-flow cursor rejects C1 control characters that can be interpreted by legacy terminals.")]
+	public void When_ResultFlowCursorContainsC1Control_Then_DiagnosticErrorIsProduced()
+	{
+		var parsed = GlobalOptionParser.Parse(
+			["users", "list", "--result:cursor=abc\u009b2J"],
 			new OutputOptions(),
 			new ParsingOptions());
 

--- a/src/Repl.Tests/Given_HandlerBinding.cs
+++ b/src/Repl.Tests/Given_HandlerBinding.cs
@@ -160,6 +160,37 @@ public sealed class Given_HandlerBinding
 		exitCode.Should().Be(1);
 	}
 
+	[TestMethod]
+	[Description("Result-flow paging context is injected so handlers can page data at the source.")]
+	public void When_HandlerRequestsPagingContext_Then_ResultFlowOptionsAreAvailable()
+	{
+		var sut = ReplApp.Create();
+		IReplPagingContext? captured = null;
+		ReplPage<string>? page = null;
+
+		sut.Map("users list", (IReplPagingContext paging) =>
+		{
+			captured = paging;
+			page = paging.Page(["Alice", "Bob"], nextCursor: "next", totalCount: 3);
+			return "ok";
+		});
+
+		var exitCode = sut.Run(
+			["users", "list", "--result:page-size=2", "--result:cursor=start", "--no-logo"]);
+
+		exitCode.Should().Be(0);
+		captured.Should().NotBeNull();
+		captured!.SuggestedPageSize.Should().Be(2);
+		captured.Cursor.Should().Be("start");
+		captured.MaxPageSize.Should().BeGreaterThanOrEqualTo(2);
+		page.Should().NotBeNull();
+		page!.Items.Should().Equal("Alice", "Bob");
+		page.PageInfo.Cursor.Should().Be("start");
+		page.PageInfo.NextCursor.Should().Be("next");
+		page.PageInfo.TotalCount.Should().Be(3);
+		page.PageInfo.HasMore.Should().BeTrue();
+	}
+
 	private interface ITestCounter
 	{
 		int Value { get; }
@@ -170,7 +201,6 @@ public sealed class Given_HandlerBinding
 		public int Value { get; } = value;
 	}
 }
-
 
 
 

--- a/src/Repl.Tests/Given_ReplLogging.cs
+++ b/src/Repl.Tests/Given_ReplLogging.cs
@@ -126,7 +126,7 @@ public sealed partial class Given_ReplLogging
 		exitCode.Should().Be(1);
 		provider.Entries.Should().Contain(entry =>
 			entry.Category == "Repl.ResultFlow"
-			&& entry.Level == LogLevel.Warning
+			&& entry.Level == LogLevel.Error
 			&& entry.Message.Contains("page fetch failed", StringComparison.OrdinalIgnoreCase));
 	}
 

--- a/src/Repl.Tests/Given_ReplLogging.cs
+++ b/src/Repl.Tests/Given_ReplLogging.cs
@@ -131,6 +131,41 @@ public sealed partial class Given_ReplLogging
 	}
 
 	[TestMethod]
+	[Description("Result-flow diagnostics fall back to the app root provider when a hosted runtime provider does not register diagnostics.")]
+	public void When_RuntimeProviderDoesNotRegisterResultFlowDiagnostics_Then_AppProviderStillLogsFetchFailure()
+	{
+		var provider = new CapturingLoggerProvider();
+		var app = ReplApp.Create(services =>
+		{
+			services.AddSingleton(provider);
+			services.AddLogging(builder =>
+			{
+				builder.ClearProviders();
+				builder.AddProvider(provider);
+			});
+		});
+		app.Map("items", () => ReplPageSource.Create<string>((_, _) =>
+			throw new InvalidOperationException("fetch failed")));
+
+		using var input = new StringReader(string.Empty);
+		using var output = new StringWriter();
+		var host = new InMemoryHost(input, output);
+		using var runtimeProvider = new ServiceCollection().BuildServiceProvider();
+
+		var exitCode = app.Run(
+			["items", "--no-logo"],
+			host,
+			runtimeProvider,
+			new ReplRunOptions { HostedServiceLifecycle = HostedServiceLifecycleMode.None });
+
+		exitCode.Should().Be(1);
+		provider.Entries.Should().Contain(entry =>
+			entry.Category == "Repl.ResultFlow"
+			&& entry.Level == LogLevel.Error
+			&& entry.Message.Contains("page fetch failed", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[TestMethod]
 	[Description("Regression guard: verifies ambient Repl log context reflects hosted session metadata so apps can route logs to the active session.")]
 	public void When_HostedSessionRuns_Then_LogContextExposesSessionMetadata()
 	{

--- a/src/Repl.Tests/Given_ReplLogging.cs
+++ b/src/Repl.Tests/Given_ReplLogging.cs
@@ -97,6 +97,40 @@ public sealed partial class Given_ReplLogging
 	}
 
 	[TestMethod]
+	[Description("Result-flow page-source fetch failures are logged through the Repl logging bridge.")]
+	public void When_ResultFlowPageFetchFails_Then_DiagnosticIsLogged()
+	{
+		var provider = new CapturingLoggerProvider();
+		var app = ReplApp.Create(services =>
+		{
+			services.AddSingleton(provider);
+			services.AddLogging(builder =>
+			{
+				builder.ClearProviders();
+				builder.AddProvider(provider);
+			});
+		});
+
+		app.Map("items", () => ReplPageSource.Create<string>((_, _) =>
+			throw new InvalidOperationException("fetch failed")));
+
+		using var input = new StringReader(string.Empty);
+		using var output = new StringWriter();
+		var host = new InMemoryHost(input, output);
+
+		var exitCode = app.Run(
+			["items", "--no-logo"],
+			host,
+			new ReplRunOptions { HostedServiceLifecycle = HostedServiceLifecycleMode.None });
+
+		exitCode.Should().Be(1);
+		provider.Entries.Should().Contain(entry =>
+			entry.Category == "Repl.ResultFlow"
+			&& entry.Level == LogLevel.Warning
+			&& entry.Message.Contains("page fetch failed", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[TestMethod]
 	[Description("Regression guard: verifies ambient Repl log context reflects hosted session metadata so apps can route logs to the active session.")]
 	public void When_HostedSessionRuns_Then_LogContextExposesSessionMetadata()
 	{

--- a/src/Repl.Tests/Given_ReplPageSource.cs
+++ b/src/Repl.Tests/Given_ReplPageSource.cs
@@ -343,6 +343,22 @@ public sealed class Given_ReplPageSource
 		pageInfo.HasMore.Should().BeFalse();
 	}
 
+	[TestMethod]
+	[Description("ReplPage reuses object arrays for UntypedItems instead of allocating another array.")]
+	public void When_ReplPageItemsAreObjectArray_Then_UntypedItemsReusesArray()
+	{
+		object?[] items = ["one", 2];
+		var page = new ReplPage<object?>(
+			items,
+			new ReplPageInfo(
+				Cursor: null,
+				NextCursor: null,
+				TotalCount: items.Length,
+				PageSize: items.Length));
+
+		page.UntypedItems.Should().BeSameAs(items);
+	}
+
 	private static async IAsyncEnumerable<string> ReadItemsAsync(IEnumerable<string> items)
 	{
 		foreach (var item in items)

--- a/src/Repl.Tests/Given_ReplPageSource.cs
+++ b/src/Repl.Tests/Given_ReplPageSource.cs
@@ -274,6 +274,19 @@ public sealed class Given_ReplPageSource
 		page.PageInfo.HasMore.Should().BeTrue();
 	}
 
+	[TestMethod]
+	[Description("ReplPageInfo derives HasMore from NextCursor so manual construction cannot create divergent page metadata.")]
+	public void When_PageInfoHasNoNextCursor_Then_HasMoreIsFalse()
+	{
+		var pageInfo = new ReplPageInfo(
+			Cursor: "current",
+			NextCursor: null,
+			TotalCount: null,
+			PageSize: 10);
+
+		pageInfo.HasMore.Should().BeFalse();
+	}
+
 	private static async IAsyncEnumerable<string> ReadItemsAsync(IEnumerable<string> items)
 	{
 		foreach (var item in items)

--- a/src/Repl.Tests/Given_ReplPageSource.cs
+++ b/src/Repl.Tests/Given_ReplPageSource.cs
@@ -160,6 +160,46 @@ public sealed class Given_ReplPageSource
 	}
 
 	[TestMethod]
+	[Description("ReplPageSource.FromItems rejects malformed offset cursors instead of silently replaying the first page.")]
+	public async Task When_FromItemsReceivesMalformedCursor_Then_FailsClearly()
+	{
+		var source = ReplPageSource.FromItems(["one", "two", "three"]);
+
+		var action = async () => await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: "abc",
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console)).ConfigureAwait(false);
+
+		await action.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*cursor*offset*")
+			.ConfigureAwait(false);
+	}
+
+	[TestMethod]
+	[Description("ReplPageSource.FromOffset rejects negative offset cursors instead of silently replaying the first page.")]
+	public async Task When_FromOffsetReceivesNegativeCursor_Then_FailsClearly()
+	{
+		var source = ReplPageSource.FromOffset<int>(
+			static (offset, take, _) => ValueTask.FromResult<IReadOnlyList<int>>(
+				Enumerable.Range(offset, take).ToArray()));
+
+		var action = async () => await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: "-1",
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console)).ConfigureAwait(false);
+
+		await action.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*cursor*offset*")
+			.ConfigureAwait(false);
+	}
+
+	[TestMethod]
 	[Description("ReplPageSource.FromAsyncEnumerable pages async streams with offset cursors.")]
 	public async Task When_FromAsyncEnumerableFetchesPages_Then_EmitsOffsetCursor()
 	{

--- a/src/Repl.Tests/Given_ReplPageSource.cs
+++ b/src/Repl.Tests/Given_ReplPageSource.cs
@@ -189,6 +189,31 @@ public sealed class Given_ReplPageSource
 	}
 
 	[TestMethod]
+	[Description("ReplPageSource.FromAsyncEnumerable requires deterministic replay so page two returns the raw offset continuation.")]
+	public async Task When_FromAsyncEnumerableFactoryIsDeterministic_Then_SecondPageUsesRawOffset()
+	{
+		var source = ReplPageSource.FromAsyncEnumerable(_ => ReadItemsAsync(["one", "two", "three", "four"]));
+
+		var first = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: null,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+		var second = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: first.PageInfo.NextCursor,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+
+		second.Items.Should().Equal("three", "four");
+		second.PageInfo.Cursor.Should().Be("2");
+	}
+
+	[TestMethod]
 	[Description("ReplPageSource.FromAsyncEnumerable requires a replayable factory and fails clearly when the factory returns a single-use stream.")]
 	public async Task When_FromAsyncEnumerableFactoryIsNotReplayable_Then_SecondPageFailsClearly()
 	{
@@ -286,6 +311,17 @@ public sealed class Given_ReplPageSource
 
 		page.Items.Should().Equal("one", "two");
 		page.PageInfo.NextCursor.Should().Be("2");
+
+		var second = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: page.PageInfo.NextCursor,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+
+		second.Items.Should().Equal("four");
+		second.PageInfo.HasMore.Should().BeFalse();
 	}
 
 	[TestMethod]

--- a/src/Repl.Tests/Given_ReplPageSource.cs
+++ b/src/Repl.Tests/Given_ReplPageSource.cs
@@ -276,9 +276,28 @@ public sealed class Given_ReplPageSource
 				AllRequested: false,
 				Surface: ReplResultSurface.Console)).ConfigureAwait(false);
 
-		await action.Should().ThrowAsync<InvalidOperationException>()
-			.WithMessage("*replayable*")
-			.ConfigureAwait(false);
+		await action.Should().ThrowAsync<InvalidOperationException>().ConfigureAwait(false);
+	}
+
+	[TestMethod]
+	[Description("ReplPageSource.FromAsyncEnumerable starts scan-limit accounting after the raw offset skip.")]
+	public async Task When_FromAsyncEnumerableUsesDeepOffset_Then_ScanLimitAppliesAfterOffset()
+	{
+		var source = ReplPageSource.FromAsyncEnumerable(
+			_ => ReadIntItemsAsync(Enumerable.Range(0, 100)),
+			filter: static _ => true,
+			maxSourceItemsToScan: 3);
+
+		var page = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: "50",
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+
+		page.Items.Should().Equal(50, 51);
+		page.PageInfo.NextCursor.Should().Be("52");
 	}
 
 	[TestMethod]
@@ -436,6 +455,15 @@ public sealed class Given_ReplPageSource
 	}
 
 	private static async IAsyncEnumerable<string> ReadItemsAsync(IEnumerable<string> items)
+	{
+		foreach (var item in items)
+		{
+			await Task.Yield();
+			yield return item;
+		}
+	}
+
+	private static async IAsyncEnumerable<int> ReadIntItemsAsync(IEnumerable<int> items)
 	{
 		foreach (var item in items)
 		{

--- a/src/Repl.Tests/Given_ReplPageSource.cs
+++ b/src/Repl.Tests/Given_ReplPageSource.cs
@@ -189,6 +189,62 @@ public sealed class Given_ReplPageSource
 	}
 
 	[TestMethod]
+	[Description("ReplPageSource.FromAsyncEnumerable requires a replayable factory and fails clearly when the factory returns a single-use stream.")]
+	public async Task When_FromAsyncEnumerableFactoryIsNotReplayable_Then_SecondPageFailsClearly()
+	{
+		var state = new SingleUseAsyncEnumerable<string>(["one", "two", "three"]);
+		var source = ReplPageSource.FromAsyncEnumerable(_ => state);
+
+		var first = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: null,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+
+		var action = async () => await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: first.PageInfo.NextCursor,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console)).ConfigureAwait(false);
+
+		await action.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*replayable*")
+			.ConfigureAwait(false);
+	}
+
+	[TestMethod]
+	[Description("ReplPageSource.FromOffset enforces the client-side filter scan limit per source item.")]
+	public async Task When_FilteredOffsetSourceExceedsScanLimit_Then_FailsBeforeFetchingAnotherBatch()
+	{
+		var fetches = 0;
+		var source = ReplPageSource.FromOffset<int>(
+			(_, take, _) =>
+			{
+				fetches++;
+				return ValueTask.FromResult<IReadOnlyList<int>>(Enumerable.Range(0, take).ToArray());
+			},
+			filter: static _ => false,
+			maxSourceItemsToScan: 2);
+
+		var action = async () => await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: null,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console)).ConfigureAwait(false);
+
+		await action.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*scan limit*")
+			.ConfigureAwait(false);
+		fetches.Should().Be(1);
+	}
+
+	[TestMethod]
 	[Description("ReplPageSource.FromAsyncEnumerable passes cancellation to the async stream.")]
 	public async Task When_FromAsyncEnumerableIsCancelled_Then_SourceObservesCancellation()
 	{
@@ -314,4 +370,25 @@ public sealed class Given_ReplPageSource
 	}
 
 	private sealed record PageStore(IReadOnlyList<string> Items);
+
+	private sealed class SingleUseAsyncEnumerable<T>(IReadOnlyList<T> items) : IAsyncEnumerable<T>
+	{
+		private bool _used;
+
+		public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+		{
+			if (_used)
+			{
+				throw new InvalidOperationException("The stream is not replayable.");
+			}
+
+			_used = true;
+			foreach (var item in items)
+			{
+				await Task.Yield();
+				cancellationToken.ThrowIfCancellationRequested();
+				yield return item;
+			}
+		}
+	}
 }

--- a/src/Repl.Tests/Given_ReplPageSource.cs
+++ b/src/Repl.Tests/Given_ReplPageSource.cs
@@ -1,0 +1,304 @@
+namespace Repl.Tests;
+
+using System.Runtime.CompilerServices;
+
+[TestClass]
+public sealed class Given_ReplPageSource
+{
+	[TestMethod]
+	[Description("ReplPageSource.FromItems uses offset cursors so in-memory result sets can be paged without custom interface implementations.")]
+	public async Task When_FromItemsFetchesPages_Then_EmitsOffsetCursor()
+	{
+		var source = ReplPageSource.FromItems(["one", "two", "three"]);
+
+		var first = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: null,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+		var second = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: first.PageInfo.NextCursor,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+
+		first.Items.Should().Equal("one", "two");
+		first.PageInfo.NextCursor.Should().Be("2");
+		first.PageInfo.HasMore.Should().BeTrue();
+		second.Items.Should().Equal("three");
+		second.PageInfo.NextCursor.Should().BeNull();
+		second.PageInfo.HasMore.Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("ReplPageSource.FromOffset fetches one extra row so offset-based stores do not need to compute totals.")]
+	public async Task When_FromOffsetFetchesPages_Then_EmitsOffsetCursor()
+	{
+		var all = new[] { "one", "two", "three" };
+		var source = ReplPageSource.FromOffset<string>((offset, take, _) =>
+			ValueTask.FromResult<IReadOnlyList<string>>(all.Skip(offset).Take(take).ToArray()), all.Length);
+
+		var first = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: null,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+		var second = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: first.PageInfo.NextCursor,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+
+		first.Items.Should().Equal("one", "two");
+		first.PageInfo.NextCursor.Should().Be("2");
+		first.PageInfo.TotalCount.Should().Be(3);
+		second.Items.Should().Equal("three");
+		second.PageInfo.HasMore.Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("ReplPageSource.FromOffset supports state arguments so handlers can use static lambdas without closure allocations.")]
+	public async Task When_FromOffsetUsesState_Then_StaticFetchCanReadState()
+	{
+		var state = new PageStore(["one", "two", "three"]);
+		var source = ReplPageSource.FromOffset<string, PageStore>(
+			state,
+			static (store, offset, take, _) =>
+				ValueTask.FromResult<IReadOnlyList<string>>(store.Items.Skip(offset).Take(take).ToArray()));
+
+		var page = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: null,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+
+		page.Items.Should().Equal("one", "two");
+		page.PageInfo.NextCursor.Should().Be("2");
+		page.PageInfo.TotalCount.Should().BeNull();
+	}
+
+	[TestMethod]
+	[Description("ReplPageSource.FromOffset can apply a client-side filter after source paging and before the final page is emitted.")]
+	public async Task When_FromOffsetUsesClientSideFilter_Then_PageContainsFilteredItems()
+	{
+		var state = new PageStore(["one", "two", "three", "four", "five", "six"]);
+		var source = ReplPageSource.FromOffset<string, PageStore>(
+			state,
+			static (store, offset, take, _) =>
+				ValueTask.FromResult<IReadOnlyList<string>>(store.Items.Skip(offset).Take(take).ToArray()),
+			filter: static (_, item) => item.Length == 3);
+
+		var first = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: null,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+		var second = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: first.PageInfo.NextCursor,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+
+		first.Items.Should().Equal("one", "two");
+		first.PageInfo.NextCursor.Should().Be("2");
+		first.PageInfo.TotalCount.Should().BeNull();
+		second.Items.Should().Equal("six");
+		second.PageInfo.HasMore.Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("ReplPageSource.FromOffset fails clearly when All is requested because unbounded source paging can exhaust memory.")]
+	public async Task When_FromOffsetReceivesAllRequest_Then_FailsClearly()
+	{
+		var source = ReplPageSource.FromOffset<int>(
+			static (_, take, _) => ValueTask.FromResult<IReadOnlyList<int>>(Enumerable.Range(0, take).ToArray()));
+
+		var action = async () => await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: null,
+				VisibleRowCapacityHint: null,
+				AllRequested: true,
+				Surface: ReplResultSurface.Console)).ConfigureAwait(false);
+
+		await action.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*--result:all*not supported*")
+			.ConfigureAwait(false);
+	}
+
+	[TestMethod]
+	[Description("ReplPageSource.FromOffset treats an explicit zero cursor as the first offset.")]
+	public async Task When_FromOffsetReceivesZeroCursor_Then_StartsAtFirstItem()
+	{
+		var source = ReplPageSource.FromOffset<int>(
+			static (offset, take, _) => ValueTask.FromResult<IReadOnlyList<int>>(
+				Enumerable.Range(offset, take).ToArray()));
+
+		var page = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: "0",
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+
+		page.Items.Should().Equal(0, 1);
+	}
+
+	[TestMethod]
+	[Description("ReplPageSource.FromAsyncEnumerable pages async streams with offset cursors.")]
+	public async Task When_FromAsyncEnumerableFetchesPages_Then_EmitsOffsetCursor()
+	{
+		var source = ReplPageSource.FromAsyncEnumerable(_ => ReadItemsAsync(["one", "two", "three"]));
+
+		var first = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: null,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+		var second = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: first.PageInfo.NextCursor,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+
+		first.Items.Should().Equal("one", "two");
+		first.PageInfo.NextCursor.Should().Be("2");
+		first.PageInfo.HasMore.Should().BeTrue();
+		second.Items.Should().Equal("three");
+		second.PageInfo.NextCursor.Should().BeNull();
+		second.PageInfo.HasMore.Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("ReplPageSource.FromAsyncEnumerable passes cancellation to the async stream.")]
+	public async Task When_FromAsyncEnumerableIsCancelled_Then_SourceObservesCancellation()
+	{
+		using var cts = new CancellationTokenSource();
+		var observed = false;
+		var source = ReplPageSource.FromAsyncEnumerable(ct => ReadUntilCancelledAsync(() => observed = true, ct));
+		await cts.CancelAsync().ConfigureAwait(false);
+
+		var action = async () => await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: null,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console),
+			cts.Token).ConfigureAwait(false);
+
+		await action.Should().ThrowAsync<OperationCanceledException>().ConfigureAwait(false);
+		observed.Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("ReplPageSource.FromAsyncEnumerable supports state arguments and client-side filtering over replayable streams.")]
+	public async Task When_FromAsyncEnumerableUsesStateAndFilter_Then_StaticFactoryCanReadState()
+	{
+		var state = new PageStore(["one", "two", "three", "four"]);
+		var source = ReplPageSource.FromAsyncEnumerable<string, PageStore>(
+			state,
+			static (store, _) => ReadItemsAsync(store.Items),
+			filter: static (_, item) => item.Contains('o', StringComparison.Ordinal));
+
+		var page = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: null,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+
+		page.Items.Should().Equal("one", "two");
+		page.PageInfo.NextCursor.Should().Be("2");
+	}
+
+	[TestMethod]
+	[Description("ReplPageSource.FromItems can filter bounded in-memory data before applying the final page window.")]
+	public async Task When_FromItemsUsesFilter_Then_PagesFilteredItems()
+	{
+		var source = ReplPageSource.FromItems(
+			["one", "two", "three", "four"],
+			static item => item.Contains('o', StringComparison.Ordinal));
+
+		var page = await source.FetchAsync(
+			new ReplPageRequest(
+				PageSize: 2,
+				Cursor: null,
+				VisibleRowCapacityHint: null,
+				AllRequested: false,
+				Surface: ReplResultSurface.Console));
+
+		page.Items.Should().Equal("one", "two");
+		page.PageInfo.NextCursor.Should().Be("2");
+		page.PageInfo.TotalCount.Should().Be(3);
+	}
+
+	[TestMethod]
+	[Description("ReplPageRequest.Page copies request metadata and marks HasMore from the emitted cursor.")]
+	public void When_RequestCreatesPage_Then_PageInfoUsesRequestAndNextCursor()
+	{
+		var request = new ReplPageRequest(
+			PageSize: 5,
+			Cursor: "start",
+			VisibleRowCapacityHint: 10,
+			AllRequested: false,
+			Surface: ReplResultSurface.Console);
+
+		var page = request.Page(["one"], nextCursor: "next", totalCount: 2);
+
+		page.Items.Should().Equal("one");
+		page.PageInfo.Cursor.Should().Be("start");
+		page.PageInfo.NextCursor.Should().Be("next");
+		page.PageInfo.TotalCount.Should().Be(2);
+		page.PageInfo.PageSize.Should().Be(5);
+		page.PageInfo.HasMore.Should().BeTrue();
+	}
+
+	private static async IAsyncEnumerable<string> ReadItemsAsync(IEnumerable<string> items)
+	{
+		foreach (var item in items)
+		{
+			await Task.Yield();
+			yield return item;
+		}
+	}
+
+	private static async IAsyncEnumerable<int> ReadUntilCancelledAsync(
+		Action observeCancellation,
+		[EnumeratorCancellation] CancellationToken cancellationToken)
+	{
+		while (true)
+		{
+			if (cancellationToken.IsCancellationRequested)
+			{
+				observeCancellation();
+			}
+
+			cancellationToken.ThrowIfCancellationRequested();
+			await Task.Yield();
+			yield return 1;
+		}
+	}
+
+	private sealed record PageStore(IReadOnlyList<string> Items);
+}

--- a/src/Repl.Tests/Given_ResultFlowOutputTransformer.cs
+++ b/src/Repl.Tests/Given_ResultFlowOutputTransformer.cs
@@ -1,0 +1,92 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Repl.Tests;
+
+[TestClass]
+public sealed class Given_ResultFlowOutputTransformer
+{
+	[TestMethod]
+	[Description("Result-flow continuation payloads render table rows only so pagers do not receive repeated headers or page footers.")]
+	public async Task When_RenderingHumanContinuationPage_Then_HeaderAndFooterAreOmitted()
+	{
+		var transformer = new HumanOutputTransformer(
+			() => new HumanRenderSettings(
+				Width: 120,
+				UseAnsi: false,
+				Palette: new DefaultAnsiPaletteProvider().Create(ThemeMode.Dark)));
+		var page = new ReplPage<ActivityRow>(
+			[
+				new ActivityRow(
+					Id: 49,
+					At: "2026-01-12 13:43Z",
+					Area: "identity",
+					Event: "validated",
+					Summary: "identity batch 10 validated successfully"),
+				new ActivityRow(
+					Id: 50,
+					At: "2026-01-12 13:50Z",
+					Area: "billing",
+					Event: "queued",
+					Summary: "billing batch 10 queued successfully"),
+			],
+			new ReplPageInfo(
+				Cursor: "48",
+				NextCursor: "50",
+				TotalCount: 250,
+				PageSize: 2));
+
+		var output = await ((IResultFlowOutputTransformer)transformer).TransformPageAsync(
+			page,
+			ResultFlowPageRenderMode.Continuation,
+			CancellationToken.None);
+
+		output.Should().NotContain("#");
+		output.Should().NotContain("---");
+		output.Should().NotContain("Showing ");
+		output.Should().Contain("49");
+		output.Should().Contain("identity batch 10 validated successfully");
+		output.Should().Contain("50");
+		output.Should().Contain("billing batch 10 queued successfully");
+	}
+
+	[TestMethod]
+	[Description("Result-flow initial payloads keep the table header so the first page remains readable.")]
+	public async Task When_RenderingHumanInitialPage_Then_HeaderIsIncluded()
+	{
+		var transformer = new HumanOutputTransformer(
+			() => new HumanRenderSettings(
+				Width: 120,
+				UseAnsi: false,
+				Palette: new DefaultAnsiPaletteProvider().Create(ThemeMode.Dark)));
+		var page = new ReplPage<ActivityRow>(
+			[
+				new ActivityRow(
+					Id: 49,
+					At: "2026-01-12 13:43Z",
+					Area: "identity",
+					Event: "validated",
+					Summary: "identity batch 10 validated successfully"),
+			],
+			new ReplPageInfo(
+				Cursor: null,
+				NextCursor: "49",
+				TotalCount: 250,
+				PageSize: 1));
+
+		var output = await ((IResultFlowOutputTransformer)transformer).TransformPageAsync(
+			page,
+			ResultFlowPageRenderMode.Initial,
+			CancellationToken.None);
+
+		output.Should().Contain("#");
+		output.Should().Contain("At");
+		output.Should().NotContain("Showing ");
+	}
+
+	private sealed record ActivityRow(
+		[property: Display(Name = "#", Order = 0)] int Id,
+		[property: Display(Name = "At", Order = 1)] string At,
+		[property: Display(Name = "Area", Order = 2)] string Area,
+		[property: Display(Name = "Event", Order = 3)] string Event,
+		[property: Display(Name = "Summary", Order = 4)] string Summary);
+}

--- a/src/Repl.Tests/Given_ResultFlowOutputTransformer.cs
+++ b/src/Repl.Tests/Given_ResultFlowOutputTransformer.cs
@@ -83,6 +83,48 @@ public sealed class Given_ResultFlowOutputTransformer
 		output.Should().NotContain("Showing ");
 	}
 
+	[TestMethod]
+	[Description("Human page footers never render unsafe cursor text directly.")]
+	public async Task When_HumanPageFooterHasUnsafeCursor_Then_CursorIsNotRenderedVerbatim()
+	{
+		var transformer = new HumanOutputTransformer(
+			() => new HumanRenderSettings(
+				Width: 120,
+				UseAnsi: false,
+				Palette: new DefaultAnsiPaletteProvider().Create(ThemeMode.Dark)));
+		var page = new ReplPage<ActivityRow>(
+			[new ActivityRow(1, "2026-01-12 12:00Z", "ops", "queued", "queued")],
+			new ReplPageInfo(
+				Cursor: null,
+				NextCursor: "abc\u001b[2J",
+				TotalCount: 2,
+				PageSize: 1));
+
+		var output = await transformer.TransformAsync(page, CancellationToken.None);
+
+		output.Should().NotContain("\u001b[2J");
+		output.Should().Contain("cursor");
+	}
+
+	[TestMethod]
+	[Description("Markdown page footers never render unsafe cursor text directly.")]
+	public async Task When_MarkdownPageFooterHasUnsafeCursor_Then_CursorIsNotRenderedVerbatim()
+	{
+		var transformer = new MarkdownOutputTransformer();
+		var page = new ReplPage<ActivityRow>(
+			[new ActivityRow(1, "2026-01-12 12:00Z", "ops", "queued", "queued")],
+			new ReplPageInfo(
+				Cursor: null,
+				NextCursor: "abc\u001b[2J",
+				TotalCount: 2,
+				PageSize: 1));
+
+		var output = await transformer.TransformAsync(page, CancellationToken.None);
+
+		output.Should().NotContain("\u001b[2J");
+		output.Should().Contain("cursor");
+	}
+
 	private sealed record ActivityRow(
 		[property: Display(Name = "#", Order = 0)] int Id,
 		[property: Display(Name = "At", Order = 1)] string At,

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -263,7 +263,7 @@ public sealed class Given_ResultFlowPager
 			{
 				fetches++;
 				return ValueTask.FromResult<ResultFlowPagerPage?>(
-					new ResultFlowPagerPage("three\nfour", HasMore: false));
+					new ResultFlowPagerPage("four\nfive", HasMore: false));
 			},
 			CancellationToken.None);
 
@@ -410,6 +410,89 @@ public sealed class Given_ResultFlowPager
 
 		// Enter maps to DownArrow (one line); status bar should show 2-3/4, not 3-4/4
 		writer.ToString().Should().Contain("2-3/4");
+	}
+
+	[TestMethod]
+	[Description("Result-flow scroll pager advances by one line when Down fetches the next payload at a boundary.")]
+	public async Task When_ScrollPagerDownFetchesNextPayload_Then_ViewportAdvancesOneLine()
+	{
+		using var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.DownArrow, '\0'),
+			MakeKey(ConsoleKey.DownArrow, '\0'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nthree",
+			writer,
+			keys,
+			visibleRows: 3,
+			pagerMode: ReplPagerMode.Scroll,
+			ansiEnabled: true,
+			hasMorePayload: true,
+			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
+				new ResultFlowPagerPage("four\nfive", HasMore: false)),
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Should().Contain("2-3/3+");
+		output.Should().Contain("3-4/5");
+		output.Should().NotContain("4-5/5");
+	}
+
+	[TestMethod]
+	[Description("Result-flow scroll pager keeps a rich table header pinned and skips duplicate headers from later payloads.")]
+	public async Task When_ScrollPagerHasRichTableHeader_Then_HeaderStaysPinned()
+	{
+		using var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.Spacebar, ' '),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+		var header = "\u001b[1m#\u001b[0m  \u001b[1mAt\u001b[0m";
+
+		await ResultFlowPager.WriteAsync(
+			$"{header}\none\ntwo\nthree",
+			writer,
+			keys,
+			visibleRows: 4,
+			pagerMode: ReplPagerMode.Scroll,
+			ansiEnabled: true,
+			hasMorePayload: true,
+			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
+				new ResultFlowPagerPage($"{header}\nfour\nfive", HasMore: false)),
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Should().Contain($"{header}\r\n\u001b[2Kthree\r\n\u001b[2Kfour");
+		output.Should().Contain("3-4/5");
+	}
+
+	[TestMethod]
+	[Description("Result-flow scroll pager does not clear the whole viewport on every redraw.")]
+	public async Task When_ScrollPagerRedraws_Then_DoesNotClearScreenEveryTime()
+	{
+		using var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.DownArrow, '\0'),
+			MakeKey(ConsoleKey.DownArrow, '\0'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nthree\nfour",
+			writer,
+			keys,
+			visibleRows: 3,
+			pagerMode: ReplPagerMode.Scroll,
+			ansiEnabled: true,
+			CancellationToken.None);
+
+		writer.ToString().Split("\u001b[J").Length.Should().Be(2);
 	}
 
 	private static ConsoleKeyInfo MakeKey(ConsoleKey key, char keyChar) =>

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -209,6 +209,71 @@ public sealed class Given_ResultFlowPager
 		output.Split("four", StringSplitOptions.None).Should().HaveCount(3);
 	}
 
+	[TestMethod]
+	[Description("Result-flow scroll pager owns an alternate-screen viewport instead of relying on terminal scrollback.")]
+	public async Task When_ScrollPagerRunsWithAnsi_Then_UsesAlternateScreenViewport()
+	{
+		var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.DownArrow, '\0'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nthree",
+			writer,
+			keys,
+			visibleRows: 3,
+			pagerMode: ReplPagerMode.Scroll,
+			ansiEnabled: true,
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Should().Contain("\u001b[?1049h");
+		output.Should().Contain("\u001b[?1049l");
+		output.Should().Contain("\u001b[H\u001b[J");
+		output.Should().Contain("one");
+		output.Should().Contain("three");
+		output.Should().Contain("q: quit");
+		output.Should().NotContain("--More--");
+	}
+
+	[TestMethod]
+	[Description("Result-flow scroll pager fetches additional payloads into the same viewport when the user pages past the buffered end.")]
+	public async Task When_ScrollPagerReachesBufferedEnd_Then_FetchesNextPayload()
+	{
+		var writer = new StringWriter();
+		var fetches = 0;
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.Spacebar, ' '),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo",
+			writer,
+			keys,
+			visibleRows: 3,
+			pagerMode: ReplPagerMode.Scroll,
+			ansiEnabled: true,
+			hasMorePayload: true,
+			fetchNextPayload: _ =>
+			{
+				fetches++;
+				return ValueTask.FromResult<ResultFlowPagerPage?>(
+					new ResultFlowPagerPage("three\nfour", HasMore: false));
+			},
+			CancellationToken.None);
+
+		fetches.Should().Be(1);
+		var output = writer.ToString();
+		output.Should().Contain("one");
+		output.Should().Contain("four");
+		output.Should().Contain("\u001b[?1049h");
+	}
+
 	private static ConsoleKeyInfo MakeKey(ConsoleKey key, char keyChar) =>
 		new(keyChar, key, shift: false, alt: false, control: false);
 }

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -62,6 +62,36 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
+	[Description("Result-flow more pager clears the prompt before writing the next row when ANSI rendering is available.")]
+	public async Task When_MorePagerUsesAnsiPrompt_Then_PromptDoesNotBecomeAVisibleRow()
+	{
+		using var writer = new StringWriter();
+		const string morePrompt = "--More-- Space/PageDown: continue, Enter/Down: line, Up/PageUp: ignored, q/Esc: stop";
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.DownArrow, '\0'),
+			MakeKey(ConsoleKey.DownArrow, '\0'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nthree\nfour",
+			writer,
+			keys,
+			visibleRows: 2,
+			pagerMode: ReplPagerMode.More,
+			ansiEnabled: true,
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Should().Contain($"two{Environment.NewLine}{morePrompt}");
+		output.Should().Contain($"{morePrompt}\r{new string(' ', morePrompt.Length)}\rthree");
+		output.Should().Contain($"{morePrompt}\r{new string(' ', morePrompt.Length)}\rfour");
+		output.Should().NotContain($"{morePrompt}{Environment.NewLine}three");
+		output.Should().NotContain($"{morePrompt}{Environment.NewLine}four");
+	}
+
+	[TestMethod]
 	[Description("Result-flow more pager ignores UpArrow because append-only output cannot redraw previous lines cleanly.")]
 	public async Task When_MorePagerReceivesUpArrow_Then_DoesNotReplayOrAdvance()
 	{

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -356,6 +356,62 @@ public sealed class Given_ResultFlowPager
 		writer.ToString().Should().Contain("1-2/2");
 	}
 
+	[TestMethod]
+	[Description("Result-flow scroll pager treats unrecognized keys as no-ops and does not advance the viewport or trigger a fetch.")]
+	public async Task When_ScrollPagerUnknownKeyPressed_Then_ViewportDoesNotAdvanceAndNoFetch()
+	{
+		var writer = new StringWriter();
+		var fetches = 0;
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.F1, '\0'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nthree\nfour",
+			writer,
+			keys,
+			visibleRows: 3,
+			pagerMode: ReplPagerMode.Scroll,
+			ansiEnabled: true,
+			hasMorePayload: true,
+			fetchNextPayload: _ =>
+			{
+				fetches++;
+				return ValueTask.FromResult<ResultFlowPagerPage?>(
+					new ResultFlowPagerPage("five", HasMore: false));
+			},
+			CancellationToken.None);
+
+		fetches.Should().Be(0);
+		writer.ToString().Should().NotContain("five");
+	}
+
+	[TestMethod]
+	[Description("Result-flow scroll pager advances the viewport only on Space/PageDown, not on Enter or other keys.")]
+	public async Task When_ScrollPagerEnterKeyPressed_Then_ViewportAdvancesByOneLine()
+	{
+		var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.Enter, '\r'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nthree\nfour",
+			writer,
+			keys,
+			visibleRows: 3,
+			pagerMode: ReplPagerMode.Scroll,
+			ansiEnabled: true,
+			CancellationToken.None);
+
+		// Enter maps to DownArrow (one line); status bar should show 2-3/4, not 3-4/4
+		writer.ToString().Should().Contain("2-3/4");
+	}
+
 	private static ConsoleKeyInfo MakeKey(ConsoleKey key, char keyChar) =>
 		new(keyChar, key, shift: false, alt: false, control: false);
 }

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -32,7 +32,7 @@ public sealed class Given_ResultFlowPager
 		output.Should().Contain("--More--");
 		output.Should().Contain("Space/PageDown: continue");
 		output.Should().Contain("Enter/Down: line");
-		output.Should().Contain("Up/PageUp: back");
+		output.Should().Contain("Up/PageUp: ignored");
 		output.Should().Contain("q/Esc: stop");
 	}
 
@@ -62,30 +62,28 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
-	[Description("Result-flow pager UpArrow moves back one line instead of jumping to the header.")]
-	public async Task When_PagingBackWithUpArrow_Then_DoesNotRepeatHeader()
+	[Description("Result-flow more pager ignores UpArrow because append-only output cannot redraw previous lines cleanly.")]
+	public async Task When_MorePagerReceivesUpArrow_Then_DoesNotReplayOrAdvance()
 	{
 		using var writer = new StringWriter();
 		var keys = new FakeKeyReader(
 		[
-			MakeKey(ConsoleKey.Spacebar, ' '),
 			MakeKey(ConsoleKey.UpArrow, '\0'),
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
 		await ResultFlowPager.WriteAsync(
-			"# At Area Event Summary\nr1\nr2\nr3\nr4\nr5",
+			"# At Area Event Summary\n---\nr1\nr2\nr3\nr4\nr5",
 			writer,
 			keys,
 			visibleRows: 2,
 			CancellationToken.None);
 
 		var output = writer.ToString();
-		output.Split("# At Area Event Summary", StringSplitOptions.None)
-			.Should().HaveCount(2);
+		output.Split("# At Area Event Summary", StringSplitOptions.None).Should().HaveCount(2);
 		output.Should().Contain("r1");
 		output.Should().Contain("r2");
-		output.Should().Contain("r3");
+		output.Should().NotContain("r3");
 	}
 
 	[TestMethod]
@@ -184,8 +182,8 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
-	[Description("Result-flow pager replays the previous full window when the user presses UpArrow at a data-page boundary.")]
-	public async Task When_AtPayloadBoundaryAndUserPressesUpArrow_Then_ReplaysPreviousWindow()
+	[Description("Result-flow more pager ignores UpArrow at a payload boundary instead of replaying previous lines.")]
+	public async Task When_MorePagerAtPayloadBoundaryReceivesUpArrow_Then_DoesNotReplayOrFetch()
 	{
 		using var writer = new StringWriter();
 		var keys = new FakeKeyReader(
@@ -205,12 +203,40 @@ public sealed class Given_ResultFlowPager
 			CancellationToken.None);
 
 		var output = writer.ToString();
-		output.Split("three", StringSplitOptions.None).Should().HaveCount(3);
-		output.Split("four", StringSplitOptions.None).Should().HaveCount(3);
+		output.Split("three", StringSplitOptions.None).Should().HaveCount(2);
+		output.Split("four", StringSplitOptions.None).Should().HaveCount(2);
 	}
 
 	[TestMethod]
-	[Description("Result-flow scroll pager owns an alternate-screen viewport instead of relying on terminal scrollback.")]
+	[Description("Result-flow more pager strips duplicate page headers and page footers from fetched payloads.")]
+	public async Task When_MorePagerFetchesNextPayload_Then_DuplicateHeadersAndFootersAreSkipped()
+	{
+		using var writer = new StringWriter();
+		var header = "#    At";
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.Spacebar, ' '),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			$"{header}\none\ntwo\nShowing 2 of 5.",
+			writer,
+			keys,
+			visibleRows: 4,
+			hasMorePayload: true,
+			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
+				new ResultFlowPagerPage($"{header}\nthree\nShowing 1 of 5.", HasMore: false)),
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Split(header, StringSplitOptions.None).Should().HaveCount(3);
+		output.Should().Contain("three");
+		output.Should().NotContain("Showing 2 of 5");
+		output.Should().NotContain("Showing 1 of 5");
+	}
+
+	[TestMethod]
+	[Description("Result-flow full pager owns an alternate-screen viewport instead of relying on terminal scrollback.")]
 	public async Task When_ScrollPagerRunsWithAnsi_Then_UsesAlternateScreenViewport()
 	{
 		using var writer = new StringWriter();
@@ -225,7 +251,7 @@ public sealed class Given_ResultFlowPager
 			writer,
 			keys,
 			visibleRows: 3,
-			pagerMode: ReplPagerMode.Scroll,
+			pagerMode: ReplPagerMode.Full,
 			ansiEnabled: true,
 			CancellationToken.None);
 
@@ -240,7 +266,7 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
-	[Description("Result-flow scroll pager fetches additional payloads into the same viewport when the user pages past the buffered end.")]
+	[Description("Result-flow full pager fetches additional payloads into the same viewport when the user pages past the buffered end.")]
 	public async Task When_ScrollPagerReachesBufferedEnd_Then_FetchesNextPayload()
 	{
 		using var writer = new StringWriter();
@@ -256,7 +282,7 @@ public sealed class Given_ResultFlowPager
 			writer,
 			keys,
 			visibleRows: 3,
-			pagerMode: ReplPagerMode.Scroll,
+			pagerMode: ReplPagerMode.Full,
 			ansiEnabled: true,
 			hasMorePayload: true,
 			fetchNextPayload: _ =>
@@ -275,7 +301,7 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
-	[Description("Result-flow scroll pager advances to the new buffered end when a fetch returns fewer lines than one viewport.")]
+	[Description("Result-flow full pager advances to the new buffered end when a fetch returns fewer lines than one viewport.")]
 	public async Task When_ScrollPagerFetchesShortPayload_Then_ViewportAdvances()
 	{
 		using var writer = new StringWriter();
@@ -290,7 +316,7 @@ public sealed class Given_ResultFlowPager
 			writer,
 			keys,
 			visibleRows: 4,
-			pagerMode: ReplPagerMode.Scroll,
+			pagerMode: ReplPagerMode.Full,
 			ansiEnabled: true,
 			hasMorePayload: true,
 			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
@@ -303,7 +329,7 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
-	[Description("Result-flow scroll pager does not fetch another payload when the current payload is exactly visible and the user presses Space once.")]
+	[Description("Result-flow full pager does not fetch another payload when the current payload is exactly visible and the user presses Space once.")]
 	public async Task When_ScrollPagerContentExactlyFitsViewport_Then_SpaceDoesNotFetchImmediately()
 	{
 		using var writer = new StringWriter();
@@ -319,7 +345,7 @@ public sealed class Given_ResultFlowPager
 			writer,
 			keys,
 			visibleRows: 4,
-			pagerMode: ReplPagerMode.Scroll,
+			pagerMode: ReplPagerMode.Full,
 			ansiEnabled: true,
 			hasMorePayload: true,
 			fetchNextPayload: _ =>
@@ -349,7 +375,7 @@ public sealed class Given_ResultFlowPager
 			writer,
 			keys,
 			visibleRows: 3,
-			pagerMode: ReplPagerMode.Scroll,
+			pagerMode: ReplPagerMode.Full,
 			ansiEnabled: true,
 			CancellationToken.None);
 
@@ -357,7 +383,7 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
-	[Description("Result-flow scroll pager treats unrecognized keys as no-ops and does not advance the viewport or trigger a fetch.")]
+	[Description("Result-flow full pager treats unrecognized keys as no-ops and does not advance the viewport or trigger a fetch.")]
 	public async Task When_ScrollPagerUnknownKeyPressed_Then_ViewportDoesNotAdvanceAndNoFetch()
 	{
 		using var writer = new StringWriter();
@@ -373,7 +399,7 @@ public sealed class Given_ResultFlowPager
 			writer,
 			keys,
 			visibleRows: 3,
-			pagerMode: ReplPagerMode.Scroll,
+			pagerMode: ReplPagerMode.Full,
 			ansiEnabled: true,
 			hasMorePayload: true,
 			fetchNextPayload: _ =>
@@ -389,7 +415,7 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
-	[Description("Result-flow scroll pager advances the viewport only on Space/PageDown, not on Enter or other keys.")]
+	[Description("Result-flow full pager advances the viewport only on Space/PageDown, not on Enter or other keys.")]
 	public async Task When_ScrollPagerEnterKeyPressed_Then_ViewportAdvancesByOneLine()
 	{
 		using var writer = new StringWriter();
@@ -404,7 +430,7 @@ public sealed class Given_ResultFlowPager
 			writer,
 			keys,
 			visibleRows: 3,
-			pagerMode: ReplPagerMode.Scroll,
+			pagerMode: ReplPagerMode.Full,
 			ansiEnabled: true,
 			CancellationToken.None);
 
@@ -413,7 +439,7 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
-	[Description("Result-flow scroll pager advances by one line when Down fetches the next payload at a boundary.")]
+	[Description("Result-flow full pager advances by one line when Down fetches the next payload at a boundary.")]
 	public async Task When_ScrollPagerDownFetchesNextPayload_Then_ViewportAdvancesOneLine()
 	{
 		using var writer = new StringWriter();
@@ -429,7 +455,7 @@ public sealed class Given_ResultFlowPager
 			writer,
 			keys,
 			visibleRows: 3,
-			pagerMode: ReplPagerMode.Scroll,
+			pagerMode: ReplPagerMode.Full,
 			ansiEnabled: true,
 			hasMorePayload: true,
 			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
@@ -443,7 +469,7 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
-	[Description("Result-flow scroll pager keeps a rich table header pinned and skips duplicate headers from later payloads.")]
+	[Description("Result-flow full pager keeps a rich table header pinned and skips duplicate headers from later payloads.")]
 	public async Task When_ScrollPagerHasRichTableHeader_Then_HeaderStaysPinned()
 	{
 		using var writer = new StringWriter();
@@ -459,7 +485,7 @@ public sealed class Given_ResultFlowPager
 			writer,
 			keys,
 			visibleRows: 4,
-			pagerMode: ReplPagerMode.Scroll,
+			pagerMode: ReplPagerMode.Full,
 			ansiEnabled: true,
 			hasMorePayload: true,
 			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
@@ -472,7 +498,7 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
-	[Description("Result-flow scroll pager does not clear the whole viewport on every redraw.")]
+	[Description("Result-flow full pager does not clear the whole viewport on every redraw.")]
 	public async Task When_ScrollPagerRedraws_Then_DoesNotClearScreenEveryTime()
 	{
 		using var writer = new StringWriter();
@@ -488,7 +514,7 @@ public sealed class Given_ResultFlowPager
 			writer,
 			keys,
 			visibleRows: 3,
-			pagerMode: ReplPagerMode.Scroll,
+			pagerMode: ReplPagerMode.Full,
 			ansiEnabled: true,
 			CancellationToken.None);
 
@@ -497,7 +523,7 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
-	[Description("Result-flow scroll pager strips page footer hints already represented by its own status bar.")]
+	[Description("Result-flow full pager strips page footer hints already represented by its own status bar.")]
 	public async Task When_ScrollPagerReceivesPageFooterLines_Then_FooterLinesAreNotRendered()
 	{
 		using var writer = new StringWriter();
@@ -513,7 +539,7 @@ public sealed class Given_ResultFlowPager
 			writer,
 			keys,
 			visibleRows: 3,
-			pagerMode: ReplPagerMode.Scroll,
+			pagerMode: ReplPagerMode.Full,
 			ansiEnabled: true,
 			hasMorePayload: true,
 			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
@@ -528,7 +554,7 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
-	[Description("Result-flow scroll pager skips duplicate rich table headers even when they are not the first line in a fetched payload.")]
+	[Description("Result-flow full pager skips duplicate rich table headers even when they are not the first line in a fetched payload.")]
 	public async Task When_ScrollPagerReceivesIndentedDuplicateHeader_Then_HeaderIsNotBuffered()
 	{
 		using var writer = new StringWriter();
@@ -545,7 +571,7 @@ public sealed class Given_ResultFlowPager
 			writer,
 			keys,
 			visibleRows: 3,
-			pagerMode: ReplPagerMode.Scroll,
+			pagerMode: ReplPagerMode.Full,
 			ansiEnabled: true,
 			hasMorePayload: true,
 			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
@@ -557,7 +583,7 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
-	[Description("Result-flow scroll pager End moves to the end of the currently buffered content.")]
+	[Description("Result-flow full pager End moves to the end of the currently buffered content.")]
 	public async Task When_ScrollPagerEndPressed_Then_MovesToKnownEndWithoutFetching()
 	{
 		using var writer = new StringWriter();
@@ -573,7 +599,7 @@ public sealed class Given_ResultFlowPager
 			writer,
 			keys,
 			visibleRows: 3,
-			pagerMode: ReplPagerMode.Scroll,
+			pagerMode: ReplPagerMode.Full,
 			ansiEnabled: true,
 			hasMorePayload: true,
 			fetchNextPayload: _ =>
@@ -589,7 +615,7 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
-	[Description("Result-flow scroll pager recalculates viewport height between redraws.")]
+	[Description("Result-flow full pager recalculates viewport height between redraws.")]
 	public async Task When_ScrollPagerHeightChanges_Then_ViewportUsesCurrentHeight()
 	{
 		using var writer = new StringWriter();
@@ -607,7 +633,7 @@ public sealed class Given_ResultFlowPager
 			keys,
 			visibleRows,
 			visibleRowsProvider: () => reads++ == 0 ? visibleRows : 3,
-			pagerMode: ReplPagerMode.Scroll,
+			pagerMode: ReplPagerMode.Full,
 			ansiEnabled: true,
 			hasMorePayload: false,
 			fetchNextPayload: null,
@@ -620,7 +646,7 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
-	[Description("Result-flow scroll pager disables terminal line wrapping while the alternate screen is active.")]
+	[Description("Result-flow full pager disables terminal line wrapping while the alternate screen is active.")]
 	public async Task When_ScrollPagerRuns_Then_LineWrappingIsDisabledDuringAlternateScreen()
 	{
 		using var writer = new StringWriter();
@@ -634,7 +660,7 @@ public sealed class Given_ResultFlowPager
 			writer,
 			keys,
 			visibleRows: 3,
-			pagerMode: ReplPagerMode.Scroll,
+			pagerMode: ReplPagerMode.Full,
 			ansiEnabled: true,
 			CancellationToken.None);
 
@@ -645,6 +671,71 @@ public sealed class Given_ResultFlowPager
 			.Should().BeLessThan(output.IndexOf("\u001b[?7h", StringComparison.Ordinal));
 	}
 
+	[TestMethod]
+	[Description("Result-flow inline pager redraws in the main terminal buffer without entering the alternate screen.")]
+	public async Task When_InlinePagerRuns_Then_RedrawsWithoutAlternateScreen()
+	{
+		using var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.DownArrow, '\0'),
+			MakeKey(ConsoleKey.UpArrow, '\0'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nthree\nfour",
+			writer,
+			keys,
+			visibleRows: 3,
+			pagerMode: ReplPagerMode.Inline,
+			ansiEnabled: true,
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Should().Contain("\u001b[3A");
+		output.Should().Contain("\u001b[J");
+		output.Should().NotContain("\u001b[?1049h");
+		output.Should().NotContain("\u001b[?1049l");
+	}
+
+	[TestMethod]
+	[Description("Result-flow pager uses a configured custom renderer for the requested mode.")]
+	public async Task When_CustomPagerRendererIsConfigured_Then_ItHandlesTheMatchingMode()
+	{
+		using var writer = new StringWriter();
+		var renderer = new RecordingPagerRenderer(ReplPagerMode.Inline);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo",
+			writer,
+			new FakeKeyReader([]),
+			visibleRows: 3,
+			visibleRowsProvider: null,
+			pagerMode: ReplPagerMode.Inline,
+			ansiEnabled: true,
+			hasMorePayload: false,
+			fetchNextPayload: null,
+			pagerRenderers: [renderer],
+			CancellationToken.None);
+
+		renderer.Payloads.Should().Equal("one\ntwo");
+		writer.ToString().Should().Be("custom");
+	}
+
 	private static ConsoleKeyInfo MakeKey(ConsoleKey key, char keyChar) =>
 		new(keyChar, key, shift: false, alt: false, control: false);
+
+	private sealed class RecordingPagerRenderer(ReplPagerMode mode) : IReplPagerRenderer
+	{
+		public List<string> Payloads { get; } = [];
+
+		public ReplPagerMode Mode { get; } = mode;
+
+		public async ValueTask RenderAsync(ReplPagerRenderContext context, CancellationToken cancellationToken = default)
+		{
+			Payloads.Add(context.InitialPayload);
+			await context.Output.WriteAsync("custom").ConfigureAwait(false);
+		}
+	}
 }

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -9,7 +9,7 @@ public sealed class Given_ResultFlowPager
 	[Description("Result-flow pager advances by page on Space and stops on Q.")]
 	public async Task When_PagingWithSpaceAndQuit_Then_WritesOnlyRequestedPages()
 	{
-		var writer = new StringWriter();
+		using var writer = new StringWriter();
 		var keys = new FakeKeyReader(
 		[
 			MakeKey(ConsoleKey.Spacebar, ' '),
@@ -40,7 +40,7 @@ public sealed class Given_ResultFlowPager
 	[Description("Result-flow pager advances by one line on Enter.")]
 	public async Task When_PagingWithEnter_Then_AdvancesSingleLine()
 	{
-		var writer = new StringWriter();
+		using var writer = new StringWriter();
 		var keys = new FakeKeyReader(
 		[
 			MakeKey(ConsoleKey.Enter, '\r'),
@@ -65,7 +65,7 @@ public sealed class Given_ResultFlowPager
 	[Description("Result-flow pager UpArrow moves back one line instead of jumping to the header.")]
 	public async Task When_PagingBackWithUpArrow_Then_DoesNotRepeatHeader()
 	{
-		var writer = new StringWriter();
+		using var writer = new StringWriter();
 		var keys = new FakeKeyReader(
 		[
 			MakeKey(ConsoleKey.Spacebar, ' '),
@@ -92,7 +92,7 @@ public sealed class Given_ResultFlowPager
 	[Description("Result-flow pager fetches the next data page in the same interactive run.")]
 	public async Task When_CurrentPayloadEndsAndMoreDataExists_Then_SpaceFetchesNextPayload()
 	{
-		var writer = new StringWriter();
+		using var writer = new StringWriter();
 		var fetches = 0;
 		var keys = new FakeKeyReader(
 		[
@@ -125,7 +125,7 @@ public sealed class Given_ResultFlowPager
 	[Description("Result-flow pager stops at a data-page boundary without fetching more data when the user quits.")]
 	public async Task When_CurrentPayloadEndsAndUserQuits_Then_DoesNotFetchNextPayload()
 	{
-		var writer = new StringWriter();
+		using var writer = new StringWriter();
 		var fetches = 0;
 		var keys = new FakeKeyReader(
 		[
@@ -158,7 +158,7 @@ public sealed class Given_ResultFlowPager
 	[Description("Result-flow pager fetches the next data page instead of showing an empty --More-- prompt when a payload has no content.")]
 	public async Task When_CurrentPayloadIsEmptyAndMoreDataExists_Then_FetchesNextPayload()
 	{
-		var writer = new StringWriter();
+		using var writer = new StringWriter();
 		var fetches = 0;
 		var keys = new FakeKeyReader([]);
 
@@ -187,7 +187,7 @@ public sealed class Given_ResultFlowPager
 	[Description("Result-flow pager replays the previous full window when the user presses UpArrow at a data-page boundary.")]
 	public async Task When_AtPayloadBoundaryAndUserPressesUpArrow_Then_ReplaysPreviousWindow()
 	{
-		var writer = new StringWriter();
+		using var writer = new StringWriter();
 		var keys = new FakeKeyReader(
 		[
 			MakeKey(ConsoleKey.Spacebar, ' '),
@@ -213,7 +213,7 @@ public sealed class Given_ResultFlowPager
 	[Description("Result-flow scroll pager owns an alternate-screen viewport instead of relying on terminal scrollback.")]
 	public async Task When_ScrollPagerRunsWithAnsi_Then_UsesAlternateScreenViewport()
 	{
-		var writer = new StringWriter();
+		using var writer = new StringWriter();
 		var keys = new FakeKeyReader(
 		[
 			MakeKey(ConsoleKey.DownArrow, '\0'),
@@ -243,7 +243,7 @@ public sealed class Given_ResultFlowPager
 	[Description("Result-flow scroll pager fetches additional payloads into the same viewport when the user pages past the buffered end.")]
 	public async Task When_ScrollPagerReachesBufferedEnd_Then_FetchesNextPayload()
 	{
-		var writer = new StringWriter();
+		using var writer = new StringWriter();
 		var fetches = 0;
 		var keys = new FakeKeyReader(
 		[
@@ -278,7 +278,7 @@ public sealed class Given_ResultFlowPager
 	[Description("Result-flow scroll pager advances to the new buffered end when a fetch returns fewer lines than one viewport.")]
 	public async Task When_ScrollPagerFetchesShortPayload_Then_ViewportAdvances()
 	{
-		var writer = new StringWriter();
+		using var writer = new StringWriter();
 		var keys = new FakeKeyReader(
 		[
 			MakeKey(ConsoleKey.Spacebar, ' '),
@@ -306,7 +306,7 @@ public sealed class Given_ResultFlowPager
 	[Description("Result-flow scroll pager does not fetch another payload when the current payload is exactly visible and the user presses Space once.")]
 	public async Task When_ScrollPagerContentExactlyFitsViewport_Then_SpaceDoesNotFetchImmediately()
 	{
-		var writer = new StringWriter();
+		using var writer = new StringWriter();
 		var fetches = 0;
 		var keys = new FakeKeyReader(
 		[
@@ -338,7 +338,7 @@ public sealed class Given_ResultFlowPager
 	[Description("Result-flow pager does not add a phantom empty line when a payload ends with a newline.")]
 	public async Task When_PayloadEndsWithNewline_Then_LineCountExcludesTrailingEmptyLine()
 	{
-		var writer = new StringWriter();
+		using var writer = new StringWriter();
 		var keys = new FakeKeyReader(
 		[
 			MakeKey(ConsoleKey.Q, 'q'),
@@ -360,7 +360,7 @@ public sealed class Given_ResultFlowPager
 	[Description("Result-flow scroll pager treats unrecognized keys as no-ops and does not advance the viewport or trigger a fetch.")]
 	public async Task When_ScrollPagerUnknownKeyPressed_Then_ViewportDoesNotAdvanceAndNoFetch()
 	{
-		var writer = new StringWriter();
+		using var writer = new StringWriter();
 		var fetches = 0;
 		var keys = new FakeKeyReader(
 		[
@@ -392,7 +392,7 @@ public sealed class Given_ResultFlowPager
 	[Description("Result-flow scroll pager advances the viewport only on Space/PageDown, not on Enter or other keys.")]
 	public async Task When_ScrollPagerEnterKeyPressed_Then_ViewportAdvancesByOneLine()
 	{
-		var writer = new StringWriter();
+		using var writer = new StringWriter();
 		var keys = new FakeKeyReader(
 		[
 			MakeKey(ConsoleKey.Enter, '\r'),

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -504,6 +504,7 @@ public sealed class Given_ResultFlowPager
 		var keys = new FakeKeyReader(
 		[
 			MakeKey(ConsoleKey.DownArrow, '\0'),
+			MakeKey(ConsoleKey.DownArrow, '\0'),
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
@@ -524,6 +525,35 @@ public sealed class Given_ResultFlowPager
 		output.Should().Contain("three");
 		output.Should().NotContain("Showing 2 of 5");
 		output.Should().NotContain("Showing 1 of 5");
+	}
+
+	[TestMethod]
+	[Description("Result-flow scroll pager skips duplicate rich table headers even when they are not the first line in a fetched payload.")]
+	public async Task When_ScrollPagerReceivesIndentedDuplicateHeader_Then_HeaderIsNotBuffered()
+	{
+		using var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.DownArrow, '\0'),
+			MakeKey(ConsoleKey.DownArrow, '\0'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+		var header = "\u001b[1m#\u001b[0m   \u001b[1mAt\u001b[0m";
+
+		await ResultFlowPager.WriteAsync(
+			$"{header}\none\ntwo\nShowing 2 of 5.",
+			writer,
+			keys,
+			visibleRows: 3,
+			pagerMode: ReplPagerMode.Scroll,
+			ansiEnabled: true,
+			hasMorePayload: true,
+			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
+				new ResultFlowPagerPage($"Showing 1 of 5.\n{header}\nthree", HasMore: false)),
+			CancellationToken.None);
+
+		writer.ToString().Should().Contain($"{header}\r\nthree");
+		writer.ToString().Split(header).Length.Should().Be(4);
 	}
 
 	[TestMethod]
@@ -587,6 +617,32 @@ public sealed class Given_ResultFlowPager
 		output.Should().Contain("1-4/5");
 		output.Should().Contain("2-3/5");
 		output.Should().Contain("\u001b[H\u001b[J");
+	}
+
+	[TestMethod]
+	[Description("Result-flow scroll pager disables terminal line wrapping while the alternate screen is active.")]
+	public async Task When_ScrollPagerRuns_Then_LineWrappingIsDisabledDuringAlternateScreen()
+	{
+		using var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nthree",
+			writer,
+			keys,
+			visibleRows: 3,
+			pagerMode: ReplPagerMode.Scroll,
+			ansiEnabled: true,
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Should().Contain("\u001b[?7l");
+		output.Should().Contain("\u001b[?7h");
+		output.IndexOf("\u001b[?7l", StringComparison.Ordinal)
+			.Should().BeLessThan(output.IndexOf("\u001b[?7h", StringComparison.Ordinal));
 	}
 
 	private static ConsoleKeyInfo MakeKey(ConsoleKey key, char keyChar) =>

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -467,7 +467,7 @@ public sealed class Given_ResultFlowPager
 			CancellationToken.None);
 
 		var output = writer.ToString();
-		output.Should().Contain($"{header}\r\n\u001b[2Kthree\r\n\u001b[2Kfour");
+		output.Should().Contain($"{header}\r\nthree\r\nfour");
 		output.Should().Contain("3-4/5");
 	}
 
@@ -493,6 +493,100 @@ public sealed class Given_ResultFlowPager
 			CancellationToken.None);
 
 		writer.ToString().Split("\u001b[J").Length.Should().Be(2);
+		writer.ToString().Should().NotContain("\u001b[2K");
+	}
+
+	[TestMethod]
+	[Description("Result-flow scroll pager strips page footer hints already represented by its own status bar.")]
+	public async Task When_ScrollPagerReceivesPageFooterLines_Then_FooterLinesAreNotRendered()
+	{
+		using var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.DownArrow, '\0'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nShowing 2 of 5. Next data page: rerun with --result:cursor page-2.",
+			writer,
+			keys,
+			visibleRows: 3,
+			pagerMode: ReplPagerMode.Scroll,
+			ansiEnabled: true,
+			hasMorePayload: true,
+			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
+				new ResultFlowPagerPage("three\nShowing 1 of 5.", HasMore: false)),
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Should().Contain("one");
+		output.Should().Contain("three");
+		output.Should().NotContain("Showing 2 of 5");
+		output.Should().NotContain("Showing 1 of 5");
+	}
+
+	[TestMethod]
+	[Description("Result-flow scroll pager End moves to the end of the currently buffered content.")]
+	public async Task When_ScrollPagerEndPressed_Then_MovesToKnownEndWithoutFetching()
+	{
+		using var writer = new StringWriter();
+		var fetches = 0;
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.End, '\0'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nthree\nfour\nfive",
+			writer,
+			keys,
+			visibleRows: 3,
+			pagerMode: ReplPagerMode.Scroll,
+			ansiEnabled: true,
+			hasMorePayload: true,
+			fetchNextPayload: _ =>
+			{
+				fetches++;
+				return ValueTask.FromResult<ResultFlowPagerPage?>(
+					new ResultFlowPagerPage("six", HasMore: false));
+			},
+			CancellationToken.None);
+
+		fetches.Should().Be(0);
+		writer.ToString().Should().Contain("4-5/5+");
+	}
+
+	[TestMethod]
+	[Description("Result-flow scroll pager recalculates viewport height between redraws.")]
+	public async Task When_ScrollPagerHeightChanges_Then_ViewportUsesCurrentHeight()
+	{
+		using var writer = new StringWriter();
+		var visibleRows = 5;
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.DownArrow, '\0'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+		var reads = 0;
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nthree\nfour\nfive",
+			writer,
+			keys,
+			visibleRows,
+			visibleRowsProvider: () => reads++ == 0 ? visibleRows : 3,
+			pagerMode: ReplPagerMode.Scroll,
+			ansiEnabled: true,
+			hasMorePayload: false,
+			fetchNextPayload: null,
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Should().Contain("1-4/5");
+		output.Should().Contain("2-3/5");
+		output.Should().Contain("\u001b[H\u001b[J");
 	}
 
 	private static ConsoleKeyInfo MakeKey(ConsoleKey key, char keyChar) =>

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -244,25 +244,27 @@ public sealed class Given_ResultFlowPager
 	{
 		using var writer = new StringWriter();
 		var header = "#    At              Area       Event      Summary";
+		var fetchedHeader = "#   At                 Area       Event       Summary";
 		var keys = new FakeKeyReader(
 		[
 			MakeKey(ConsoleKey.Spacebar, ' '),
 		]);
 
 		await ResultFlowPager.WriteAsync(
-			$"{header}\n1    2026-01-12      identity   validated  identity batch 1 validated successfully\nShowing 1 of 3.",
+			$"{header}\n---  -----------------  ---------  ----------  ----------------------------------------\n1    2026-01-12      identity   validated  identity batch 1 validated successfully\nShowing 1 of 3.",
 			writer,
 			keys,
 			visibleRows: 2,
 			hasMorePayload: true,
 			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
 				new ResultFlowPagerPage(
-					$"{header}\n2    2026-01-12      billing    queued     billing batch 1 queued successfully\nShowing 2 of 3.",
+					$"{fetchedHeader}\n---  -----------------  ---------  ----------  ----------------------------------------\n2    2026-01-12      billing    queued     billing batch 1 queued successfully\nShowing 2 of 3.",
 					HasMore: false)),
 			CancellationToken.None);
 
 		var output = writer.ToString();
 		output.Split(header, StringSplitOptions.None).Should().HaveCount(2);
+		output.Should().NotContain(fetchedHeader);
 		output.Should().Contain("identity batch 1 validated successfully");
 		output.Should().Contain("billing batch 1 queued successfully");
 		output.Should().NotContain("Showing 1 of 3");

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -30,6 +30,10 @@ public sealed class Given_ResultFlowPager
 		output.Should().Contain("four");
 		output.Should().NotContain("five");
 		output.Should().Contain("--More--");
+		output.Should().Contain("Space/PageDown: continue");
+		output.Should().Contain("Enter/Down: line");
+		output.Should().Contain("Up/PageUp: back");
+		output.Should().Contain("q/Esc: stop");
 	}
 
 	[TestMethod]
@@ -55,6 +59,154 @@ public sealed class Given_ResultFlowPager
 		output.Should().Contain("two");
 		output.Should().Contain("three");
 		output.Should().NotContain("four");
+	}
+
+	[TestMethod]
+	[Description("Result-flow pager UpArrow moves back one line instead of jumping to the header.")]
+	public async Task When_PagingBackWithUpArrow_Then_DoesNotRepeatHeader()
+	{
+		var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.Spacebar, ' '),
+			MakeKey(ConsoleKey.UpArrow, '\0'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"# At Area Event Summary\nr1\nr2\nr3\nr4\nr5",
+			writer,
+			keys,
+			visibleRows: 2,
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Split("# At Area Event Summary", StringSplitOptions.None)
+			.Should().HaveCount(2);
+		output.Should().Contain("r1");
+		output.Should().Contain("r2");
+		output.Should().Contain("r3");
+	}
+
+	[TestMethod]
+	[Description("Result-flow pager fetches the next data page in the same interactive run.")]
+	public async Task When_CurrentPayloadEndsAndMoreDataExists_Then_SpaceFetchesNextPayload()
+	{
+		var writer = new StringWriter();
+		var fetches = 0;
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.Spacebar, ' '),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo",
+			writer,
+			keys,
+			visibleRows: 2,
+			hasMorePayload: true,
+			fetchNextPayload: _ =>
+			{
+				fetches++;
+				return ValueTask.FromResult<ResultFlowPagerPage?>(
+					new ResultFlowPagerPage("three\nfour", HasMore: false));
+			},
+			CancellationToken.None);
+
+		fetches.Should().Be(1);
+		var output = writer.ToString();
+		output.Should().Contain("one");
+		output.Should().Contain("two");
+		output.Should().Contain("three");
+		output.Should().Contain("four");
+	}
+
+	[TestMethod]
+	[Description("Result-flow pager stops at a data-page boundary without fetching more data when the user quits.")]
+	public async Task When_CurrentPayloadEndsAndUserQuits_Then_DoesNotFetchNextPayload()
+	{
+		var writer = new StringWriter();
+		var fetches = 0;
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo",
+			writer,
+			keys,
+			visibleRows: 2,
+			hasMorePayload: true,
+			fetchNextPayload: _ =>
+			{
+				fetches++;
+				return ValueTask.FromResult<ResultFlowPagerPage?>(
+					new ResultFlowPagerPage("three\nfour", HasMore: false));
+			},
+			CancellationToken.None);
+
+		fetches.Should().Be(0);
+		var output = writer.ToString();
+		output.Should().Contain("one");
+		output.Should().Contain("two");
+		output.Should().NotContain("three");
+		output.Should().NotContain("four");
+	}
+
+	[TestMethod]
+	[Description("Result-flow pager fetches the next data page instead of showing an empty --More-- prompt when a payload has no content.")]
+	public async Task When_CurrentPayloadIsEmptyAndMoreDataExists_Then_FetchesNextPayload()
+	{
+		var writer = new StringWriter();
+		var fetches = 0;
+		var keys = new FakeKeyReader([]);
+
+		await ResultFlowPager.WriteAsync(
+			string.Empty,
+			writer,
+			keys,
+			visibleRows: 2,
+			hasMorePayload: true,
+			fetchNextPayload: _ =>
+			{
+				fetches++;
+				return ValueTask.FromResult<ResultFlowPagerPage?>(
+					new ResultFlowPagerPage("one\ntwo", HasMore: false));
+			},
+			CancellationToken.None);
+
+		fetches.Should().Be(1);
+		var output = writer.ToString();
+		output.Should().Contain("one");
+		output.Should().Contain("two");
+		output.Should().NotContain("--More--");
+	}
+
+	[TestMethod]
+	[Description("Result-flow pager replays the previous full window when the user presses UpArrow at a data-page boundary.")]
+	public async Task When_AtPayloadBoundaryAndUserPressesUpArrow_Then_ReplaysPreviousWindow()
+	{
+		var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.Spacebar, ' '),
+			MakeKey(ConsoleKey.UpArrow, '\0'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nthree\nfour",
+			writer,
+			keys,
+			visibleRows: 2,
+			hasMorePayload: true,
+			fetchNextPayload: _ => throw new InvalidOperationException("Should not fetch while replaying the previous window."),
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Split("three", StringSplitOptions.None).Should().HaveCount(3);
+		output.Split("four", StringSplitOptions.None).Should().HaveCount(3);
 	}
 
 	private static ConsoleKeyInfo MakeKey(ConsoleKey key, char keyChar) =>

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -1,0 +1,62 @@
+using Repl.Tests.TerminalSupport;
+
+namespace Repl.Tests;
+
+[TestClass]
+public sealed class Given_ResultFlowPager
+{
+	[TestMethod]
+	[Description("Result-flow pager advances by page on Space and stops on Q.")]
+	public async Task When_PagingWithSpaceAndQuit_Then_WritesOnlyRequestedPages()
+	{
+		var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.Spacebar, ' '),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nthree\nfour\nfive",
+			writer,
+			keys,
+			visibleRows: 2,
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Should().Contain("one");
+		output.Should().Contain("two");
+		output.Should().Contain("three");
+		output.Should().Contain("four");
+		output.Should().NotContain("five");
+		output.Should().Contain("--More--");
+	}
+
+	[TestMethod]
+	[Description("Result-flow pager advances by one line on Enter.")]
+	public async Task When_PagingWithEnter_Then_AdvancesSingleLine()
+	{
+		var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.Enter, '\r'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nthree\nfour",
+			writer,
+			keys,
+			visibleRows: 2,
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Should().Contain("one");
+		output.Should().Contain("two");
+		output.Should().Contain("three");
+		output.Should().NotContain("four");
+	}
+
+	private static ConsoleKeyInfo MakeKey(ConsoleKey key, char keyChar) =>
+		new(keyChar, key, shift: false, alt: false, control: false);
+}

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -332,6 +332,30 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
+	[Description("Structured continuation payloads do not use presentation-text sniffing, so data lines that look like footers are preserved.")]
+	public async Task When_ContinuationPayloadIsMarkedClean_Then_FooterLikeDataLineIsPreserved()
+	{
+		using var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.Spacebar, ' '),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one",
+			writer,
+			keys,
+			visibleRows: 2,
+			hasMorePayload: true,
+			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
+				new ResultFlowPagerPage("Showing 1 of 5.", HasMore: false, ContainsPresentationChrome: false)),
+			CancellationToken.None);
+
+		writer.ToString().Should().Contain("Showing 1 of 5.");
+	}
+
+	[TestMethod]
 	[Description("Result-flow full pager owns an alternate-screen viewport instead of relying on terminal scrollback.")]
 	public async Task When_ScrollPagerRunsWithAnsi_Then_UsesAlternateScreenViewport()
 	{

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -153,6 +153,36 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
+	[Description("Result-flow more pager fills the requested PageDown window across payload boundaries.")]
+	public async Task When_MorePagerPageDownCrossesPayloadBoundary_Then_FetchesAndContinuesWindow()
+	{
+		using var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.PageDown, '\0'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nthree",
+			writer,
+			keys,
+			visibleRows: 2,
+			hasMorePayload: true,
+			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
+				new ResultFlowPagerPage("four\nfive\nsix", HasMore: false)),
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Should().Contain("one");
+		output.Should().Contain("two");
+		output.Should().Contain("three");
+		output.Should().Contain("four");
+		output.Should().NotContain("five");
+		output.Should().NotContain("six");
+	}
+
+	[TestMethod]
 	[Description("Result-flow pager stops at a data-page boundary without fetching more data when the user quits.")]
 	public async Task When_CurrentPayloadEndsAndUserQuits_Then_DoesNotFetchNextPayload()
 	{

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -819,6 +819,43 @@ public sealed class Given_ResultFlowPager
 		writer.ToString().Should().Be("custom");
 	}
 
+	[TestMethod]
+	[Description("Result-flow options expose pager renderers as a controlled read-only list keyed by mode.")]
+	public void When_PagerRendererIsRegisteredTwiceForMode_Then_LatestRendererReplacesPrevious()
+	{
+		var options = new ResultFlowOptions();
+		var first = new RecordingPagerRenderer(ReplPagerMode.Inline);
+		var second = new RecordingPagerRenderer(ReplPagerMode.Inline);
+
+		options.UsePagerRenderer(first);
+		options.UsePagerRenderer(second);
+
+		options.PagerRenderers.Should().ContainSingle().Which.Should().BeSameAs(second);
+		options.RemovePagerRenderer(ReplPagerMode.Inline).Should().BeTrue();
+		options.PagerRenderers.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	[Description("ReplPagerRenderContext can be constructed and fetch payloads in custom renderer tests.")]
+	public async Task When_RenderContextIsCreatedDirectly_Then_FetchNextPayloadReturnsConfiguredPayload()
+	{
+		var context = new ReplPagerRenderContext(
+			initialPayload: "one",
+			output: new StringWriter(),
+			keyReader: new FakeKeyReader([]),
+			visibleRows: 3,
+			visibleRowsProvider: null,
+			ansiEnabled: true,
+			hasMorePayload: true,
+			fetchNextPayload: _ => ValueTask.FromResult<ReplPagerPayload?>(new ReplPagerPayload("two", HasMore: false)));
+
+		var payload = await context.FetchNextPayloadAsync(CancellationToken.None);
+
+		payload.Should().NotBeNull();
+		payload!.Payload.Should().Be("two");
+		context.CanFetchNextPayload.Should().BeTrue();
+	}
+
 	private static ConsoleKeyInfo MakeKey(ConsoleKey key, char keyChar) =>
 		new(keyChar, key, shift: false, alt: false, control: false);
 

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -856,6 +856,39 @@ public sealed class Given_ResultFlowPager
 		context.CanFetchNextPayload.Should().BeTrue();
 	}
 
+	[TestMethod]
+	[Description("Viewport pager stops fetching and reports status when the buffered line limit is reached.")]
+	public async Task When_ViewportPagerReachesBufferLimit_Then_StatusReportsLimit()
+	{
+		using var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.DownArrow, '\0'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo",
+			writer,
+			keys,
+			visibleRows: 3,
+			visibleRowsProvider: null,
+			pagerMode: ReplPagerMode.Full,
+			ansiEnabled: true,
+			hasMorePayload: true,
+			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
+				new ResultFlowPagerPage("three\nfour\nfive", HasMore: true)),
+			pagerRenderers: null,
+			maxBufferedLines: 3,
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Should().Contain("buffer limit");
+		output.Should().Contain("three");
+		output.Should().NotContain("four");
+		output.Should().NotContain("five");
+	}
+
 	private static ConsoleKeyInfo MakeKey(ConsoleKey key, char keyChar) =>
 		new(keyChar, key, shift: false, alt: false, control: false);
 

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -252,7 +252,7 @@ public sealed class Given_ResultFlowPager
 		]);
 
 		await ResultFlowPager.WriteAsync(
-			"one\ntwo",
+			"one\ntwo\nthree",
 			writer,
 			keys,
 			visibleRows: 3,
@@ -286,7 +286,7 @@ public sealed class Given_ResultFlowPager
 		]);
 
 		await ResultFlowPager.WriteAsync(
-			"one\ntwo\nthree",
+			"one\ntwo\nthree\nfour",
 			writer,
 			keys,
 			visibleRows: 4,
@@ -294,12 +294,66 @@ public sealed class Given_ResultFlowPager
 			ansiEnabled: true,
 			hasMorePayload: true,
 			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
-				new ResultFlowPagerPage("four", HasMore: false)),
+				new ResultFlowPagerPage("five", HasMore: false)),
 			CancellationToken.None);
 
 		var output = writer.ToString();
-		output.Should().Contain("2-4/4");
-		output.Should().Contain("four");
+		output.Should().Contain("3-5/5");
+		output.Should().Contain("five");
+	}
+
+	[TestMethod]
+	[Description("Result-flow scroll pager does not fetch another payload when the current payload is exactly visible and the user presses Space once.")]
+	public async Task When_ScrollPagerContentExactlyFitsViewport_Then_SpaceDoesNotFetchImmediately()
+	{
+		var writer = new StringWriter();
+		var fetches = 0;
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.Spacebar, ' '),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nthree",
+			writer,
+			keys,
+			visibleRows: 4,
+			pagerMode: ReplPagerMode.Scroll,
+			ansiEnabled: true,
+			hasMorePayload: true,
+			fetchNextPayload: _ =>
+			{
+				fetches++;
+				return ValueTask.FromResult<ResultFlowPagerPage?>(
+					new ResultFlowPagerPage("four", HasMore: false));
+			},
+			CancellationToken.None);
+
+		fetches.Should().Be(0);
+		writer.ToString().Should().NotContain("four");
+	}
+
+	[TestMethod]
+	[Description("Result-flow pager does not add a phantom empty line when a payload ends with a newline.")]
+	public async Task When_PayloadEndsWithNewline_Then_LineCountExcludesTrailingEmptyLine()
+	{
+		var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\n",
+			writer,
+			keys,
+			visibleRows: 3,
+			pagerMode: ReplPagerMode.Scroll,
+			ansiEnabled: true,
+			CancellationToken.None);
+
+		writer.ToString().Should().Contain("1-2/2");
 	}
 
 	private static ConsoleKeyInfo MakeKey(ConsoleKey key, char keyChar) =>

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -449,8 +449,8 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
-	[Description("Result-flow full pager does not fetch another payload when the current payload is exactly visible and the user presses Space once.")]
-	public async Task When_ScrollPagerContentExactlyFitsViewport_Then_SpaceDoesNotFetchImmediately()
+	[Description("Result-flow full pager fetches another payload when the current payload exactly fills the viewport and the user presses Space.")]
+	public async Task When_ScrollPagerContentExactlyFitsViewport_Then_SpaceFetchesNextPayload()
 	{
 		using var writer = new StringWriter();
 		var fetches = 0;
@@ -476,8 +476,8 @@ public sealed class Given_ResultFlowPager
 			},
 			CancellationToken.None);
 
-		fetches.Should().Be(0);
-		writer.ToString().Should().NotContain("four");
+		fetches.Should().Be(1);
+		writer.ToString().Should().Contain("four");
 	}
 
 	[TestMethod]
@@ -613,7 +613,9 @@ public sealed class Given_ResultFlowPager
 			CancellationToken.None);
 
 		var output = writer.ToString();
-		output.Should().Contain($"{header}\r\nthree\r\nfour");
+		output.Should().Contain(header);
+		output.Should().Contain("three");
+		output.Should().Contain("four");
 		output.Should().Contain("3-4/5");
 	}
 
@@ -698,8 +700,9 @@ public sealed class Given_ResultFlowPager
 				new ResultFlowPagerPage($"Showing 1 of 5.\n{header}\nthree", HasMore: false)),
 			CancellationToken.None);
 
-		writer.ToString().Should().Contain($"{header}\r\nthree");
-		writer.ToString().Split(header).Length.Should().Be(4);
+		writer.ToString().Should().Contain(header);
+		writer.ToString().Should().Contain("three");
+		writer.ToString().Should().Contain("3-3/3");
 	}
 
 	[TestMethod]
@@ -857,6 +860,17 @@ public sealed class Given_ResultFlowPager
 		options.PagerRenderers.Should().ContainSingle().Which.Should().BeSameAs(second);
 		options.RemovePagerRenderer(ReplPagerMode.Inline).Should().BeTrue();
 		options.PagerRenderers.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	[Description("Result-flow options reject inconsistent page-size bounds.")]
+	public void When_MaxPageSizeIsSmallerThanDefault_Then_OptionsRejectIt()
+	{
+		var options = new ResultFlowOptions();
+
+		var action = () => options.MaxPageSize = options.DefaultPageSize - 1;
+
+		action.Should().Throw<ArgumentOutOfRangeException>();
 	}
 
 	[TestMethod]

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -481,6 +481,62 @@ public sealed class Given_ResultFlowPager
 	}
 
 	[TestMethod]
+	[Description("Result-flow full pager fetches when all known content is visible but more payloads exist.")]
+	public async Task When_ScrollPagerContentIsShorterThanViewport_Then_PageDownFetchesNextPayload()
+	{
+		using var writer = new StringWriter();
+		var fetches = 0;
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.PageDown, '\0'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await WritePagerAsync(
+			"one\ntwo",
+			writer,
+			keys,
+			visibleRows: 5,
+			pagerMode: ReplPagerMode.Full,
+			ansiEnabled: true,
+			hasMorePayload: true,
+			fetchNextPayload: _ =>
+			{
+				fetches++;
+				return ValueTask.FromResult<ResultFlowPagerPage?>(
+					new ResultFlowPagerPage("three", HasMore: false));
+			},
+			CancellationToken.None);
+
+		fetches.Should().Be(1);
+		writer.ToString().Should().Contain("three");
+	}
+
+	[TestMethod]
+	[Description("Result-flow options reject invalid pager buffer and inline payload limits.")]
+	public void When_ResultFlowLimitsAreInvalid_Then_SettersThrow()
+	{
+		var options = new ResultFlowOptions();
+
+		var setMaxBufferedLines = () => options.MaxBufferedLines = 0;
+		var setProgrammaticBytes = () => options.ProgrammaticMaxInlineBytes = 0;
+
+		setMaxBufferedLines.Should().Throw<ArgumentOutOfRangeException>();
+		setProgrammaticBytes.Should().Throw<ArgumentOutOfRangeException>();
+	}
+
+	[TestMethod]
+	[Description("Result-flow options reject a default page size greater than the configured maximum.")]
+	public void When_DefaultPageSizeExceedsMaxPageSize_Then_SetterThrows()
+	{
+		var options = new ResultFlowOptions { MaxPageSize = 150 };
+
+		var action = () => options.DefaultPageSize = 151;
+
+		action.Should().Throw<ArgumentOutOfRangeException>();
+	}
+
+	[TestMethod]
 	[Description("Result-flow pager does not add a phantom empty line when a payload ends with a newline.")]
 	public async Task When_PayloadEndsWithNewline_Then_LineCountExcludesTrailingEmptyLine()
 	{
@@ -1085,7 +1141,7 @@ public sealed class Given_ResultFlowPager
 		bool ansiEnabled,
 		bool hasMorePayload,
 		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
-		IEnumerable<IReplPagerRenderer>? pagerRenderers,
+		IReadOnlyList<IReplPagerRenderer>? pagerRenderers,
 		CancellationToken cancellationToken = default)
 		=> ResultFlowPager.WriteAsync(
 			payload,
@@ -1121,7 +1177,7 @@ public sealed class Given_ResultFlowPager
 		bool ansiEnabled,
 		bool hasMorePayload,
 		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
-		IEnumerable<IReplPagerRenderer>? pagerRenderers,
+		IReadOnlyList<IReplPagerRenderer>? pagerRenderers,
 		int maxBufferedLines,
 		CancellationToken cancellationToken = default)
 		=> ResultFlowPager.WriteAsync(

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -16,7 +16,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree\nfour\nfive",
 			writer,
 			keys,
@@ -47,7 +47,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree\nfour",
 			writer,
 			keys,
@@ -74,7 +74,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree\nfour",
 			writer,
 			keys,
@@ -104,7 +104,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"# At Area Event Summary\n---\nr1\nr2\nr3\nr4\nr5",
 			writer,
 			keys,
@@ -130,7 +130,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Spacebar, ' '),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo",
 			writer,
 			keys,
@@ -163,7 +163,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree",
 			writer,
 			keys,
@@ -193,7 +193,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo",
 			writer,
 			keys,
@@ -223,7 +223,7 @@ public sealed class Given_ResultFlowPager
 		var fetches = 0;
 		var keys = new FakeKeyReader([]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			string.Empty,
 			writer,
 			keys,
@@ -256,7 +256,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree\nfour",
 			writer,
 			keys,
@@ -281,7 +281,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Spacebar, ' '),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			$"{header}\none\ntwo\nShowing 2 of 5.",
 			writer,
 			keys,
@@ -310,7 +310,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Spacebar, ' '),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			$"{header}\n---  -----------------  ---------  ----------  ----------------------------------------\n1    2026-01-12      identity   validated  identity batch 1 validated successfully\nShowing 1 of 3.",
 			writer,
 			keys,
@@ -342,7 +342,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one",
 			writer,
 			keys,
@@ -366,7 +366,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree",
 			writer,
 			keys,
@@ -397,7 +397,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree",
 			writer,
 			keys,
@@ -431,7 +431,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree\nfour",
 			writer,
 			keys,
@@ -460,7 +460,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree",
 			writer,
 			keys,
@@ -490,7 +490,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\n",
 			writer,
 			keys,
@@ -514,7 +514,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree\nfour",
 			writer,
 			keys,
@@ -545,7 +545,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree\nfour",
 			writer,
 			keys,
@@ -570,7 +570,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree",
 			writer,
 			keys,
@@ -600,7 +600,7 @@ public sealed class Given_ResultFlowPager
 		]);
 		var header = "\u001b[1m#\u001b[0m  \u001b[1mAt\u001b[0m";
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			$"{header}\none\ntwo\nthree",
 			writer,
 			keys,
@@ -631,7 +631,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree\nfour",
 			writer,
 			keys,
@@ -642,6 +642,34 @@ public sealed class Given_ResultFlowPager
 
 		writer.ToString().Split("\u001b[J").Length.Should().Be(2);
 		writer.ToString().Should().NotContain("\u001b[2K");
+	}
+
+	[TestMethod]
+	[Description("Result-flow full pager measures OSC hyperlink escapes as zero-width terminal control data.")]
+	public async Task When_ScrollPagerRedrawsOverOscHyperlink_Then_PadsUsingVisibleWidth()
+	{
+		using var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.DownArrow, '\0'),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+		var link = "\u001b]8;;https://example.invalid\u0007link\u001b]8;;\u0007";
+
+		await WritePagerAsync(
+			$"{link}\nx",
+			writer,
+			keys,
+			new ResultFlowPagerOptions
+			{
+				VisibleRows = 2,
+				PagerMode = ReplPagerMode.Full,
+				AnsiEnabled = true,
+			},
+			CancellationToken.None);
+
+		writer.ToString().Should().Contain($"x   {Environment.NewLine}");
+		writer.ToString().Should().NotContain("x          ");
 	}
 
 	[TestMethod]
@@ -656,7 +684,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nShowing 2 of 5. Next data page: rerun with --result:cursor page-2.",
 			writer,
 			keys,
@@ -688,7 +716,7 @@ public sealed class Given_ResultFlowPager
 		]);
 		var header = "\u001b[1m#\u001b[0m   \u001b[1mAt\u001b[0m";
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			$"{header}\none\ntwo\nShowing 2 of 5.",
 			writer,
 			keys,
@@ -717,7 +745,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree\nfour\nfive",
 			writer,
 			keys,
@@ -750,7 +778,7 @@ public sealed class Given_ResultFlowPager
 		]);
 		var reads = 0;
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree\nfour\nfive",
 			writer,
 			keys,
@@ -778,7 +806,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree",
 			writer,
 			keys,
@@ -806,7 +834,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo\nthree\nfour",
 			writer,
 			keys,
@@ -829,7 +857,7 @@ public sealed class Given_ResultFlowPager
 		using var writer = new StringWriter();
 		var renderer = new RecordingPagerRenderer(ReplPagerMode.Inline);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo",
 			writer,
 			new FakeKeyReader([]),
@@ -905,7 +933,7 @@ public sealed class Given_ResultFlowPager
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
-		await ResultFlowPager.WriteAsync(
+		await WritePagerAsync(
 			"one\ntwo",
 			writer,
 			keys,
@@ -951,6 +979,167 @@ public sealed class Given_ResultFlowPager
 
 		second.ContentLines.Should().Equal("two");
 	}
+
+	private static ValueTask WritePagerAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		CancellationToken cancellationToken = default)
+		=> ResultFlowPager.WriteAsync(payload, output, keyReader, visibleRows, cancellationToken);
+
+	private static ValueTask WritePagerAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		ReplPagerMode pagerMode,
+		bool ansiEnabled,
+		CancellationToken cancellationToken = default)
+		=> ResultFlowPager.WriteAsync(
+			payload,
+			output,
+			keyReader,
+			new ResultFlowPagerOptions
+			{
+				VisibleRows = visibleRows,
+				PagerMode = pagerMode,
+				AnsiEnabled = ansiEnabled,
+			},
+			cancellationToken);
+
+	private static ValueTask WritePagerAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		bool hasMorePayload,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		CancellationToken cancellationToken = default)
+		=> WritePagerAsync(
+			payload,
+			output,
+			keyReader,
+			visibleRows,
+			ReplPagerMode.More,
+			ansiEnabled: false,
+			hasMorePayload,
+			fetchNextPayload,
+			cancellationToken);
+
+	private static ValueTask WritePagerAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		ReplPagerMode pagerMode,
+		bool ansiEnabled,
+		bool hasMorePayload,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		CancellationToken cancellationToken = default)
+		=> ResultFlowPager.WriteAsync(
+			payload,
+			output,
+			keyReader,
+			new ResultFlowPagerOptions
+			{
+				VisibleRows = visibleRows,
+				PagerMode = pagerMode,
+				AnsiEnabled = ansiEnabled,
+				HasMorePayload = hasMorePayload,
+				FetchNextPayload = fetchNextPayload,
+			},
+			cancellationToken);
+
+	private static ValueTask WritePagerAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		Func<int> visibleRowsProvider,
+		ReplPagerMode pagerMode,
+		bool ansiEnabled,
+		bool hasMorePayload,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		CancellationToken cancellationToken = default)
+		=> WritePagerAsync(
+			payload,
+			output,
+			keyReader,
+			visibleRows,
+			visibleRowsProvider,
+			pagerMode,
+			ansiEnabled,
+			hasMorePayload,
+			fetchNextPayload,
+			pagerRenderers: null,
+			cancellationToken);
+
+	private static ValueTask WritePagerAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		Func<int>? visibleRowsProvider,
+		ReplPagerMode pagerMode,
+		bool ansiEnabled,
+		bool hasMorePayload,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		IEnumerable<IReplPagerRenderer>? pagerRenderers,
+		CancellationToken cancellationToken = default)
+		=> ResultFlowPager.WriteAsync(
+			payload,
+			output,
+			keyReader,
+			new ResultFlowPagerOptions
+			{
+				VisibleRows = visibleRows,
+				VisibleRowsProvider = visibleRowsProvider,
+				PagerMode = pagerMode,
+				AnsiEnabled = ansiEnabled,
+				HasMorePayload = hasMorePayload,
+				FetchNextPayload = fetchNextPayload,
+				PagerRenderers = pagerRenderers,
+			},
+			cancellationToken);
+
+	private static ValueTask WritePagerAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		ResultFlowPagerOptions options,
+		CancellationToken cancellationToken = default)
+		=> ResultFlowPager.WriteAsync(payload, output, keyReader, options, cancellationToken);
+
+	private static ValueTask WritePagerAsync(
+		string payload,
+		TextWriter output,
+		IReplKeyReader keyReader,
+		int visibleRows,
+		Func<int>? visibleRowsProvider,
+		ReplPagerMode pagerMode,
+		bool ansiEnabled,
+		bool hasMorePayload,
+		Func<CancellationToken, ValueTask<ResultFlowPagerPage?>>? fetchNextPayload,
+		IEnumerable<IReplPagerRenderer>? pagerRenderers,
+		int maxBufferedLines,
+		CancellationToken cancellationToken = default)
+		=> ResultFlowPager.WriteAsync(
+			payload,
+			output,
+			keyReader,
+			new ResultFlowPagerOptions
+			{
+				VisibleRows = visibleRows,
+				VisibleRowsProvider = visibleRowsProvider,
+				PagerMode = pagerMode,
+				AnsiEnabled = ansiEnabled,
+				HasMorePayload = hasMorePayload,
+				FetchNextPayload = fetchNextPayload,
+				PagerRenderers = pagerRenderers,
+				MaxBufferedLines = maxBufferedLines,
+			},
+			cancellationToken);
 
 	private static ConsoleKeyInfo MakeKey(ConsoleKey key, char keyChar) =>
 		new(keyChar, key, shift: false, alt: false, control: false);

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -274,6 +274,34 @@ public sealed class Given_ResultFlowPager
 		output.Should().Contain("\u001b[?1049h");
 	}
 
+	[TestMethod]
+	[Description("Result-flow scroll pager advances to the new buffered end when a fetch returns fewer lines than one viewport.")]
+	public async Task When_ScrollPagerFetchesShortPayload_Then_ViewportAdvances()
+	{
+		var writer = new StringWriter();
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.Spacebar, ' '),
+			MakeKey(ConsoleKey.Q, 'q'),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			"one\ntwo\nthree",
+			writer,
+			keys,
+			visibleRows: 4,
+			pagerMode: ReplPagerMode.Scroll,
+			ansiEnabled: true,
+			hasMorePayload: true,
+			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
+				new ResultFlowPagerPage("four", HasMore: false)),
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Should().Contain("2-4/4");
+		output.Should().Contain("four");
+	}
+
 	private static ConsoleKeyInfo MakeKey(ConsoleKey key, char keyChar) =>
 		new(keyChar, key, shift: false, alt: false, control: false);
 }

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -913,6 +913,31 @@ public sealed class Given_ResultFlowPager
 		output.Should().NotContain("five");
 	}
 
+	[TestMethod]
+	[Description("PagerSession keeps its buffer capped and clears continuation when the cap is reached.")]
+	public void When_PagerSessionReachesBufferLimit_Then_LinesStayReadOnlyAndHasMoreIsCleared()
+	{
+		var session = new PagerSession("one", hasMorePayload: true, maxBufferedLines: 2);
+
+		session.Append("two\nthree", hasMorePayload: true);
+
+		session.Lines.Should().Equal("one", "two");
+		session.Lines.Should().NotBeAssignableTo<List<string>>();
+		session.BufferLimitReached.Should().BeTrue();
+		session.HasMorePayload.Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("Pager payload parser ignores malformed ANSI escape markers when normalizing headers.")]
+	public void When_HeaderContainsLoneEscape_Then_NormalizationStillDeduplicatesContinuationHeader()
+	{
+		var header = "#   At  Area\u001b";
+		var first = PagerPayloadParser.Parse($"{header}\none", header: null);
+		var second = PagerPayloadParser.Parse($"{header}\ntwo", first.Header);
+
+		second.ContentLines.Should().Equal("two");
+	}
+
 	private static ConsoleKeyInfo MakeKey(ConsoleKey key, char keyChar) =>
 		new(keyChar, key, shift: false, alt: false, control: false);
 

--- a/src/Repl.Tests/Given_ResultFlowPager.cs
+++ b/src/Repl.Tests/Given_ResultFlowPager.cs
@@ -69,6 +69,8 @@ public sealed class Given_ResultFlowPager
 		var keys = new FakeKeyReader(
 		[
 			MakeKey(ConsoleKey.UpArrow, '\0'),
+			MakeKey(ConsoleKey.UpArrow, '\0'),
+			MakeKey(ConsoleKey.PageUp, '\0'),
 			MakeKey(ConsoleKey.Q, 'q'),
 		]);
 
@@ -81,6 +83,7 @@ public sealed class Given_ResultFlowPager
 
 		var output = writer.ToString();
 		output.Split("# At Area Event Summary", StringSplitOptions.None).Should().HaveCount(2);
+		output.Split("--More--", StringSplitOptions.None).Should().HaveCount(2);
 		output.Should().Contain("r1");
 		output.Should().Contain("r2");
 		output.Should().NotContain("r3");
@@ -229,10 +232,41 @@ public sealed class Given_ResultFlowPager
 			CancellationToken.None);
 
 		var output = writer.ToString();
-		output.Split(header, StringSplitOptions.None).Should().HaveCount(3);
+		output.Split(header, StringSplitOptions.None).Should().HaveCount(2);
 		output.Should().Contain("three");
 		output.Should().NotContain("Showing 2 of 5");
 		output.Should().NotContain("Showing 1 of 5");
+	}
+
+	[TestMethod]
+	[Description("Result-flow more pager treats plain human-output column headings as headers and strips duplicates from fetched pages.")]
+	public async Task When_MorePagerFetchesHumanOutput_Then_DuplicateHashHeadersAreSkipped()
+	{
+		using var writer = new StringWriter();
+		var header = "#    At              Area       Event      Summary";
+		var keys = new FakeKeyReader(
+		[
+			MakeKey(ConsoleKey.Spacebar, ' '),
+		]);
+
+		await ResultFlowPager.WriteAsync(
+			$"{header}\n1    2026-01-12      identity   validated  identity batch 1 validated successfully\nShowing 1 of 3.",
+			writer,
+			keys,
+			visibleRows: 2,
+			hasMorePayload: true,
+			fetchNextPayload: _ => ValueTask.FromResult<ResultFlowPagerPage?>(
+				new ResultFlowPagerPage(
+					$"{header}\n2    2026-01-12      billing    queued     billing batch 1 queued successfully\nShowing 2 of 3.",
+					HasMore: false)),
+			CancellationToken.None);
+
+		var output = writer.ToString();
+		output.Split(header, StringSplitOptions.None).Should().HaveCount(2);
+		output.Should().Contain("identity batch 1 validated successfully");
+		output.Should().Contain("billing batch 1 queued successfully");
+		output.Should().NotContain("Showing 1 of 3");
+		output.Should().NotContain("Showing 2 of 3");
 	}
 
 	[TestMethod]

--- a/src/Repl.Tests/Given_TerminalSurfaceHost.cs
+++ b/src/Repl.Tests/Given_TerminalSurfaceHost.cs
@@ -1,0 +1,89 @@
+using Repl.Terminal;
+
+namespace Repl.Tests;
+
+[TestClass]
+public sealed class Given_TerminalSurfaceHost
+{
+	[TestMethod]
+	[Description("Terminal surface enters alternate screen and restores cursor/wrap/screen when disposed.")]
+	public async Task When_AlternateScreenSurfaceIsDisposed_Then_TerminalStateIsRestored()
+	{
+		using var writer = new StringWriter();
+
+		await using (await TerminalSurfaceHost.EnterAsync(
+				writer,
+				TerminalSurfaceMode.AlternateScreen,
+				CancellationToken.None).ConfigureAwait(false))
+		{
+			await writer.WriteAsync("body").ConfigureAwait(false);
+		}
+
+		var output = writer.ToString();
+		output.Should().Contain(AnsiSequences.EnterAlternateScreen);
+		output.Should().Contain(AnsiSequences.HideCursor);
+		output.Should().Contain(AnsiSequences.DisableLineWrap);
+		output.Should().Contain(AnsiSequences.CursorHome);
+		output.Should().Contain(AnsiSequences.ClearToEndOfScreen);
+		output.Should().Contain(AnsiSequences.EnableLineWrap);
+		output.Should().Contain(AnsiSequences.ShowCursor);
+		output.Should().Contain(AnsiSequences.LeaveAlternateScreen);
+		output.IndexOf(AnsiSequences.EnterAlternateScreen, StringComparison.Ordinal)
+			.Should().BeLessThan(output.IndexOf("body", StringComparison.Ordinal));
+		output.IndexOf("body", StringComparison.Ordinal)
+			.Should().BeLessThan(output.IndexOf(AnsiSequences.LeaveAlternateScreen, StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	[Description("Terminal inline surface owns the current region without entering the alternate screen.")]
+	public async Task When_InlineSurfaceIsDisposed_Then_AlternateScreenIsNotUsed()
+	{
+		using var writer = new StringWriter();
+
+		await using (await TerminalSurfaceHost.EnterAsync(
+				writer,
+				TerminalSurfaceMode.InlineRegion,
+				CancellationToken.None).ConfigureAwait(false))
+		{
+			await writer.WriteAsync("body").ConfigureAwait(false);
+		}
+
+		var output = writer.ToString();
+		output.Should().NotContain(AnsiSequences.EnterAlternateScreen);
+		output.Should().NotContain(AnsiSequences.LeaveAlternateScreen);
+		output.Should().Contain(AnsiSequences.HideCursor);
+		output.Should().Contain(AnsiSequences.DisableLineWrap);
+		output.Should().Contain(AnsiSequences.EnableLineWrap);
+		output.Should().Contain(AnsiSequences.ShowCursor);
+	}
+
+	[TestMethod]
+	[Description("Terminal surface restores cursor/wrap/alternate screen even when rendering fails.")]
+	public async Task When_SurfaceRenderingThrows_Then_TerminalStateIsRestored()
+	{
+		using var writer = new StringWriter();
+
+		var act = async () =>
+		{
+			var surface = await TerminalSurfaceHost.EnterAsync(
+					writer,
+					TerminalSurfaceMode.AlternateScreen,
+					CancellationToken.None)
+				.ConfigureAwait(false);
+			try
+			{
+				throw new InvalidOperationException("boom");
+			}
+			finally
+			{
+				await surface.DisposeAsync().ConfigureAwait(false);
+			}
+		};
+
+		await act.Should().ThrowAsync<InvalidOperationException>().ConfigureAwait(false);
+		var output = writer.ToString();
+		output.Should().Contain(AnsiSequences.EnableLineWrap);
+		output.Should().Contain(AnsiSequences.ShowCursor);
+		output.Should().Contain(AnsiSequences.LeaveAlternateScreen);
+	}
+}

--- a/src/Repl.Tests/Given_TerminalSurfaceHost.cs
+++ b/src/Repl.Tests/Given_TerminalSurfaceHost.cs
@@ -86,4 +86,54 @@ public sealed class Given_TerminalSurfaceHost
 		output.Should().Contain(AnsiSequences.ShowCursor);
 		output.Should().Contain(AnsiSequences.LeaveAlternateScreen);
 	}
+
+	[TestMethod]
+	[Description("Terminal surface enter attempts cleanup when setup fails after partially entering the surface.")]
+	public async Task When_SurfaceEnterFailsAfterAlternateScreen_Then_CleanupIsAttempted()
+	{
+		using var writer = new ThrowOnceWriter(AnsiSequences.HideCursor);
+
+		var act = async () => await TerminalSurfaceHost.EnterAsync(
+				writer,
+				TerminalSurfaceMode.AlternateScreen,
+				CancellationToken.None)
+			.ConfigureAwait(false);
+
+		await act.Should().ThrowAsync<IOException>().ConfigureAwait(false);
+		var output = writer.ToString();
+		output.Should().Contain(AnsiSequences.EnterAlternateScreen);
+		output.Should().Contain(AnsiSequences.EnableLineWrap);
+		output.Should().Contain(AnsiSequences.ShowCursor);
+		output.Should().Contain(AnsiSequences.LeaveAlternateScreen);
+	}
+
+	[TestMethod]
+	[Description("Terminal surface dispose keeps restoring remaining state when one restore write fails.")]
+	public async Task When_SurfaceDisposeRestoreWriteFails_Then_RemainingCleanupIsAttempted()
+	{
+		using var writer = new ThrowOnceWriter(AnsiSequences.EnableLineWrap);
+		var surface = new TerminalSurfaceScope(writer, TerminalSurfaceMode.AlternateScreen);
+
+		await surface.DisposeAsync().ConfigureAwait(false);
+
+		var output = writer.ToString();
+		output.Should().Contain(AnsiSequences.ShowCursor);
+		output.Should().Contain(AnsiSequences.LeaveAlternateScreen);
+	}
+
+	private sealed class ThrowOnceWriter(string throwOn) : StringWriter
+	{
+		private bool _thrown;
+
+		public override Task WriteAsync(string? value)
+		{
+			if (!_thrown && string.Equals(value, throwOn, StringComparison.Ordinal))
+			{
+				_thrown = true;
+				throw new IOException("simulated terminal failure");
+			}
+
+			return base.WriteAsync(value);
+		}
+	}
 }

--- a/src/Repl.Tests/Given_TerminalSurfaceHost.cs
+++ b/src/Repl.Tests/Given_TerminalSurfaceHost.cs
@@ -125,15 +125,39 @@ public sealed class Given_TerminalSurfaceHost
 	{
 		private bool _thrown;
 
+		public override Task WriteAsync(char value)
+		{
+			ThrowIfMatches(value.ToString());
+			return base.WriteAsync(value);
+		}
+
+		public override Task WriteAsync(char[] buffer, int index, int count)
+		{
+			ThrowIfMatches(new string(buffer, index, count));
+			return base.WriteAsync(buffer, index, count);
+		}
+
+		public override Task WriteAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken = default)
+		{
+			ThrowIfMatches(buffer.ToString());
+			return base.WriteAsync(buffer, cancellationToken);
+		}
+
 		public override Task WriteAsync(string? value)
 		{
-			if (!_thrown && string.Equals(value, throwOn, StringComparison.Ordinal))
+			ThrowIfMatches(value);
+			return base.WriteAsync(value);
+		}
+
+		private void ThrowIfMatches(string? value)
+		{
+			if (_thrown || !string.Equals(value, throwOn, StringComparison.Ordinal))
 			{
-				_thrown = true;
-				throw new IOException("simulated terminal failure");
+				return;
 			}
 
-			return base.WriteAsync(value);
+			_thrown = true;
+			throw new IOException("simulated terminal failure");
 		}
 	}
 }


### PR DESCRIPTION
## Summary

New Result Flow paging experience.

This adds first-class paging support for commands that return large result sets. Handlers can now return one explicit `ReplPage<T>` or an `IReplPageSource<T>` that lets Repl fetch later pages on demand. Human users can continue through results in the same command run, while MCP and machine outputs get structured page metadata.

## Functional Highlights

### Page results

Handlers can return a page directly when they own the cursor contract:

```csharp
app.Map("contacts", async (IReplPagingContext paging, ContactStore store, CancellationToken ct) =>
{
    var result = await store.SearchAsync(paging.Cursor, paging.SuggestedPageSize, ct);

    return paging.Page(
        result.Items,
        nextCursor: result.NextCursor,
        totalCount: result.TotalCount);
});
```

JSON output now uses an explicit page envelope:

```json
{
  "$type": "page",
  "items": [
    { "id": 1, "name": "Alice" }
  ],
  "pageInfo": {
    "cursor": null,
    "nextCursor": "page-2",
    "totalCount": 42,
    "pageSize": 1,
    "hasMore": true
  }
}
```

### Page sources

Handlers can return a lazy source when Repl should fetch future pages interactively:

```csharp
app.Map("events", (EventStore store) =>
    ReplPageSource.FromOffset<EventRow>(
        (offset, take, ct) => store.QueryAsync(offset, take, ct),
        totalCount: store.TotalCount));
```

This improves terminal UX: the integrated pager can continue fetching data without asking users to rerun the command with `--result:cursor`.

### Built-in helpers

This PR adds helpers for:

- bounded in-memory lists via `FromItems(...)`;
- offset/limit stores via `FromOffset(...)`;
- replayable async streams via `FromAsyncEnumerable(...)`;
- state-based overloads for static lambdas;
- client-side filters as a fallback when the source cannot filter server-side.

Example with state and a client-side filter:

```csharp
app.Map("contacts", (ContactStore store, string search) =>
    ReplPageSource.FromOffset<ContactRow, ContactStore>(
        store,
        static (state, offset, take, ct) => state.QueryAsync(offset, take, ct),
        filter: (_, row) => row.Name.Contains(search, StringComparison.OrdinalIgnoreCase)));
```

Client-side filtering is documented as a fallback because it may fetch and discard rows. Server-side filtering remains preferred.

## Result Flow Help

Paged handlers now show a `Result Flow` help section:

```text
--result:page-size <n>
--result:cursor <value>
--result:all
--result:pager=auto|off|more|scroll|external
```

The section appears only for handlers that support paging: `IReplPagingContext`, `ReplPage<T>`, or `IReplPageSource<T>`.

## Integrated Pager

The human pager now has two paths:

- `more` fallback for limited terminals, with no cursor movement or ANSI redraw;
- `scroll` viewport for ANSI terminals, inspired by `less`.

The scroll pager enters the alternate screen, keeps an internal line buffer, redraws a viewport explicitly, supports up/down/page/home/end navigation, reacts to terminal-height changes, and fetches additional page-source payloads as the user reaches the buffered end. The buffer is capped by `ResultFlowOptions.MaxBufferedLines` so long sessions do not grow without bound.

## MCP Behavior

MCP tools expose reserved paging inputs:

- `_replCursor`
- `_replPageSize`

Paged results are returned as structured content with `$type: "page"`. Text fallback is configurable through `ReplMcpServerOptions.PagedResultTextMode`, so apps can choose a compact summary for structured-content-aware agents or serialized JSON for clients that only consume `Content[0].Text`.

Hardening included:

- page detection uses `$type: "page"` instead of `items + pageInfo` heuristics;
- raw cursor values are not interpolated into text summaries;
- `_replCursor` and MCP argument keys/values are validated before becoming CLI tokens;
- `_replPageSize` must be compact and numeric before normal clamping.

## Documentation And Samples

Updated docs cover:

- cursor basics;
- page-source helpers;
- offset, keyset, external token, nextLink, and snapshot cursor patterns;
- async enumerable cancellation and replayability requirements;
- client-side filtering caveats;
- MCP and Spectre testing notes;
- unknown `totalCount` scenarios;
- configurable MCP compatibility fallbacks and agent support;
- result-flow diagnostics and buffer limits;
- why live/infinite feeds are a separate future use case.

Core Basics and Spectre samples now demonstrate page-source driven activity feeds.

## Safety Notes

- `FromAsyncEnumerable` requires a replayable, idempotent, deterministic factory.
- `FromOffset` and `FromAsyncEnumerable` reject `--result:all` by default because they may be unbounded.
- `FromItems` can honor `--result:all` because the source is already bounded.
- Interactive scroll buffers are bounded by `MaxBufferedLines`; when the cap is reached, Repl stops fetching additional pages and reports diagnostics.