### PR TITLE
Add MCP Streamable HTTP hosting

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,7 +14,8 @@
 		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5"/>
 		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5"/>
 		<PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.5"/>
-		<PackageVersion Include="ModelContextProtocol" Version="1.2.0"/>
+		<PackageVersion Include="ModelContextProtocol" Version="1.4.0"/>
+		<PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.0"/>
 		<PackageVersion Include="Spectre.Console" Version="0.55.0"/>
 	</ItemGroup>
 

--- a/src/Repl.Mcp.AspNetCore/CompositeServiceProvider.cs
+++ b/src/Repl.Mcp.AspNetCore/CompositeServiceProvider.cs
@@ -1,0 +1,9 @@
+namespace Repl.Mcp.AspNetCore;
+
+internal sealed class CompositeServiceProvider(
+	IServiceProvider primary,
+	IServiceProvider fallback) : IServiceProvider
+{
+	public object? GetService(Type serviceType) =>
+		primary.GetService(serviceType) ?? fallback.GetService(serviceType);
+}

--- a/src/Repl.Mcp.AspNetCore/McpHttpBinding.cs
+++ b/src/Repl.Mcp.AspNetCore/McpHttpBinding.cs
@@ -1,0 +1,9 @@
+namespace Repl.Mcp.AspNetCore;
+
+internal sealed record McpHttpBinding(
+	string Host,
+	int Port,
+	string Path,
+	string ListenUrl,
+	string EndpointUrl,
+	bool AllowsRemote);

--- a/src/Repl.Mcp.AspNetCore/McpHttpBindingFactory.cs
+++ b/src/Repl.Mcp.AspNetCore/McpHttpBindingFactory.cs
@@ -55,7 +55,7 @@ internal static class McpHttpBindingFactory
 			normalized = "/" + normalized;
 		}
 
-		return normalized.Length == 0 ? ReplMcpHttpServerOptions.DefaultPath : normalized;
+		return normalized;
 	}
 
 	private static bool IsLoopbackHost(string host)

--- a/src/Repl.Mcp.AspNetCore/McpHttpBindingFactory.cs
+++ b/src/Repl.Mcp.AspNetCore/McpHttpBindingFactory.cs
@@ -1,0 +1,89 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Repl.Mcp.AspNetCore;
+
+internal static class McpHttpBindingFactory
+{
+	public static McpHttpBinding Create(
+		string? host,
+		int port,
+		string? path,
+		bool allowRemote)
+	{
+		if (port is < 1 or > 65535)
+		{
+			throw new InvalidOperationException("MCP HTTP port must be between 1 and 65535.");
+		}
+
+		var effectiveHost = string.IsNullOrWhiteSpace(host)
+			? ReplMcpHttpServerOptions.DefaultHost
+			: host.Trim();
+
+		var isLoopback = IsLoopbackHost(effectiveHost);
+		if (!allowRemote && !isLoopback)
+		{
+			throw new InvalidOperationException(
+				"Remote MCP HTTP bindings require --allow-remote. Use 127.0.0.1 or localhost for local-only serving.");
+		}
+
+		var normalizedPath = NormalizePath(path);
+		var urlHost = FormatUrlHost(effectiveHost);
+		var listenUrl = string.Concat("http://", urlHost, ":", port.ToString(CultureInfo.InvariantCulture));
+		var endpointUrl = string.Concat(listenUrl, normalizedPath);
+
+		return new McpHttpBinding(
+			effectiveHost,
+			port,
+			normalizedPath,
+			listenUrl,
+			endpointUrl,
+			!isLoopback);
+	}
+
+	private static string NormalizePath(string? path)
+	{
+		if (string.IsNullOrWhiteSpace(path))
+		{
+			return ReplMcpHttpServerOptions.DefaultPath;
+		}
+
+		var normalized = path.Trim();
+		if (normalized[0] != '/')
+		{
+			normalized = "/" + normalized;
+		}
+
+		return normalized.Length == 0 ? ReplMcpHttpServerOptions.DefaultPath : normalized;
+	}
+
+	private static bool IsLoopbackHost(string host)
+	{
+		var normalized = TrimIpv6Brackets(host);
+		if (string.Equals(normalized, "localhost", StringComparison.OrdinalIgnoreCase))
+		{
+			return true;
+		}
+
+		return IPAddress.TryParse(normalized, out var address)
+			&& IPAddress.IsLoopback(address);
+	}
+
+	private static string FormatUrlHost(string host)
+	{
+		var normalized = TrimIpv6Brackets(host);
+		if (IPAddress.TryParse(normalized, out var address)
+			&& address.AddressFamily == AddressFamily.InterNetworkV6)
+		{
+			return $"[{normalized}]";
+		}
+
+		return normalized;
+	}
+
+	private static string TrimIpv6Brackets(string host) =>
+		host.Length > 1 && host[0] == '[' && host[^1] == ']'
+			? host[1..^1]
+			: host;
+}

--- a/src/Repl.Mcp.AspNetCore/McpHttpModule.cs
+++ b/src/Repl.Mcp.AspNetCore/McpHttpModule.cs
@@ -1,0 +1,125 @@
+using Repl.Mcp;
+
+namespace Repl.Mcp.AspNetCore;
+
+internal sealed class McpHttpModule : IReplModule
+{
+	private readonly ReplApp _app;
+	private readonly ReplMcpHttpServerOptions _options;
+	private readonly ReplMcpServerOptions _mcpOptions;
+
+	public McpHttpModule(ReplApp app, ReplMcpHttpServerOptions options)
+	{
+		_app = app;
+		_options = options;
+		_mcpOptions = new ReplMcpServerOptions();
+		options.ConfigureServer?.Invoke(_mcpOptions);
+	}
+
+	public void Map(IReplMap map)
+	{
+		map.Context(_mcpOptions.ContextName, mcp =>
+		{
+			mcp.Map("httpserve",
+				HandleHttpServeAsync)
+				.WithDescription("Start MCP Streamable HTTP server for agent integration.")
+				.WithAlias("http", "http-serve")
+				.Hidden();
+		})
+		.Hidden();
+	}
+
+	private async Task<object> HandleHttpServeAsync(
+		IReplIoContext io,
+		string? host,
+		int? port,
+		string? path,
+		bool allowRemote,
+		bool stateless,
+		int? idleTimeoutSeconds,
+		int? maxIdleSessions,
+		bool quiet,
+		CancellationToken cancellationToken)
+	{
+		var runOptions = CreateRunOptions(
+			host,
+			port,
+			path,
+			allowRemote,
+			stateless,
+			idleTimeoutSeconds,
+			maxIdleSessions,
+			quiet);
+
+		try
+		{
+			await ReplMcpHttpServer.RunAsync(
+				_app,
+				runOptions,
+				io.Output,
+				cancellationToken).ConfigureAwait(false);
+			return Results.Exit(0);
+		}
+		catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+		{
+			return Results.Exit(0);
+		}
+		catch (Exception ex)
+		{
+			await io.Output.WriteLineAsync($"Error: {ex.Message}").ConfigureAwait(false);
+			return Results.Exit(1);
+		}
+	}
+
+	private ReplMcpHttpServerOptions CreateRunOptions(
+		string? host,
+		int? port,
+		string? path,
+		bool allowRemote,
+		bool stateless,
+		int? idleTimeoutSeconds,
+		int? maxIdleSessions,
+		bool quiet)
+	{
+		var runOptions = _options.Clone();
+		ApplyEndpointOptions(runOptions, host, port, path);
+
+		runOptions.AllowRemote |= allowRemote;
+		runOptions.Stateless |= stateless;
+		runOptions.Quiet |= quiet;
+
+		if (idleTimeoutSeconds is { } idleSeconds)
+		{
+			runOptions.IdleTimeout = TimeSpan.FromSeconds(idleSeconds);
+		}
+
+		if (maxIdleSessions is { } maxSessions)
+		{
+			runOptions.MaxIdleSessionCount = maxSessions;
+		}
+
+		return runOptions;
+	}
+
+	private static void ApplyEndpointOptions(
+		ReplMcpHttpServerOptions runOptions,
+		string? host,
+		int? port,
+		string? path)
+	{
+		if (!string.IsNullOrWhiteSpace(host))
+		{
+			runOptions.Host = host;
+		}
+
+		if (port is { } portValue)
+		{
+			runOptions.Port = portValue;
+		}
+
+		if (!string.IsNullOrWhiteSpace(path))
+		{
+			runOptions.Path = path;
+		}
+	}
+}

--- a/src/Repl.Mcp.AspNetCore/McpHttpModule.cs
+++ b/src/Repl.Mcp.AspNetCore/McpHttpModule.cs
@@ -64,7 +64,8 @@ internal sealed class McpHttpModule : IReplModule
 		}
 		catch (Exception ex)
 		{
-			await io.Output.WriteLineAsync($"Error: {ex.Message}").ConfigureAwait(false);
+			ReplMcpHttpDiagnostics.StartupFailures.Add(1);
+			await io.Error.WriteLineAsync(ex.ToString()).ConfigureAwait(false);
 			return Results.Exit(1);
 		}
 	}

--- a/src/Repl.Mcp.AspNetCore/McpHttpModule.cs
+++ b/src/Repl.Mcp.AspNetCore/McpHttpModule.cs
@@ -13,7 +13,7 @@ internal sealed class McpHttpModule : IReplModule
 		_app = app;
 		_options = options;
 		_mcpOptions = new ReplMcpServerOptions();
-		options.ConfigureServer?.Invoke(_mcpOptions);
+		options.Http.ConfigureServer?.Invoke(_mcpOptions);
 	}
 
 	public void Map(IReplMap map)
@@ -35,7 +35,6 @@ internal sealed class McpHttpModule : IReplModule
 		int? port,
 		string? path,
 		bool allowRemote,
-		bool stateless,
 		int? idleTimeoutSeconds,
 		int? maxIdleSessions,
 		bool quiet,
@@ -46,7 +45,6 @@ internal sealed class McpHttpModule : IReplModule
 			port,
 			path,
 			allowRemote,
-			stateless,
 			idleTimeoutSeconds,
 			maxIdleSessions,
 			quiet);
@@ -76,7 +74,6 @@ internal sealed class McpHttpModule : IReplModule
 		int? port,
 		string? path,
 		bool allowRemote,
-		bool stateless,
 		int? idleTimeoutSeconds,
 		int? maxIdleSessions,
 		bool quiet)
@@ -85,17 +82,16 @@ internal sealed class McpHttpModule : IReplModule
 		ApplyEndpointOptions(runOptions, host, port, path);
 
 		runOptions.AllowRemote |= allowRemote;
-		runOptions.Stateless |= stateless;
 		runOptions.Quiet |= quiet;
 
 		if (idleTimeoutSeconds is { } idleSeconds)
 		{
-			runOptions.IdleTimeout = TimeSpan.FromSeconds(idleSeconds);
+			runOptions.Http.IdleTimeout = TimeSpan.FromSeconds(idleSeconds);
 		}
 
 		if (maxIdleSessions is { } maxSessions)
 		{
-			runOptions.MaxIdleSessionCount = maxSessions;
+			runOptions.Http.MaxIdleSessionCount = maxSessions;
 		}
 
 		return runOptions;

--- a/src/Repl.Mcp.AspNetCore/McpHttpModule.cs
+++ b/src/Repl.Mcp.AspNetCore/McpHttpModule.cs
@@ -62,7 +62,7 @@ internal sealed class McpHttpModule : IReplModule
 		{
 			return Results.Exit(0);
 		}
-		catch (Exception ex)
+		catch (InvalidOperationException ex)
 		{
 			ReplMcpHttpDiagnostics.StartupFailures.Add(1);
 			await io.Error.WriteLineAsync(ex.ToString()).ConfigureAwait(false);

--- a/src/Repl.Mcp.AspNetCore/README.md
+++ b/src/Repl.Mcp.AspNetCore/README.md
@@ -11,6 +11,8 @@ var app = builder.Build();
 app.MapReplMcp("/mcp");
 ```
 
+`MapReplMcp()` maps the default `/mcp` endpoint.
+
 Use ASP.NET Core middleware and endpoint conventions for production concerns
 such as authentication, authorization, CORS, HTTPS, and reverse proxy hosting.
 
@@ -23,6 +25,16 @@ var app = builder.Build();
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapReplMcp("/mcp").RequireAuthorization();
+```
+
+For per-installation transport customization, configure the hosted transport:
+
+```csharp
+builder.Services.AddReplMcpHttp(replApp, http =>
+{
+	http.IdleTimeout = TimeSpan.FromMinutes(15);
+	http.MaxIdleSessionCount = 50;
+});
 ```
 
 ## Self-Hosted CLI
@@ -41,10 +53,32 @@ myapp mcp httpserve
 ```
 
 The default endpoint is `http://127.0.0.1:7375/mcp`. The port digits map to
-`repl` on a phone keypad. Non-loopback bindings require an explicit opt-in:
+`repl` on a phone keypad. The self-hosted command is intended for local agents
+and trusted development networks. Non-loopback bindings require an explicit
+opt-in:
 
 ```bash
 myapp mcp httpserve --host 0.0.0.0 --allow-remote
+```
+
+Loopback self-hosting rejects browser requests with unexpected `Origin` headers
+and restricts the HTTP `Host` header to loopback names. Remote opt-in relaxes
+the Host restriction for trusted networks, but does not add authentication or
+TLS. Use hosted ASP.NET Core when the endpoint needs production-grade auth,
+certificates, reverse proxy integration, or custom network policy.
+
+Self-hosted apps can expose limited advanced hooks:
+
+```csharp
+var replApp = ReplApp.Create()
+	.UseMcpHttpServer(options =>
+	{
+		options.ConfigureBuilder = builder =>
+			builder.Configuration.AddEnvironmentVariables("MYAPP_");
+
+		options.ConfigureApp = app =>
+			app.UseForwardedHeaders();
+	});
 ```
 
 The `http` and `http-serve` aliases also resolve to `httpserve`.

--- a/src/Repl.Mcp.AspNetCore/README.md
+++ b/src/Repl.Mcp.AspNetCore/README.md
@@ -2,6 +2,8 @@
 
 ASP.NET Core Streamable HTTP hosting integration for Repl MCP servers.
 
+## Hosted in ASP.NET Core
+
 ```csharp
 builder.Services.AddReplMcpHttp(replApp);
 
@@ -11,3 +13,38 @@ app.MapReplMcp("/mcp");
 
 Use ASP.NET Core middleware and endpoint conventions for production concerns
 such as authentication, authorization, CORS, HTTPS, and reverse proxy hosting.
+
+```csharp
+builder.Services.AddAuthentication();
+builder.Services.AddAuthorization();
+builder.Services.AddReplMcpHttp(replApp);
+
+var app = builder.Build();
+app.UseAuthentication();
+app.UseAuthorization();
+app.MapReplMcp("/mcp").RequireAuthorization();
+```
+
+## Self-Hosted CLI
+
+Register the local HTTP command on a Repl app:
+
+```csharp
+var replApp = ReplApp.Create()
+	.UseMcpHttpServer();
+```
+
+Then run:
+
+```bash
+myapp mcp httpserve
+```
+
+The default endpoint is `http://127.0.0.1:7375/mcp`. The port digits map to
+`repl` on a phone keypad. Non-loopback bindings require an explicit opt-in:
+
+```bash
+myapp mcp httpserve --host 0.0.0.0 --allow-remote
+```
+
+The `http` and `http-serve` aliases also resolve to `httpserve`.

--- a/src/Repl.Mcp.AspNetCore/README.md
+++ b/src/Repl.Mcp.AspNetCore/README.md
@@ -1,0 +1,13 @@
+# Repl.Mcp.AspNetCore
+
+ASP.NET Core Streamable HTTP hosting integration for Repl MCP servers.
+
+```csharp
+builder.Services.AddReplMcpHttp(replApp);
+
+var app = builder.Build();
+app.MapReplMcp("/mcp");
+```
+
+Use ASP.NET Core middleware and endpoint conventions for production concerns
+such as authentication, authorization, CORS, HTTPS, and reverse proxy hosting.

--- a/src/Repl.Mcp.AspNetCore/Repl.Mcp.AspNetCore.csproj
+++ b/src/Repl.Mcp.AspNetCore/Repl.Mcp.AspNetCore.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<Description>ASP.NET Core Streamable HTTP hosting integration for Repl MCP servers.</Description>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Repl.Mcp\Repl.Mcp.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+		<PackageReference Include="ModelContextProtocol.AspNetCore" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="README.md" Pack="true" PackagePath="" />
+	</ItemGroup>
+
+</Project>

--- a/src/Repl.Mcp.AspNetCore/Repl.Mcp.AspNetCore.csproj
+++ b/src/Repl.Mcp.AspNetCore/Repl.Mcp.AspNetCore.csproj
@@ -7,6 +7,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<InternalsVisibleTo Include="Repl.McpTests" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<ProjectReference Include="..\Repl.Mcp\Repl.Mcp.csproj" />
 	</ItemGroup>
 

--- a/src/Repl.Mcp.AspNetCore/ReplMcpEndpointRouteBuilderExtensions.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+
+namespace Repl.Mcp.AspNetCore;
+
+/// <summary>
+/// Extension methods for mapping Repl MCP endpoints.
+/// </summary>
+public static class ReplMcpEndpointRouteBuilderExtensions
+{
+	/// <summary>
+	/// Maps the Repl MCP Streamable HTTP endpoint.
+	/// </summary>
+	/// <param name="endpoints">Endpoint route builder.</param>
+	/// <param name="pattern">Route pattern for the Streamable HTTP endpoint.</param>
+	/// <returns>An endpoint convention builder.</returns>
+	public static IEndpointConventionBuilder MapReplMcp(
+		this IEndpointRouteBuilder endpoints,
+		string pattern = "/mcp")
+	{
+		ArgumentNullException.ThrowIfNull(endpoints);
+		return endpoints.MapMcp(pattern);
+	}
+}

--- a/src/Repl.Mcp.AspNetCore/ReplMcpEndpointRouteBuilderExtensions.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpEndpointRouteBuilderExtensions.cs
@@ -16,9 +16,17 @@ public static class ReplMcpEndpointRouteBuilderExtensions
 	/// <returns>An endpoint convention builder.</returns>
 	public static IEndpointConventionBuilder MapReplMcp(
 		this IEndpointRouteBuilder endpoints,
-		string pattern = "/mcp")
+		string pattern)
 	{
 		ArgumentNullException.ThrowIfNull(endpoints);
 		return endpoints.MapMcp(pattern);
 	}
+
+	/// <summary>
+	/// Maps the Repl MCP Streamable HTTP endpoint at the default path.
+	/// </summary>
+	/// <param name="endpoints">Endpoint route builder.</param>
+	/// <returns>An endpoint convention builder.</returns>
+	public static IEndpointConventionBuilder MapReplMcp(this IEndpointRouteBuilder endpoints) =>
+		endpoints.MapReplMcp(ReplMcpHttpServerOptions.DefaultPath);
 }

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpDiagnostics.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpDiagnostics.cs
@@ -10,6 +10,9 @@ internal static class ReplMcpHttpDiagnostics
 
 	public static readonly Meter Meter = new(MeterName);
 	public static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+	public static readonly Counter<long> SessionsStarted = Meter.CreateCounter<long>("repl.mcp.http.sessions.started");
+	public static readonly Counter<long> SessionsEnded = Meter.CreateCounter<long>("repl.mcp.http.sessions.ended");
+	public static readonly UpDownCounter<long> SessionsActive = Meter.CreateUpDownCounter<long>("repl.mcp.http.sessions.active");
 	public static readonly Counter<long> RejectedRequests = Meter.CreateCounter<long>("repl.mcp.http.requests.rejected");
 	public static readonly Counter<long> StartupFailures = Meter.CreateCounter<long>("repl.mcp.http.startup.failures");
 }

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpDiagnostics.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpDiagnostics.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Repl.Mcp.AspNetCore;
+
+internal static class ReplMcpHttpDiagnostics
+{
+	public const string MeterName = "Repl.Mcp.Http";
+	public const string ActivitySourceName = "Repl.Mcp.Http";
+
+	public static readonly Meter Meter = new(MeterName);
+	public static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+	public static readonly Counter<long> RejectedRequests = Meter.CreateCounter<long>("repl.mcp.http.requests.rejected");
+	public static readonly Counter<long> StartupFailures = Meter.CreateCounter<long>("repl.mcp.http.startup.failures");
+}

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpOptions.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpOptions.cs
@@ -1,0 +1,45 @@
+using ModelContextProtocol.AspNetCore;
+using Repl.Mcp;
+
+namespace Repl.Mcp.AspNetCore;
+
+/// <summary>
+/// Configures Repl MCP over ASP.NET Core Streamable HTTP.
+/// </summary>
+public sealed class ReplMcpHttpOptions
+{
+	/// <summary>
+	/// Gets or sets a callback for configuring the Repl MCP server surface created for each MCP session.
+	/// </summary>
+	public Action<ReplMcpServerOptions>? ConfigureServer { get; set; }
+
+	/// <summary>
+	/// Gets or sets a callback for configuring the underlying MCP HTTP transport.
+	/// </summary>
+	public Action<HttpServerTransportOptions>? ConfigureTransport { get; set; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether MCP authorization filters should be registered.
+	/// </summary>
+	public bool EnableAuthorizationFilters { get; set; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether HTTP sessions should be stateless.
+	/// </summary>
+	public bool Stateless { get; set; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether a single execution context should be used per MCP session.
+	/// </summary>
+	public bool PerSessionExecutionContext { get; set; }
+
+	/// <summary>
+	/// Gets or sets the amount of idle time after which a stateful MCP session expires.
+	/// </summary>
+	public TimeSpan? IdleTimeout { get; set; }
+
+	/// <summary>
+	/// Gets or sets the maximum number of idle stateful MCP sessions to keep in memory.
+	/// </summary>
+	public int? MaxIdleSessionCount { get; set; }
+}

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpOptions.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpOptions.cs
@@ -42,4 +42,15 @@ public sealed class ReplMcpHttpOptions
 	/// Gets or sets the maximum number of idle stateful MCP sessions to keep in memory.
 	/// </summary>
 	public int? MaxIdleSessionCount { get; set; }
+
+	internal ReplMcpHttpOptions Clone() => new()
+	{
+		ConfigureServer = ConfigureServer,
+		ConfigureTransport = ConfigureTransport,
+		EnableAuthorizationFilters = EnableAuthorizationFilters,
+		Stateless = Stateless,
+		PerSessionExecutionContext = PerSessionExecutionContext,
+		IdleTimeout = IdleTimeout,
+		MaxIdleSessionCount = MaxIdleSessionCount,
+	};
 }

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpReplAppExtensions.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpReplAppExtensions.cs
@@ -1,0 +1,29 @@
+namespace Repl.Mcp.AspNetCore;
+
+/// <summary>
+/// Extension methods for enabling Repl MCP Streamable HTTP CLI hosting.
+/// </summary>
+public static class ReplMcpHttpReplAppExtensions
+{
+	/// <summary>
+	/// Enables MCP Streamable HTTP server mode via <c>{commandName} mcp httpserve</c>.
+	/// </summary>
+	/// <param name="app">Target Repl app.</param>
+	/// <param name="configure">Optional server configuration callback.</param>
+	/// <returns>The same app instance.</returns>
+	public static ReplApp UseMcpHttpServer(
+		this ReplApp app,
+		Action<ReplMcpHttpServerOptions>? configure = null)
+	{
+		ArgumentNullException.ThrowIfNull(app);
+
+		var options = new ReplMcpHttpServerOptions();
+		configure?.Invoke(options);
+
+		app.MapModule(
+			new McpHttpModule(app, options),
+			static context => context.Channel is ReplRuntimeChannel.Cli);
+
+		return app;
+	}
+}

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpSecurityMiddleware.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpSecurityMiddleware.cs
@@ -1,0 +1,128 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Repl.Mcp.AspNetCore;
+
+internal sealed class ReplMcpHttpSecurityMiddleware
+{
+	private static readonly Action<ILogger, string, Exception?> LogRejectedHost =
+		LoggerMessage.Define<string>(
+			LogLevel.Warning,
+			new EventId(1, nameof(LogRejectedHost)),
+			"Rejected MCP HTTP request with Host '{Host}'.");
+
+	private static readonly Action<ILogger, string, Exception?> LogRejectedOrigin =
+		LoggerMessage.Define<string>(
+			LogLevel.Warning,
+			new EventId(2, nameof(LogRejectedOrigin)),
+			"Rejected MCP HTTP request with Origin '{Origin}'.");
+
+	private readonly RequestDelegate _next;
+	private readonly ILogger<ReplMcpHttpSecurityMiddleware> _logger;
+	private readonly ReplMcpHttpSecurityOptions _options;
+
+	public ReplMcpHttpSecurityMiddleware(
+		RequestDelegate next,
+		ILogger<ReplMcpHttpSecurityMiddleware> logger,
+		ReplMcpHttpSecurityOptions options)
+	{
+		_next = next;
+		_logger = logger;
+		_options = options;
+	}
+
+	public async Task InvokeAsync(HttpContext context)
+	{
+		if (!IsAllowedHost(context.Request.Host.Host))
+		{
+			ReplMcpHttpDiagnostics.RejectedRequests.Add(1, new KeyValuePair<string, object?>("reason", "host"));
+			LogRejectedHost(_logger, context.Request.Host.Value ?? string.Empty, null);
+			context.Response.StatusCode = StatusCodes.Status403Forbidden;
+			return;
+		}
+
+		if (!IsAllowedOrigin(context.Request.Headers.Origin.ToString()))
+		{
+			ReplMcpHttpDiagnostics.RejectedRequests.Add(1, new KeyValuePair<string, object?>("reason", "origin"));
+			LogRejectedOrigin(_logger, context.Request.Headers.Origin.ToString(), null);
+			context.Response.StatusCode = StatusCodes.Status403Forbidden;
+			return;
+		}
+
+		using var activity = ReplMcpHttpDiagnostics.ActivitySource.StartActivity(
+			"Repl.Mcp.HttpRequest",
+			ActivityKind.Server);
+		await _next(context).ConfigureAwait(false);
+	}
+
+	private bool IsAllowedHost(string? host)
+	{
+		if (_options.AllowAnyHost)
+		{
+			return true;
+		}
+
+		if (string.IsNullOrWhiteSpace(host))
+		{
+			return false;
+		}
+
+		var normalized = NormalizeHost(host);
+		return _options.AllowedHosts
+			.Select(NormalizeHost)
+			.Contains(normalized, StringComparer.OrdinalIgnoreCase);
+	}
+
+	private bool IsAllowedOrigin(string origin)
+	{
+		if (_options.AllowAnyOrigin || string.IsNullOrWhiteSpace(origin))
+		{
+			return true;
+		}
+
+		return _options.AllowedOrigins.Contains(origin, StringComparer.OrdinalIgnoreCase);
+	}
+
+	private static string NormalizeHost(string host)
+	{
+		var normalized = host.Trim();
+		if (normalized.Length > 1 && normalized[0] == '[')
+		{
+			var closingBracket = normalized.IndexOf(']', StringComparison.Ordinal);
+			if (closingBracket >= 0)
+			{
+				return normalized[..(closingBracket + 1)];
+			}
+		}
+
+		if (ContainsMultipleColons(normalized))
+		{
+			return normalized;
+		}
+
+		var colon = normalized.LastIndexOf(':');
+		return colon > 0 ? normalized[..colon] : normalized;
+	}
+
+	private static bool ContainsMultipleColons(string value)
+	{
+		var found = false;
+		foreach (var character in value)
+		{
+			if (character != ':')
+			{
+				continue;
+			}
+
+			if (found)
+			{
+				return true;
+			}
+
+			found = true;
+		}
+
+		return false;
+	}
+}

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpSecurityOptions.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpSecurityOptions.cs
@@ -40,27 +40,9 @@ public sealed class ReplMcpHttpSecurityOptions
 			return false;
 		}
 
-		foreach (var defaultHost in DefaultAllowedHosts)
-		{
-			if (!ContainsAllowedHost(defaultHost))
-			{
-				return false;
-			}
-		}
-
-		return true;
+		return !DefaultAllowedHosts.Any(defaultHost => !ContainsAllowedHost(defaultHost));
 	}
 
-	private bool ContainsAllowedHost(string host)
-	{
-		foreach (var allowedHost in AllowedHosts)
-		{
-			if (StringComparer.OrdinalIgnoreCase.Equals(allowedHost, host))
-			{
-				return true;
-			}
-		}
-
-		return false;
-	}
+	private bool ContainsAllowedHost(string host) =>
+		AllowedHosts.Any(allowedHost => StringComparer.OrdinalIgnoreCase.Equals(allowedHost, host));
 }

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpSecurityOptions.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpSecurityOptions.cs
@@ -1,0 +1,33 @@
+namespace Repl.Mcp.AspNetCore;
+
+/// <summary>
+/// Configures defensive HTTP checks for self-hosted Repl MCP endpoints.
+/// </summary>
+public sealed class ReplMcpHttpSecurityOptions
+{
+	/// <summary>
+	/// Gets or sets the allowed HTTP Host header values. Ports are ignored when matching.
+	/// </summary>
+	public IList<string> AllowedHosts { get; } =
+	[
+		"localhost",
+		"127.0.0.1",
+		"::1",
+		"[::1]",
+	];
+
+	/// <summary>
+	/// Gets the allowed browser Origin header values.
+	/// </summary>
+	public IList<string> AllowedOrigins { get; } = [];
+
+	/// <summary>
+	/// Gets or sets a value indicating whether any HTTP Host header should be accepted.
+	/// </summary>
+	public bool AllowAnyHost { get; set; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether any browser Origin header should be accepted.
+	/// </summary>
+	public bool AllowAnyOrigin { get; set; }
+}

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpSecurityOptions.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpSecurityOptions.cs
@@ -5,16 +5,18 @@ namespace Repl.Mcp.AspNetCore;
 /// </summary>
 public sealed class ReplMcpHttpSecurityOptions
 {
-	/// <summary>
-	/// Gets or sets the allowed HTTP Host header values. Ports are ignored when matching.
-	/// </summary>
-	public IList<string> AllowedHosts { get; } =
+	private static readonly string[] DefaultAllowedHosts =
 	[
 		"localhost",
 		"127.0.0.1",
 		"::1",
 		"[::1]",
 	];
+
+	/// <summary>
+	/// Gets or sets the allowed HTTP Host header values. Ports are ignored when matching.
+	/// </summary>
+	public IList<string> AllowedHosts { get; } = [.. DefaultAllowedHosts];
 
 	/// <summary>
 	/// Gets the allowed browser Origin header values.
@@ -30,4 +32,35 @@ public sealed class ReplMcpHttpSecurityOptions
 	/// Gets or sets a value indicating whether any browser Origin header should be accepted.
 	/// </summary>
 	public bool AllowAnyOrigin { get; set; }
+
+	internal bool UsesDefaultAllowedHosts()
+	{
+		if (AllowAnyHost || AllowedHosts.Count != DefaultAllowedHosts.Length)
+		{
+			return false;
+		}
+
+		foreach (var defaultHost in DefaultAllowedHosts)
+		{
+			if (!ContainsAllowedHost(defaultHost))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private bool ContainsAllowedHost(string host)
+	{
+		foreach (var allowedHost in AllowedHosts)
+		{
+			if (StringComparer.OrdinalIgnoreCase.Equals(allowedHost, host))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
 }

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpServer.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpServer.cs
@@ -1,0 +1,89 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Repl.Mcp.AspNetCore;
+
+/// <summary>
+/// Runs self-hosted Repl MCP Streamable HTTP servers.
+/// </summary>
+public static class ReplMcpHttpServer
+{
+	/// <summary>
+	/// Runs a self-hosted Repl MCP Streamable HTTP server until cancellation is requested.
+	/// </summary>
+	/// <param name="app">The Repl app to expose over MCP.</param>
+	/// <param name="configure">Optional server configuration callback.</param>
+	/// <param name="output">Optional startup output writer.</param>
+	/// <param name="cancellationToken">Cancellation token.</param>
+	public static async Task RunAsync(
+		ReplApp app,
+		Action<ReplMcpHttpServerOptions>? configure = null,
+		TextWriter? output = null,
+		CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(app);
+
+		var options = new ReplMcpHttpServerOptions();
+		configure?.Invoke(options);
+
+		await RunAsync(app, options, output, cancellationToken).ConfigureAwait(false);
+	}
+
+	internal static async Task RunAsync(
+		ReplApp replApp,
+		ReplMcpHttpServerOptions options,
+		TextWriter? output,
+		CancellationToken cancellationToken)
+	{
+		ArgumentNullException.ThrowIfNull(replApp);
+		ArgumentNullException.ThrowIfNull(options);
+
+		var binding = McpHttpBindingFactory.Create(
+			options.Host,
+			options.Port,
+			options.Path,
+			options.AllowRemote);
+
+		var builder = WebApplication.CreateSlimBuilder();
+		builder.Logging.ClearProviders();
+		builder.WebHost.UseUrls(binding.ListenUrl);
+		builder.Services.AddReplMcpHttp(replApp, http =>
+		{
+			var httpOptions = options.ToHttpOptions();
+			http.ConfigureServer = httpOptions.ConfigureServer;
+			http.ConfigureTransport = httpOptions.ConfigureTransport;
+			http.EnableAuthorizationFilters = httpOptions.EnableAuthorizationFilters;
+			http.Stateless = httpOptions.Stateless;
+			http.PerSessionExecutionContext = httpOptions.PerSessionExecutionContext;
+			http.IdleTimeout = httpOptions.IdleTimeout;
+			http.MaxIdleSessionCount = httpOptions.MaxIdleSessionCount;
+		});
+
+		var webApp = builder.Build();
+		await using (webApp.ConfigureAwait(false))
+		{
+			webApp.MapReplMcp(binding.Path);
+
+			if (!options.Quiet && output is not null)
+			{
+				await output.WriteLineAsync($"MCP HTTP server listening on {binding.EndpointUrl}").ConfigureAwait(false);
+				await output.WriteLineAsync(
+					binding.AllowsRemote
+						? "Remote clients are allowed by the selected binding."
+						: "Remote clients are disabled; bind a non-loopback host with --allow-remote to expose it.")
+					.ConfigureAwait(false);
+			}
+
+			await webApp.StartAsync(cancellationToken).ConfigureAwait(false);
+			try
+			{
+				await Task.Delay(Timeout.InfiniteTimeSpan, TimeProvider.System, cancellationToken).ConfigureAwait(false);
+			}
+			finally
+			{
+				await webApp.StopAsync(CancellationToken.None).ConfigureAwait(false);
+			}
+		}
+	}
+}

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpServer.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpServer.cs
@@ -10,6 +10,12 @@ namespace Repl.Mcp.AspNetCore;
 /// </summary>
 public static class ReplMcpHttpServer
 {
+	private static readonly Action<ILogger, Exception?> LogShutdownRequested =
+		LoggerMessage.Define(
+			LogLevel.Debug,
+			new EventId(1, nameof(LogShutdownRequested)),
+			"MCP HTTP server shutdown requested.");
+
 	/// <summary>
 	/// Runs a self-hosted Repl MCP Streamable HTTP server until cancellation is requested.
 	/// </summary>
@@ -79,6 +85,7 @@ public static class ReplMcpHttpServer
 			}
 			catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
 			{
+				LogShutdownRequested(webApp.Logger, null);
 			}
 			finally
 			{

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpServer.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpServer.cs
@@ -50,6 +50,7 @@ public static class ReplMcpHttpServer
 		builder.Logging.AddSimpleConsole();
 		options.ConfigureBuilder?.Invoke(builder);
 		builder.WebHost.UseUrls(binding.ListenUrl);
+		ApplyBindingSecurityDefaults(binding, options.Security);
 		builder.Services.AddSingleton(options.Security);
 		builder.Services.AddReplMcpHttp(replApp, options.Http);
 
@@ -83,6 +84,16 @@ public static class ReplMcpHttpServer
 			{
 				await webApp.StopAsync(CancellationToken.None).ConfigureAwait(false);
 			}
+		}
+	}
+
+	internal static void ApplyBindingSecurityDefaults(
+		McpHttpBinding binding,
+		ReplMcpHttpSecurityOptions security)
+	{
+		if (binding.AllowsRemote && security.UsesDefaultAllowedHosts())
+		{
+			security.AllowAnyHost = true;
 		}
 	}
 }

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpServer.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpServer.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Repl.Mcp.AspNetCore;
@@ -46,24 +47,19 @@ public static class ReplMcpHttpServer
 			options.AllowRemote);
 
 		var builder = WebApplication.CreateSlimBuilder();
-		builder.Logging.ClearProviders();
+		builder.Logging.AddSimpleConsole();
+		options.ConfigureBuilder?.Invoke(builder);
 		builder.WebHost.UseUrls(binding.ListenUrl);
-		builder.Services.AddReplMcpHttp(replApp, http =>
-		{
-			var httpOptions = options.ToHttpOptions();
-			http.ConfigureServer = httpOptions.ConfigureServer;
-			http.ConfigureTransport = httpOptions.ConfigureTransport;
-			http.EnableAuthorizationFilters = httpOptions.EnableAuthorizationFilters;
-			http.Stateless = httpOptions.Stateless;
-			http.PerSessionExecutionContext = httpOptions.PerSessionExecutionContext;
-			http.IdleTimeout = httpOptions.IdleTimeout;
-			http.MaxIdleSessionCount = httpOptions.MaxIdleSessionCount;
-		});
+		builder.Services.AddSingleton(options.Security);
+		builder.Services.AddReplMcpHttp(replApp, options.Http);
 
 		var webApp = builder.Build();
 		await using (webApp.ConfigureAwait(false))
 		{
-			webApp.MapReplMcp(binding.Path);
+			webApp.UseMiddleware<ReplMcpHttpSecurityMiddleware>();
+			options.ConfigureApp?.Invoke(webApp);
+			var endpoint = webApp.MapReplMcp(binding.Path);
+			options.ConfigureEndpoint?.Invoke(endpoint);
 
 			if (!options.Quiet && output is not null)
 			{
@@ -79,6 +75,9 @@ public static class ReplMcpHttpServer
 			try
 			{
 				await Task.Delay(Timeout.InfiniteTimeSpan, TimeProvider.System, cancellationToken).ConfigureAwait(false);
+			}
+			catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+			{
 			}
 			finally
 			{

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpServerOptions.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpServerOptions.cs
@@ -1,0 +1,112 @@
+using ModelContextProtocol.AspNetCore;
+using Repl.Mcp;
+
+namespace Repl.Mcp.AspNetCore;
+
+/// <summary>
+/// Configures the self-hosted Repl MCP Streamable HTTP server.
+/// </summary>
+public sealed class ReplMcpHttpServerOptions
+{
+	/// <summary>
+	/// Default local-only host.
+	/// </summary>
+	public const string DefaultHost = "127.0.0.1";
+
+	/// <summary>
+	/// Default HTTP port. The digits correspond to "repl" on a phone keypad.
+	/// </summary>
+	public const int DefaultPort = 7375;
+
+	/// <summary>
+	/// Default Streamable HTTP endpoint path.
+	/// </summary>
+	public const string DefaultPath = "/mcp";
+
+	/// <summary>
+	/// Gets or sets the hostname or IP address to bind.
+	/// </summary>
+	public string Host { get; set; } = DefaultHost;
+
+	/// <summary>
+	/// Gets or sets the HTTP port to bind.
+	/// </summary>
+	public int Port { get; set; } = DefaultPort;
+
+	/// <summary>
+	/// Gets or sets the Streamable HTTP endpoint path.
+	/// </summary>
+	public string Path { get; set; } = DefaultPath;
+
+	/// <summary>
+	/// Gets or sets a value indicating whether non-loopback bindings are allowed.
+	/// </summary>
+	public bool AllowRemote { get; set; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether startup messages should be suppressed.
+	/// </summary>
+	public bool Quiet { get; set; }
+
+	/// <summary>
+	/// Gets or sets a callback for configuring the Repl MCP server surface created for each MCP session.
+	/// </summary>
+	public Action<ReplMcpServerOptions>? ConfigureServer { get; set; }
+
+	/// <summary>
+	/// Gets or sets a callback for configuring the underlying MCP HTTP transport.
+	/// </summary>
+	public Action<HttpServerTransportOptions>? ConfigureTransport { get; set; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether MCP authorization filters should be registered.
+	/// </summary>
+	public bool EnableAuthorizationFilters { get; set; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether HTTP sessions should be stateless.
+	/// </summary>
+	public bool Stateless { get; set; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether a single execution context should be used per MCP session.
+	/// </summary>
+	public bool PerSessionExecutionContext { get; set; }
+
+	/// <summary>
+	/// Gets or sets the amount of idle time after which a stateful MCP session expires.
+	/// </summary>
+	public TimeSpan? IdleTimeout { get; set; }
+
+	/// <summary>
+	/// Gets or sets the maximum number of idle stateful MCP sessions to keep in memory.
+	/// </summary>
+	public int? MaxIdleSessionCount { get; set; }
+
+	internal ReplMcpHttpOptions ToHttpOptions() => new()
+	{
+		ConfigureServer = ConfigureServer,
+		ConfigureTransport = ConfigureTransport,
+		EnableAuthorizationFilters = EnableAuthorizationFilters,
+		Stateless = Stateless,
+		PerSessionExecutionContext = PerSessionExecutionContext,
+		IdleTimeout = IdleTimeout,
+		MaxIdleSessionCount = MaxIdleSessionCount,
+	};
+
+	internal ReplMcpHttpServerOptions Clone() => new()
+	{
+		Host = Host,
+		Port = Port,
+		Path = Path,
+		AllowRemote = AllowRemote,
+		Quiet = Quiet,
+		ConfigureServer = ConfigureServer,
+		ConfigureTransport = ConfigureTransport,
+		EnableAuthorizationFilters = EnableAuthorizationFilters,
+		Stateless = Stateless,
+		PerSessionExecutionContext = PerSessionExecutionContext,
+		IdleTimeout = IdleTimeout,
+		MaxIdleSessionCount = MaxIdleSessionCount,
+	};
+}

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpServerOptions.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpServerOptions.cs
@@ -1,5 +1,5 @@
-using ModelContextProtocol.AspNetCore;
-using Repl.Mcp;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
 
 namespace Repl.Mcp.AspNetCore;
 
@@ -11,17 +11,17 @@ public sealed class ReplMcpHttpServerOptions
 	/// <summary>
 	/// Default local-only host.
 	/// </summary>
-	public const string DefaultHost = "127.0.0.1";
+	public static readonly string DefaultHost = "127.0.0.1";
 
 	/// <summary>
 	/// Default HTTP port. The digits correspond to "repl" on a phone keypad.
 	/// </summary>
-	public const int DefaultPort = 7375;
+	public static readonly int DefaultPort = 7375;
 
 	/// <summary>
 	/// Default Streamable HTTP endpoint path.
 	/// </summary>
-	public const string DefaultPath = "/mcp";
+	public static readonly string DefaultPath = "/mcp";
 
 	/// <summary>
 	/// Gets or sets the hostname or IP address to bind.
@@ -49,64 +49,79 @@ public sealed class ReplMcpHttpServerOptions
 	public bool Quiet { get; set; }
 
 	/// <summary>
-	/// Gets or sets a callback for configuring the Repl MCP server surface created for each MCP session.
+	/// Gets the shared Repl MCP HTTP transport options.
 	/// </summary>
-	public Action<ReplMcpServerOptions>? ConfigureServer { get; set; }
+	public ReplMcpHttpOptions Http { get; } = new();
 
 	/// <summary>
-	/// Gets or sets a callback for configuring the underlying MCP HTTP transport.
+	/// Gets the self-hosted HTTP security options.
 	/// </summary>
-	public Action<HttpServerTransportOptions>? ConfigureTransport { get; set; }
+	public ReplMcpHttpSecurityOptions Security { get; } = new();
 
 	/// <summary>
-	/// Gets or sets a value indicating whether MCP authorization filters should be registered.
+	/// Gets or sets a callback invoked before the inner <see cref="WebApplication"/> is built.
 	/// </summary>
-	public bool EnableAuthorizationFilters { get; set; }
+	public Action<WebApplicationBuilder>? ConfigureBuilder { get; set; }
 
 	/// <summary>
-	/// Gets or sets a value indicating whether HTTP sessions should be stateless.
+	/// Gets or sets a callback invoked after the inner <see cref="WebApplication"/> is built and before MCP is mapped.
 	/// </summary>
-	public bool Stateless { get; set; }
+	public Action<WebApplication>? ConfigureApp { get; set; }
 
 	/// <summary>
-	/// Gets or sets a value indicating whether a single execution context should be used per MCP session.
+	/// Gets or sets a callback invoked after the MCP endpoint is mapped.
 	/// </summary>
-	public bool PerSessionExecutionContext { get; set; }
+	public Action<IEndpointConventionBuilder>? ConfigureEndpoint { get; set; }
 
-	/// <summary>
-	/// Gets or sets the amount of idle time after which a stateful MCP session expires.
-	/// </summary>
-	public TimeSpan? IdleTimeout { get; set; }
-
-	/// <summary>
-	/// Gets or sets the maximum number of idle stateful MCP sessions to keep in memory.
-	/// </summary>
-	public int? MaxIdleSessionCount { get; set; }
-
-	internal ReplMcpHttpOptions ToHttpOptions() => new()
+	internal ReplMcpHttpServerOptions Clone()
 	{
-		ConfigureServer = ConfigureServer,
-		ConfigureTransport = ConfigureTransport,
-		EnableAuthorizationFilters = EnableAuthorizationFilters,
-		Stateless = Stateless,
-		PerSessionExecutionContext = PerSessionExecutionContext,
-		IdleTimeout = IdleTimeout,
-		MaxIdleSessionCount = MaxIdleSessionCount,
-	};
+		var clone = new ReplMcpHttpServerOptions
+		{
+			Host = Host,
+			Port = Port,
+			Path = Path,
+			AllowRemote = AllowRemote,
+			Quiet = Quiet,
+			ConfigureBuilder = ConfigureBuilder,
+			ConfigureApp = ConfigureApp,
+			ConfigureEndpoint = ConfigureEndpoint,
+		};
 
-	internal ReplMcpHttpServerOptions Clone() => new()
+		CopyNestedOptionsTo(clone);
+		return clone;
+	}
+
+	internal void CopyNestedOptionsTo(ReplMcpHttpServerOptions target)
 	{
-		Host = Host,
-		Port = Port,
-		Path = Path,
-		AllowRemote = AllowRemote,
-		Quiet = Quiet,
-		ConfigureServer = ConfigureServer,
-		ConfigureTransport = ConfigureTransport,
-		EnableAuthorizationFilters = EnableAuthorizationFilters,
-		Stateless = Stateless,
-		PerSessionExecutionContext = PerSessionExecutionContext,
-		IdleTimeout = IdleTimeout,
-		MaxIdleSessionCount = MaxIdleSessionCount,
-	};
+		CopyHttpOptions(Http, target.Http);
+		CopySecurityOptions(Security, target.Security);
+	}
+
+	private static void CopyHttpOptions(ReplMcpHttpOptions source, ReplMcpHttpOptions target)
+	{
+		target.ConfigureServer = source.ConfigureServer;
+		target.ConfigureTransport = source.ConfigureTransport;
+		target.EnableAuthorizationFilters = source.EnableAuthorizationFilters;
+		target.Stateless = source.Stateless;
+		target.PerSessionExecutionContext = source.PerSessionExecutionContext;
+		target.IdleTimeout = source.IdleTimeout;
+		target.MaxIdleSessionCount = source.MaxIdleSessionCount;
+	}
+
+	private static void CopySecurityOptions(ReplMcpHttpSecurityOptions source, ReplMcpHttpSecurityOptions target)
+	{
+		target.AllowAnyHost = source.AllowAnyHost;
+		target.AllowAnyOrigin = source.AllowAnyOrigin;
+		target.AllowedHosts.Clear();
+		foreach (var host in source.AllowedHosts)
+		{
+			target.AllowedHosts.Add(host);
+		}
+
+		target.AllowedOrigins.Clear();
+		foreach (var origin in source.AllowedOrigins)
+		{
+			target.AllowedOrigins.Add(origin);
+		}
+	}
 }

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpServerOptions.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpServerOptions.cs
@@ -24,6 +24,15 @@ public sealed class ReplMcpHttpServerOptions
 	public static readonly string DefaultPath = "/mcp";
 
 	/// <summary>
+	/// Initializes a new instance of the <see cref="ReplMcpHttpServerOptions"/> class.
+	/// </summary>
+	public ReplMcpHttpServerOptions()
+	{
+		Http.IdleTimeout = TimeSpan.FromMinutes(30);
+		Http.MaxIdleSessionCount = 100;
+	}
+
+	/// <summary>
 	/// Gets or sets the hostname or IP address to bind.
 	/// </summary>
 	public string Host { get; set; } = DefaultHost;

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpServiceCollectionExtensions.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModelContextProtocol.AspNetCore;
@@ -11,6 +12,8 @@ namespace Repl.Mcp.AspNetCore;
 /// </summary>
 public static class ReplMcpHttpServiceCollectionExtensions
 {
+	private static readonly object SessionItemKey = new();
+
 	/// <summary>
 	/// Registers Repl MCP server services using the MCP Streamable HTTP transport.
 	/// </summary>
@@ -52,26 +55,80 @@ public static class ReplMcpHttpServiceCollectionExtensions
 			builder.AddAuthorizationFilters();
 		}
 
-		builder.WithHttpTransport(http =>
-		{
-			ApplyTransportOptions(http, options);
-			options.ConfigureTransport?.Invoke(http);
+		builder.WithHttpTransport(http => ConfigureTransport(http, app, options));
 
-			var configureSessionOptions = http.ConfigureSessionOptions;
-			http.ConfigureSessionOptions = async (context, serverOptions, cancellationToken) =>
+		return builder;
+	}
+
+	internal static void ConfigureTransport(
+		HttpServerTransportOptions http,
+		ReplApp app,
+		ReplMcpHttpOptions options)
+	{
+		ApplyTransportOptions(http, options);
+		options.ConfigureTransport?.Invoke(http);
+		ConfigureSessionOptions(http, app, options);
+		ConfigureRunSessionHandler(http);
+	}
+
+	private static void ConfigureSessionOptions(
+		HttpServerTransportOptions http,
+		ReplApp app,
+		ReplMcpHttpOptions options)
+	{
+		var configureSessionOptions = http.ConfigureSessionOptions;
+		http.ConfigureSessionOptions = async (context, serverOptions, cancellationToken) =>
+		{
+			var sessionServices = new CompositeServiceProvider(context.RequestServices, app.Services);
+			var session = app.CreateMcpServerSession(sessionServices, options.ConfigureServer);
+			try
 			{
-				var sessionServices = new CompositeServiceProvider(context.RequestServices, app.Services);
-				var session = app.CreateMcpServerSession(sessionServices, options.ConfigureServer);
 				CopyServerOptions(session.ServerOptions, serverOptions);
+				context.Items[SessionItemKey] = session;
 
 				if (configureSessionOptions is not null)
 				{
 					await configureSessionOptions(context, serverOptions, cancellationToken).ConfigureAwait(false);
 				}
-			};
-		});
+			}
+			catch
+			{
+				context.Items.Remove(SessionItemKey);
+				session.Dispose();
+				throw;
+			}
+		};
+	}
 
-		return builder;
+	private static void ConfigureRunSessionHandler(HttpServerTransportOptions http)
+	{
+#pragma warning disable MCPEXP002
+		var runSessionHandler = http.RunSessionHandler;
+		http.RunSessionHandler = async (context, server, cancellationToken) =>
+		{
+			var session = TakeSession(context);
+			ReplMcpHttpDiagnostics.SessionsStarted.Add(1);
+			ReplMcpHttpDiagnostics.SessionsActive.Add(1);
+			try
+			{
+				if (runSessionHandler is not null)
+				{
+					await runSessionHandler(context, server, cancellationToken).ConfigureAwait(false);
+				}
+				else
+				{
+					await server.RunAsync(cancellationToken).ConfigureAwait(false);
+				}
+			}
+			finally
+			{
+				session ??= TakeSession(context);
+				session?.Dispose();
+				ReplMcpHttpDiagnostics.SessionsEnded.Add(1);
+				ReplMcpHttpDiagnostics.SessionsActive.Add(-1);
+			}
+		};
+#pragma warning restore MCPEXP002
 	}
 
 	private static void ApplyTransportOptions(
@@ -97,5 +154,17 @@ public static class ReplMcpHttpServiceCollectionExtensions
 		target.ServerInfo = source.ServerInfo;
 		target.Capabilities = source.Capabilities;
 		target.Handlers = source.Handlers;
+	}
+
+	private static ReplMcpServerSession? TakeSession(HttpContext context)
+	{
+		if (context.Items.TryGetValue(SessionItemKey, out var value)
+			&& value is ReplMcpServerSession session)
+		{
+			context.Items.Remove(SessionItemKey);
+			return session;
+		}
+
+		return null;
 	}
 }

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpServiceCollectionExtensions.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpServiceCollectionExtensions.cs
@@ -1,0 +1,86 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using ModelContextProtocol.AspNetCore;
+using ModelContextProtocol.Server;
+using Repl.Mcp;
+
+namespace Repl.Mcp.AspNetCore;
+
+/// <summary>
+/// Extension methods for registering Repl MCP over ASP.NET Core Streamable HTTP.
+/// </summary>
+public static class ReplMcpHttpServiceCollectionExtensions
+{
+	/// <summary>
+	/// Registers Repl MCP server services using the MCP Streamable HTTP transport.
+	/// </summary>
+	/// <param name="services">Service collection.</param>
+	/// <param name="app">The Repl app to expose over MCP.</param>
+	/// <param name="configure">Optional HTTP MCP configuration callback.</param>
+	/// <returns>The MCP server builder.</returns>
+	public static IMcpServerBuilder AddReplMcpHttp(
+		this IServiceCollection services,
+		ReplApp app,
+		Action<ReplMcpHttpOptions>? configure = null)
+	{
+		ArgumentNullException.ThrowIfNull(services);
+		ArgumentNullException.ThrowIfNull(app);
+
+		var options = new ReplMcpHttpOptions();
+		configure?.Invoke(options);
+
+		services.TryAddSingleton(app);
+
+		var builder = services.AddMcpServer();
+		if (options.EnableAuthorizationFilters)
+		{
+			builder.AddAuthorizationFilters();
+		}
+
+		builder.WithHttpTransport(http =>
+		{
+			ApplyTransportOptions(http, options);
+			options.ConfigureTransport?.Invoke(http);
+
+			var configureSessionOptions = http.ConfigureSessionOptions;
+			http.ConfigureSessionOptions = async (context, serverOptions, cancellationToken) =>
+			{
+				var sessionServices = new CompositeServiceProvider(context.RequestServices, app.Services);
+				var session = app.CreateMcpServerSession(sessionServices, options.ConfigureServer);
+				CopyServerOptions(session.ServerOptions, serverOptions);
+
+				if (configureSessionOptions is not null)
+				{
+					await configureSessionOptions(context, serverOptions, cancellationToken).ConfigureAwait(false);
+				}
+			};
+		});
+
+		return builder;
+	}
+
+	private static void ApplyTransportOptions(
+		HttpServerTransportOptions transport,
+		ReplMcpHttpOptions options)
+	{
+		transport.Stateless = options.Stateless;
+		transport.PerSessionExecutionContext = options.PerSessionExecutionContext;
+
+		if (options.IdleTimeout is { } idleTimeout)
+		{
+			transport.IdleTimeout = idleTimeout;
+		}
+
+		if (options.MaxIdleSessionCount is { } maxIdleSessionCount)
+		{
+			transport.MaxIdleSessionCount = maxIdleSessionCount;
+		}
+	}
+
+	private static void CopyServerOptions(McpServerOptions source, McpServerOptions target)
+	{
+		target.ServerInfo = source.ServerInfo;
+		target.Capabilities = source.Capabilities;
+		target.Handlers = source.Handlers;
+	}
+}

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpServiceCollectionExtensions.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpServiceCollectionExtensions.cs
@@ -23,11 +23,26 @@ public static class ReplMcpHttpServiceCollectionExtensions
 		ReplApp app,
 		Action<ReplMcpHttpOptions>? configure = null)
 	{
-		ArgumentNullException.ThrowIfNull(services);
-		ArgumentNullException.ThrowIfNull(app);
-
 		var options = new ReplMcpHttpOptions();
 		configure?.Invoke(options);
+		return services.AddReplMcpHttp(app, options);
+	}
+
+	/// <summary>
+	/// Registers Repl MCP server services using the MCP Streamable HTTP transport.
+	/// </summary>
+	/// <param name="services">Service collection.</param>
+	/// <param name="app">The Repl app to expose over MCP.</param>
+	/// <param name="options">HTTP MCP configuration.</param>
+	/// <returns>The MCP server builder.</returns>
+	public static IMcpServerBuilder AddReplMcpHttp(
+		this IServiceCollection services,
+		ReplApp app,
+		ReplMcpHttpOptions options)
+	{
+		ArgumentNullException.ThrowIfNull(services);
+		ArgumentNullException.ThrowIfNull(app);
+		ArgumentNullException.ThrowIfNull(options);
 
 		services.TryAddSingleton(app);
 

--- a/src/Repl.Mcp.AspNetCore/ReplMcpHttpServiceCollectionExtensions.cs
+++ b/src/Repl.Mcp.AspNetCore/ReplMcpHttpServiceCollectionExtensions.cs
@@ -122,8 +122,7 @@ public static class ReplMcpHttpServiceCollectionExtensions
 			}
 			finally
 			{
-				session ??= TakeSession(context);
-				session?.Dispose();
+				using var sessionToDispose = session ?? TakeSession(context);
 				ReplMcpHttpDiagnostics.SessionsEnded.Add(1);
 				ReplMcpHttpDiagnostics.SessionsActive.Add(-1);
 			}

--- a/src/Repl.Mcp/McpReplExtensions.cs
+++ b/src/Repl.Mcp/McpReplExtensions.cs
@@ -81,6 +81,25 @@ public static class McpReplExtensions
 	}
 
 	/// <summary>
+	/// Creates a session-aware MCP server configuration from a <see cref="ReplApp"/>'s command graph
+	/// using an externally supplied service provider during tool dispatch.
+	/// </summary>
+	/// <param name="app">The Repl app.</param>
+	/// <param name="services">Service provider used for DI during tool dispatch.</param>
+	/// <param name="configure">Optional MCP configuration callback.</param>
+	/// <returns>A disposable MCP server session.</returns>
+	public static ReplMcpServerSession CreateMcpServerSession(
+		this ReplApp app,
+		IServiceProvider services,
+		Action<ReplMcpServerOptions>? configure = null)
+	{
+		ArgumentNullException.ThrowIfNull(app);
+		ArgumentNullException.ThrowIfNull(services);
+
+		return app.Core.CreateMcpServerSession(configure, services);
+	}
+
+	/// <summary>
 	/// Builds <see cref="McpServerOptions"/> from the Repl app's command graph.
 	/// Use this to integrate with custom transports (WebSocket, HTTP) or ASP.NET Core
 	/// without going through the <c>mcp serve</c> CLI command.

--- a/src/Repl.Mcp/McpReplExtensions.cs
+++ b/src/Repl.Mcp/McpReplExtensions.cs
@@ -65,6 +65,22 @@ public static class McpReplExtensions
 	}
 
 	/// <summary>
+	/// Creates a session-aware MCP server configuration from a <see cref="ReplApp"/>'s command graph.
+	/// Use this for multi-session transports such as Streamable HTTP.
+	/// </summary>
+	/// <param name="app">The Repl app.</param>
+	/// <param name="configure">Optional MCP configuration callback.</param>
+	/// <returns>A disposable MCP server session.</returns>
+	public static ReplMcpServerSession CreateMcpServerSession(
+		this ReplApp app,
+		Action<ReplMcpServerOptions>? configure = null)
+	{
+		ArgumentNullException.ThrowIfNull(app);
+
+		return app.Core.CreateMcpServerSession(configure, app.Services);
+	}
+
+	/// <summary>
 	/// Builds <see cref="McpServerOptions"/> from the Repl app's command graph.
 	/// Use this to integrate with custom transports (WebSocket, HTTP) or ASP.NET Core
 	/// without going through the <c>mcp serve</c> CLI command.
@@ -87,6 +103,28 @@ public static class McpReplExtensions
 
 		var handler = new McpServerHandler(app, options, services ?? EmptyServiceProvider.Instance);
 		return handler.BuildStaticServerOptions();
+	}
+
+	/// <summary>
+	/// Creates a session-aware MCP server configuration from a Repl command graph.
+	/// Use this for multi-session transports such as Streamable HTTP.
+	/// </summary>
+	/// <param name="app">The core Repl app.</param>
+	/// <param name="configure">Optional MCP configuration callback.</param>
+	/// <param name="services">Optional service provider for DI during tool dispatch.</param>
+	/// <returns>A disposable MCP server session.</returns>
+	public static ReplMcpServerSession CreateMcpServerSession(
+		this ICoreReplApp app,
+		Action<ReplMcpServerOptions>? configure = null,
+		IServiceProvider? services = null)
+	{
+		ArgumentNullException.ThrowIfNull(app);
+
+		var options = new ReplMcpServerOptions();
+		configure?.Invoke(options);
+
+		var handler = new McpServerHandler(app, options, services ?? EmptyServiceProvider.Instance);
+		return new ReplMcpServerSession(handler);
 	}
 
 	private sealed class EmptyServiceProvider : IServiceProvider

--- a/src/Repl.Mcp/McpServerHandler.cs
+++ b/src/Repl.Mcp/McpServerHandler.cs
@@ -12,7 +12,7 @@ namespace Repl.Mcp;
 /// Orchestrates the MCP server lifecycle: builds the documentation model,
 /// generates MCP primitives, and runs the server until cancellation.
 /// </summary>
-internal sealed class McpServerHandler
+internal sealed class McpServerHandler : IDisposable
 {
 	private const string DiscoverToolsName = "discover_tools";
 	private const string CallToolName = "call_tool";
@@ -68,6 +68,8 @@ internal sealed class McpServerHandler
 				[typeof(IMcpFeedback)] = _feedback,
 			});
 	}
+
+	internal IServiceProvider SessionServices => _sessionServices;
 
 	[UnconditionalSuppressMessage(
 		"Trimming",
@@ -533,6 +535,12 @@ internal sealed class McpServerHandler
 			_debounceTimer?.Dispose();
 			_debounceTimer = null;
 		}
+	}
+
+	public void Dispose()
+	{
+		UnsubscribeFromRoutingChanges();
+		_snapshotGate.Dispose();
 	}
 
 	private ServerCapabilities BuildCapabilities()

--- a/src/Repl.Mcp/ReplMcpServerSession.cs
+++ b/src/Repl.Mcp/ReplMcpServerSession.cs
@@ -1,0 +1,41 @@
+using ModelContextProtocol.Server;
+
+namespace Repl.Mcp;
+
+/// <summary>
+/// Represents a dynamically generated MCP server session for custom transports.
+/// </summary>
+public sealed class ReplMcpServerSession : IDisposable
+{
+	private readonly McpServerHandler _handler;
+	private bool _disposed;
+
+	internal ReplMcpServerSession(McpServerHandler handler)
+	{
+		_handler = handler;
+		ServerOptions = handler.BuildDynamicServerOptions();
+		Services = handler.SessionServices;
+	}
+
+	/// <summary>
+	/// Gets the MCP server options for this session.
+	/// </summary>
+	public McpServerOptions ServerOptions { get; }
+
+	/// <summary>
+	/// Gets the session-aware service provider for this session.
+	/// </summary>
+	public IServiceProvider Services { get; }
+
+	/// <inheritdoc />
+	public void Dispose()
+	{
+		if (_disposed)
+		{
+			return;
+		}
+
+		_handler.Dispose();
+		_disposed = true;
+	}
+}

--- a/src/Repl.McpTests/Given_McpHttpBinding.cs
+++ b/src/Repl.McpTests/Given_McpHttpBinding.cs
@@ -1,0 +1,64 @@
+using Repl.Mcp.AspNetCore;
+
+namespace Repl.McpTests;
+
+[TestClass]
+public sealed class Given_McpHttpBinding
+{
+	[TestMethod]
+	public void When_DefaultBindingCreated_Then_UsesLocalReplPort()
+	{
+		var binding = McpHttpBindingFactory.Create(
+			host: null,
+			ReplMcpHttpServerOptions.DefaultPort,
+			path: null,
+			allowRemote: false);
+
+		binding.Host.Should().Be("127.0.0.1");
+		binding.Port.Should().Be(7375);
+		binding.Path.Should().Be("/mcp");
+		binding.EndpointUrl.Should().Be("http://127.0.0.1:7375/mcp");
+		binding.AllowsRemote.Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void When_RemoteBindingWithoutOptIn_Then_Fails()
+	{
+		var action = () => McpHttpBindingFactory.Create(
+			"0.0.0.0",
+			ReplMcpHttpServerOptions.DefaultPort,
+			"/mcp",
+			allowRemote: false);
+
+		action.Should().Throw<InvalidOperationException>()
+			.WithMessage("*--allow-remote*");
+	}
+
+	[TestMethod]
+	public void When_RemoteBindingAllowed_Then_UsesRequestedHost()
+	{
+		var binding = McpHttpBindingFactory.Create(
+			"0.0.0.0",
+			4342,
+			"mcp",
+			allowRemote: true);
+
+		binding.ListenUrl.Should().Be("http://0.0.0.0:4342");
+		binding.EndpointUrl.Should().Be("http://0.0.0.0:4342/mcp");
+		binding.AllowsRemote.Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void When_Ipv6LoopbackBindingCreated_Then_HostIsBracketedInUrl()
+	{
+		var binding = McpHttpBindingFactory.Create(
+			"::1",
+			7375,
+			"/mcp",
+			allowRemote: false);
+
+		binding.ListenUrl.Should().Be("http://[::1]:7375");
+		binding.EndpointUrl.Should().Be("http://[::1]:7375/mcp");
+		binding.AllowsRemote.Should().BeFalse();
+	}
+}

--- a/src/Repl.McpTests/Given_McpHttpSelfHostSecurity.cs
+++ b/src/Repl.McpTests/Given_McpHttpSelfHostSecurity.cs
@@ -1,5 +1,8 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.AspNetCore;
+using ModelContextProtocol.Server;
 using Repl.Mcp.AspNetCore;
 
 namespace Repl.McpTests;
@@ -107,6 +110,90 @@ public sealed class Given_McpHttpSelfHostSecurity
 		clone.Security.AllowAnyHost.Should().BeTrue();
 		clone.Security.AllowedOrigins.Should().ContainSingle("https://trusted.example");
 		clone.Security.AllowedOrigins.Should().NotBeSameAs(options.Security.AllowedOrigins);
+	}
+
+	[TestMethod]
+	public void When_ServerOptionsAreCreated_Then_UsesConservativeStatefulLimits()
+	{
+		var options = new ReplMcpHttpServerOptions();
+
+		options.Http.IdleTimeout.Should().Be(TimeSpan.FromMinutes(30));
+		options.Http.MaxIdleSessionCount.Should().Be(100);
+	}
+
+	[TestMethod]
+	public void When_RemoteBindingUsesDefaultSecurity_Then_AnyHostIsAllowedButOriginsStayRestricted()
+	{
+		var binding = McpHttpBindingFactory.Create("0.0.0.0", 7375, "/mcp", allowRemote: true);
+		var security = new ReplMcpHttpSecurityOptions();
+
+		ReplMcpHttpServer.ApplyBindingSecurityDefaults(binding, security);
+
+		security.AllowAnyHost.Should().BeTrue();
+		security.AllowAnyOrigin.Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void When_RemoteBindingUsesCustomHostList_Then_HostListIsPreserved()
+	{
+		var binding = McpHttpBindingFactory.Create("0.0.0.0", 7375, "/mcp", allowRemote: true);
+		var security = new ReplMcpHttpSecurityOptions();
+		security.AllowedHosts.Clear();
+		security.AllowedHosts.Add("internal.example");
+
+		ReplMcpHttpServer.ApplyBindingSecurityDefaults(binding, security);
+
+		security.AllowAnyHost.Should().BeFalse();
+		security.AllowedHosts.Should().ContainSingle("internal.example");
+	}
+
+	[TestMethod]
+	public async Task When_HttpSessionCompletes_Then_SessionItemIsReleased()
+	{
+		var app = ReplApp.Create();
+		app.Map("ping", () => "pong");
+		var transport = new HttpServerTransportOptions();
+		var runCalled = false;
+#pragma warning disable MCPEXP002
+		transport.RunSessionHandler = (_, _, _) =>
+		{
+			runCalled = true;
+			return Task.CompletedTask;
+		};
+#pragma warning restore MCPEXP002
+		ReplMcpHttpServiceCollectionExtensions.ConfigureTransport(transport, app, new ReplMcpHttpOptions());
+		var context = CreateContext("127.0.0.1:7375");
+		context.RequestServices = new ServiceCollection().BuildServiceProvider();
+
+		await transport.ConfigureSessionOptions!(context, new McpServerOptions(), CancellationToken.None);
+		context.Items.Should().NotBeEmpty();
+
+#pragma warning disable MCPEXP002
+		await transport.RunSessionHandler!(context, null!, CancellationToken.None);
+#pragma warning restore MCPEXP002
+
+		runCalled.Should().BeTrue();
+		context.Items.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	public async Task When_ExternalSessionConfigurationFails_Then_SessionItemIsReleased()
+	{
+		var app = ReplApp.Create();
+		app.Map("ping", () => "pong");
+		var transport = new HttpServerTransportOptions
+		{
+			ConfigureSessionOptions = (_, _, _) => throw new InvalidOperationException("boom"),
+		};
+		ReplMcpHttpServiceCollectionExtensions.ConfigureTransport(transport, app, new ReplMcpHttpOptions());
+		var context = CreateContext("127.0.0.1:7375");
+		context.RequestServices = new ServiceCollection().BuildServiceProvider();
+
+		var act = () => transport.ConfigureSessionOptions!(context, new McpServerOptions(), CancellationToken.None);
+
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("boom");
+		context.Items.Should().BeEmpty();
 	}
 
 	private static ReplMcpHttpSecurityMiddleware CreateMiddleware(

--- a/src/Repl.McpTests/Given_McpHttpSelfHostSecurity.cs
+++ b/src/Repl.McpTests/Given_McpHttpSelfHostSecurity.cs
@@ -1,0 +1,128 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Repl.Mcp.AspNetCore;
+
+namespace Repl.McpTests;
+
+[TestClass]
+public sealed class Given_McpHttpSelfHostSecurity
+{
+	[TestMethod]
+	public async Task When_RequestHasLoopbackHostAndNoOrigin_Then_RequestContinues()
+	{
+		var called = false;
+		var middleware = CreateMiddleware(_ =>
+		{
+			called = true;
+			return Task.CompletedTask;
+		});
+		var context = CreateContext("127.0.0.1:7375");
+
+		await middleware.InvokeAsync(context);
+
+		called.Should().BeTrue();
+		context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+	}
+
+	[TestMethod]
+	public async Task When_RequestHasUnexpectedHost_Then_RequestIsRejected()
+	{
+		var called = false;
+		var middleware = CreateMiddleware(_ =>
+		{
+			called = true;
+			return Task.CompletedTask;
+		});
+		var context = CreateContext("example.com");
+
+		await middleware.InvokeAsync(context);
+
+		called.Should().BeFalse();
+		context.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+	}
+
+	[TestMethod]
+	public async Task When_RequestHasUnexpectedBrowserOrigin_Then_RequestIsRejected()
+	{
+		var called = false;
+		var middleware = CreateMiddleware(_ =>
+		{
+			called = true;
+			return Task.CompletedTask;
+		});
+		var context = CreateContext("127.0.0.1:7375", "https://example.com");
+
+		await middleware.InvokeAsync(context);
+
+		called.Should().BeFalse();
+		context.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+	}
+
+	[TestMethod]
+	public async Task When_RequestHasAllowedBrowserOrigin_Then_RequestContinues()
+	{
+		var called = false;
+		var options = new ReplMcpHttpSecurityOptions();
+		options.AllowedOrigins.Add("https://trusted.example");
+		var middleware = CreateMiddleware(_ =>
+		{
+			called = true;
+			return Task.CompletedTask;
+		}, options);
+		var context = CreateContext("localhost:7375", "https://trusted.example");
+
+		await middleware.InvokeAsync(context);
+
+		called.Should().BeTrue();
+		context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+	}
+
+	[TestMethod]
+	public void When_ServerOptionsAreCloned_Then_NestedHttpAndSecurityOptionsAreCopied()
+	{
+		var options = new ReplMcpHttpServerOptions
+		{
+			Host = "localhost",
+			Port = 5555,
+			Path = "/tools",
+			AllowRemote = true,
+			Quiet = true,
+		};
+		options.Http.IdleTimeout = TimeSpan.FromMinutes(2);
+		options.Http.MaxIdleSessionCount = 3;
+		options.Http.PerSessionExecutionContext = true;
+		options.Security.AllowAnyHost = true;
+		options.Security.AllowedOrigins.Add("https://trusted.example");
+
+		var clone = options.Clone();
+
+		clone.Host.Should().Be("localhost");
+		clone.Port.Should().Be(5555);
+		clone.Path.Should().Be("/tools");
+		clone.AllowRemote.Should().BeTrue();
+		clone.Quiet.Should().BeTrue();
+		clone.Http.IdleTimeout.Should().Be(TimeSpan.FromMinutes(2));
+		clone.Http.MaxIdleSessionCount.Should().Be(3);
+		clone.Http.PerSessionExecutionContext.Should().BeTrue();
+		clone.Security.AllowAnyHost.Should().BeTrue();
+		clone.Security.AllowedOrigins.Should().ContainSingle("https://trusted.example");
+		clone.Security.AllowedOrigins.Should().NotBeSameAs(options.Security.AllowedOrigins);
+	}
+
+	private static ReplMcpHttpSecurityMiddleware CreateMiddleware(
+		RequestDelegate next,
+		ReplMcpHttpSecurityOptions? options = null) =>
+		new(next, NullLogger<ReplMcpHttpSecurityMiddleware>.Instance, options ?? new ReplMcpHttpSecurityOptions());
+
+	private static DefaultHttpContext CreateContext(string host, string? origin = null)
+	{
+		var context = new DefaultHttpContext();
+		context.Request.Host = HostString.FromUriComponent(host);
+		if (origin is not null)
+		{
+			context.Request.Headers.Origin = origin;
+		}
+
+		return context;
+	}
+}

--- a/src/Repl.McpTests/Repl.McpTests.csproj
+++ b/src/Repl.McpTests/Repl.McpTests.csproj
@@ -13,6 +13,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Repl.Mcp\Repl.Mcp.csproj" />
+		<ProjectReference Include="..\Repl.Mcp.AspNetCore\Repl.Mcp.AspNetCore.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/Repl.slnx
+++ b/src/Repl.slnx
@@ -15,6 +15,7 @@
 	<Project Path="Repl.Telnet/Repl.Telnet.csproj" />
 	<Project Path="Repl.Testing/Repl.Testing.csproj" />
 	<Project Path="Repl.Mcp/Repl.Mcp.csproj" />
+	<Project Path="Repl.Mcp.AspNetCore/Repl.Mcp.AspNetCore.csproj" />
 	<Project Path="Repl.Spectre/Repl.Spectre.csproj" />
 	<Project Path="Repl.ShellCompletionTestHost/Repl.ShellCompletionTestHost.csproj" />
 	<Project Path="Repl.Tests/Repl.Tests.csproj" />


### PR DESCRIPTION
## Summary

Adds ASP.NET Core Streamable HTTP hosting support for Repl MCP servers, plus a self-hosted CLI command for simple local/trusted-network exposure.

This introduces:

- `Repl.Mcp.AspNetCore`
- hosted APIs:
  - `services.AddReplMcpHttp(replApp)`
  - `app.MapReplMcp("/mcp")`
- self-hosted CLI command:
  - `myapp mcp httpserve`
  - aliases: `mcp http`, `mcp http-serve`
- default local endpoint:
  - `http://127.0.0.1:7375/mcp`

## Security Model

The self-hosted CLI path is intended for local agents and trusted development/container networks.

Defaults:

- binds to loopback by default
- rejects non-loopback bindings unless `--allow-remote` is explicitly set
- filters loopback `Host` headers
- rejects unexpected browser `Origin` headers
- allows non-browser MCP clients that do not send `Origin`

For production-grade authentication, TLS, reverse proxy integration, CORS policy, or more rigorous Kestrel configuration, apps should use the hosted ASP.NET Core integration and compose normal ASP.NET Core middleware/endpoint conventions.

## Session Model

HTTP MCP sessions are stateful by default and support parallel clients.

This PR also adds deterministic session cleanup through the SDK `RunSessionHandler` hook, so per-session REPL/MCP resources are disposed when the MCP session completes.

Self-hosted defaults are conservative:

- idle timeout: 30 minutes
- max idle sessions: 100

## Notes

The CLI intentionally does not expose a `--stateless` switch in this first slice. Stateless and deeper transport knobs remain available through hosted/advanced configuration.

Monitoring/TUI status surfaces are also left for a later slice.

## Tests

Validated locally:

```text
dotnet test src\Repl.McpTests\Repl.McpTests.csproj
```

Result:

```text
Passed: 183/183
```